### PR TITLE
fix(client): support regexp to select models to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ openapi --help
     --useUnionTypes           Use union types instead of enums
     --exportCore <value>      Write core files to disk (default: true)
     --exportServices <value>  Write services to disk [true, false, regexp] (default: true)
-    --exportModels <value>    Write models to disk (default: true)
+    --exportModels <value>    Write models to disk [true, false, regexp] (default: true)
     --exportSchemas <value>   Write schemas to disk (default: false)
     --indent <value>          Indentation options [4, 2, tab] (default: "4")
     --postfixServices         Service name postfix (default: "Service")

--- a/bin/index.js
+++ b/bin/index.js
@@ -29,13 +29,15 @@ const params = program
 
 const OpenAPI = require(path.resolve(__dirname, '../dist/index.js'));
 
-if (OpenAPI) {
-    let exportServices;
+const parseBooleanOrString = value => {
     try {
-        exportServices = JSON.parse(params.exportServices) === true;
+        return JSON.parse(value) === true;
     } catch (error) {
-        exportServices = params.exportServices;
+        return value;
     }
+};
+
+if (OpenAPI) {
     OpenAPI.generate({
         input: params.input,
         output: params.output,
@@ -44,8 +46,8 @@ if (OpenAPI) {
         useOptions: params.useOptions,
         useUnionTypes: params.useUnionTypes,
         exportCore: JSON.parse(params.exportCore) === true,
-        exportServices,
-        exportModels: JSON.parse(params.exportModels) === true,
+        exportServices: parseBooleanOrString(params.exportServices),
+        exportModels: parseBooleanOrString(params.exportModels),
         exportSchemas: JSON.parse(params.exportSchemas) === true,
         indent: params.indent,
         postfixServices: params.postfixServices,

--- a/bin/index.spec.js
+++ b/bin/index.spec.js
@@ -43,7 +43,7 @@ describe('bin', () => {
         expect(result.stderr.toString()).toBe('');
     });
 
-    it('it should support regexp in exportSchemas', async () => {
+    it('it should support regexp params', async () => {
         const result = crossSpawn.sync('node', [
             './bin/index.js',
             '--input',
@@ -51,6 +51,8 @@ describe('bin', () => {
             '--output',
             './test/generated/bin',
             '--exportServices',
+            '^(Simple|Types)',
+            '--exportModels',
             '^(Simple|Types)',
         ]);
         expect(result.stdout.toString()).toBe('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export type Options = {
     useUnionTypes?: boolean;
     exportCore?: boolean;
     exportServices?: boolean | string;
-    exportModels?: boolean;
+    exportModels?: boolean | string;
     exportSchemas?: boolean;
     indent?: Indent;
     postfixServices?: string;

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -42,7 +42,7 @@ export const writeClient = async (
     useUnionTypes: boolean,
     exportCore: boolean,
     exportServices: boolean | string,
-    exportModels: boolean,
+    exportModels: boolean | string,
     exportSchemas: boolean,
     indent: Indent,
     postfixServices: string,
@@ -63,6 +63,11 @@ export const writeClient = async (
     if (typeof exportServices === 'string') {
         const regexp = new RegExp(exportServices);
         client.services = client.services.filter(service => regexp.test(service.name));
+    }
+
+    if (typeof exportModels === 'string') {
+        const regexp = new RegExp(exportModels);
+        client.models = client.models.filter(model => regexp.test(model.name));
     }
 
     if (exportCore) {

--- a/src/utils/writeClientIndex.ts
+++ b/src/utils/writeClientIndex.ts
@@ -30,7 +30,7 @@ export const writeClientIndex = async (
     useUnionTypes: boolean,
     exportCore: boolean,
     exportServices: boolean | string,
-    exportModels: boolean,
+    exportModels: boolean | string,
     exportSchemas: boolean,
     postfixServices: string,
     postfixModels: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,7 @@ export type Options = {
     useUnionTypes?: boolean;
     exportCore?: boolean;
     exportServices?: boolean | string;
-    exportModels?: boolean;
+    exportModels?: boolean | string;
     exportSchemas?: boolean;
     indent?: Indent | '4' | '2' | 'tab';
     postfixServices?: string;


### PR DESCRIPTION
This is mainly for debugging, not expecting anyone to actually use this. It doesn't for example remove filtered model imports from the index file.