### PR TITLE
Escape newlines when outputting pattern string value in schemas.

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -39,6 +39,7 @@ const handlebarsPlugin = () => ({
                     escapeComment: true,
                     escapeDescription: true,
                     camelCase: true,
+                    escapeNewline: true
                 },
             });
             return `export default ${templateSpec};`;

--- a/src/templates/partials/schemaGeneric.hbs
+++ b/src/templates/partials/schemaGeneric.hbs
@@ -39,7 +39,7 @@
 	minLength: {{{minLength}}},
 {{/if}}
 {{#if pattern}}
-	pattern: '{{{pattern}}}',
+	pattern: '{{{escapeNewline pattern}}}',
 {{/if}}
 {{#if maxItems}}
 	maxItems: {{{maxItems}}},

--- a/src/utils/registerHandlebarHelpers.spec.ts
+++ b/src/utils/registerHandlebarHelpers.spec.ts
@@ -21,5 +21,6 @@ describe('registerHandlebarHelpers', () => {
         expect(helpers).toContain('escapeComment');
         expect(helpers).toContain('escapeDescription');
         expect(helpers).toContain('camelCase');
+        expect(helpers).toContain('escapeNewline');
     });
 });

--- a/src/utils/registerHandlebarHelpers.ts
+++ b/src/utils/registerHandlebarHelpers.ts
@@ -104,4 +104,8 @@ export const registerHandlebarHelpers = (root: {
     Handlebars.registerHelper('camelCase', function (value: string): string {
         return camelCase(value);
     });
+
+    Handlebars.registerHelper('escapeNewline', function (value: string): string {
+        return value.replace(/\n/g, '\\n');
+    });
 };

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1328,6 +1328,8 @@ export type ModelWithPattern = {
     id?: string;
     text?: string;
     patternWithSingleQuotes?: string;
+    patternWithNewline?: string;
+    patternWithBacktick?: string;
 };
 
 "
@@ -2183,6 +2185,14 @@ export const $ModelWithPattern = {
         patternWithSingleQuotes: {
             type: 'string',
             pattern: '^[a-zA-Z0-9\\']*$',
+        },
+        patternWithNewline: {
+            type: 'string',
+            pattern: 'aaa\\nbbb',
+        },
+        patternWithBacktick: {
+            type: 'string',
+            pattern: 'aaa\`bbb',
         },
     },
 } as const;
@@ -5055,6 +5065,8 @@ export type ModelWithPattern = {
     id?: string;
     text?: string;
     patternWithSingleQuotes?: string;
+    patternWithNewline?: string;
+    patternWithBacktick?: string;
 };
 
 "
@@ -6701,6 +6713,14 @@ export const $ModelWithPattern = {
         patternWithSingleQuotes: {
             type: 'string',
             pattern: '^[a-zA-Z0-9\\']*$',
+        },
+        patternWithNewline: {
+            type: 'string',
+            pattern: 'aaa\\nbbb',
+        },
+        patternWithBacktick: {
+            type: 'string',
+            pattern: 'aaa\`bbb',
         },
     },
 } as const;

--- a/test/spec/v2.json
+++ b/test/spec/v2.json
@@ -1568,6 +1568,14 @@
                 "patternWithSingleQuotes": {
                     "type": "string",
                     "pattern": "^[a-zA-Z0-9']*$"
+                },
+                "patternWithNewline": {
+                    "type": "string",
+                    "pattern": "aaa\nbbb"
+                },
+                "patternWithBacktick": {
+                    "type": "string",
+                    "pattern": "aaa`bbb"
                 }
             }
         }

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -2676,6 +2676,14 @@
                     "patternWithSingleQuotes": {
                         "type": "string",
                         "pattern": "^[a-zA-Z0-9']*$"
+                    },
+                    "patternWithNewline": {
+                        "type": "string",
+                        "pattern": "aaa\nbbb"
+                    },
+                    "patternWithBacktick": {
+                        "type": "string",
+                        "pattern": "aaa`bbb"
                     }
                 }
             },


### PR DESCRIPTION
Otherwise a newline character (\n) in the pattern value would cause invalid typescript code to be generated.