### PR TITLE
Bugfix/issue 2052

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.27.0",
             "license": "MIT",
             "dependencies": {
-                "@apidevtools/json-schema-ref-parser": "^10.1.0",
+                "@apidevtools/json-schema-ref-parser": "^11.1.0",
                 "camelcase": "^6.3.0",
                 "commander": "^11.1.0",
                 "fs-extra": "^11.2.0",
@@ -697,12 +697,12 @@
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-10.1.0.tgz",
-            "integrity": "sha512-3e+viyMuXdrcK8v5pvP+SDoAQ77FH6OyRmuK48SZKmdHJRFm87RsSs8qm6kP39a/pOPURByJw+OXzQIqcfmKtA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.1.0.tgz",
+            "integrity": "sha512-g/VW9ZQEFJAOwAyUb8JFf7MLiLy2uEB4rU270rGzDwICxnxMlPy0O11KVePSgS36K1NI29gSlK84n5INGhd4Ag==",
             "dependencies": {
                 "@jsdevtools/ono": "^7.1.3",
-                "@types/json-schema": "^7.0.11",
+                "@types/json-schema": "^7.0.13",
                 "@types/lodash.clonedeep": "^4.5.7",
                 "js-yaml": "^4.1.0",
                 "lodash.clonedeep": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "docker": "docker build -t eeelenbaas/openapi-typescript-codegen ."
     },
     "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^10.1.0",
+        "@apidevtools/json-schema-ref-parser": "^11.1.0",
         "camelcase": "^6.3.0",
         "commander": "^11.1.0",
         "fs-extra": "^11.2.0",

--- a/src/utils/getOpenApiSpec.ts
+++ b/src/utils/getOpenApiSpec.ts
@@ -1,6 +1,7 @@
 import RefParser from '@apidevtools/json-schema-ref-parser';
-import { exists } from 'fs-extra';
-import path from 'path';
+import { resolve } from 'path';
+
+import { exists } from './fileSystem';
 
 /**
  * Load and parse te open api spec. If the file extension is ".yml" or ".yaml"
@@ -9,6 +10,6 @@ import path from 'path';
  * @param location: Path or url
  */
 export const getOpenApiSpec = async (location: string): Promise<any> => {
-    const absolutePathOrUrl = (await exists(location)) ? path.resolve(location) : location;
+    const absolutePathOrUrl = (await exists(location)) ? resolve(location) : location;
     return await RefParser.bundle(absolutePathOrUrl, absolutePathOrUrl, {});
 };

--- a/src/utils/getOpenApiSpec.ts
+++ b/src/utils/getOpenApiSpec.ts
@@ -1,4 +1,6 @@
 import RefParser from '@apidevtools/json-schema-ref-parser';
+import { exists } from 'fs-extra';
+import path from 'path';
 
 /**
  * Load and parse te open api spec. If the file extension is ".yml" or ".yaml"
@@ -7,5 +9,6 @@ import RefParser from '@apidevtools/json-schema-ref-parser';
  * @param location: Path or url
  */
 export const getOpenApiSpec = async (location: string): Promise<any> => {
-    return await RefParser.bundle(location, location, {});
+    const absolutePathOrUrl = (await exists(location)) ? path.resolve(location) : location;
+    return await RefParser.bundle(absolutePathOrUrl, absolutePathOrUrl, {});
 };


### PR DESCRIPTION
Both of these had to be made together to pass our tests
1. always pass absolute url to json-schema-ref-parser
2. update json-schema-ref-parser to v11.1.0

Should fix: https://github.com/ferdikoomen/openapi-typescript-codegen/issues/2052

(Original PR: https://github.com/ferdikoomen/openapi-typescript-codegen/pull/2053#issue-2164840140)