### PR TITLE
fix: correctly set content-type header, even when body is falsy

### DIFF
--- a/src/templates/core/angular/getHeaders.hbs
+++ b/src/templates/core/angular/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): O
 				headers['Authorization'] = `Basic ${credentials}`;
 			}
 
-			if (options.body) {
+			if (options.body !== undefined) {
 				if (options.mediaType) {
 					headers['Content-Type'] = options.mediaType;
 				} else if (isBlob(options.body)) {

--- a/src/templates/core/axios/getHeaders.hbs
+++ b/src/templates/core/axios/getHeaders.hbs
@@ -29,7 +29,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -26,7 +26,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 		headers['Authorization'] = `Basic ${credentials}`;
 	}
 
-	if (options.body) {
+	if (options.body !== undefined) {
 		if (options.mediaType) {
 			headers['Content-Type'] = options.mediaType;
 		} else if (isBlob(options.body)) {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -416,7 +416,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
         headers['Authorization'] = \`Basic \${credentials}\`;
     }
 
-    if (options.body) {
+    if (options.body !== undefined) {
         if (options.mediaType) {
             headers['Content-Type'] = options.mediaType;
         } else if (isBlob(options.body)) {
@@ -3723,7 +3723,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
         headers['Authorization'] = \`Basic \${credentials}\`;
     }
 
-    if (options.body) {
+    if (options.body !== undefined) {
         if (options.mediaType) {
             headers['Content-Type'] = options.mediaType;
         } else if (isBlob(options.body)) {
@@ -4469,7 +4469,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
         headers['Authorization'] = \`Basic \${credentials}\`;
     }
 
-    if (options.body) {
+    if (options.body !== undefined) {
         if (options.mediaType) {
             headers['Content-Type'] = options.mediaType;
         } else if (isBlob(options.body)) {


### PR DESCRIPTION
- fixes a bug, where content-type would not be set, when the request.body is a falsy value (for example an empty string or zero)