### PR TITLE
feat(response): basic support for blob responses

### DIFF
--- a/src/templates/core/fetch/getResponseBody.hbs
+++ b/src/templates/core/fetch/getResponseBody.hbs
@@ -9,7 +9,7 @@ export const getResponseBody = async (response: Response): Promise<any> => {
                 const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return await response.json();
-				} else if (isBinary) {}
+				} else if (isBinary) {
 					return await response.blob();
 				} else {
 					return await response.text();

--- a/src/templates/core/fetch/getResponseBody.hbs
+++ b/src/templates/core/fetch/getResponseBody.hbs
@@ -3,10 +3,14 @@ export const getResponseBody = async (response: Response): Promise<any> => {
 		try {
 			const contentType = response.headers.get('Content-Type');
 			if (contentType) {
-				const jsonTypes = ['application/json', 'application/problem+json']
+				const jsonTypes = ['application/json', 'application/problem+json'];
+				const binaryTypes = ['audio/', 'image/', 'video/'];
 				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return await response.json();
+				} else if (isBinary) {}
+					return await response.blob();
 				} else {
 					return await response.text();
 				}

--- a/src/templates/core/node/getResponseBody.hbs
+++ b/src/templates/core/node/getResponseBody.hbs
@@ -9,7 +9,7 @@ export const getResponseBody = async (response: Response): Promise<any> => {
 				const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return await response.json();
-				} else if (isBinary) {}
+				} else if (isBinary) {
 					return await response.blob();
 				} else {
 					return await response.text();

--- a/src/templates/core/node/getResponseBody.hbs
+++ b/src/templates/core/node/getResponseBody.hbs
@@ -3,10 +3,14 @@ export const getResponseBody = async (response: Response): Promise<any> => {
 		try {
 			const contentType = response.headers.get('Content-Type');
 			if (contentType) {
-				const jsonTypes = ['application/json', 'application/problem+json']
+				const jsonTypes = ['application/json', 'application/problem+json'];
+				const binaryTypes = ['audio/', 'image/', 'video/'];
 				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+				const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return await response.json();
+				} else if (isBinary) {}
+					return await response.blob();
 				} else {
 					return await response.text();
 				}

--- a/src/templates/core/xhr/getResponseBody.hbs
+++ b/src/templates/core/xhr/getResponseBody.hbs
@@ -3,7 +3,7 @@ export const getResponseBody = (xhr: XMLHttpRequest): any => {
 		try {
 			const contentType = xhr.getResponseHeader('Content-Type');
 			if (contentType) {
-				const jsonTypes = ['application/json', 'application/problem+json']
+				const jsonTypes = ['application/json', 'application/problem+json'];
 				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
 				if (isJSON) {
 					return JSON.parse(xhr.responseText);

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -241,277 +241,282 @@ import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export const isString = (value: any): value is string => {
-	return typeof value === 'string';
+    return typeof value === 'string';
 };
 
 export const isStringWithValue = (value: any): value is string => {
-	return isString(value) && value !== '';
+    return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-	return (
-		typeof value === 'object' &&
-		typeof value.type === 'string' &&
-		typeof value.stream === 'function' &&
-		typeof value.arrayBuffer === 'function' &&
-		typeof value.constructor === 'function' &&
-		typeof value.constructor.name === 'string' &&
-		/^(Blob|File)$/.test(value.constructor.name) &&
-		/^(Blob|File)$/.test(value[Symbol.toStringTag])
-	);
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
 };
 
 export const isFormData = (value: any): value is FormData => {
-	return value instanceof FormData;
+    return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-	try {
-		return btoa(str);
-	} catch (err) {
-		// @ts-ignore
-		return Buffer.from(str).toString('base64');
-	}
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-	const qs: string[] = [];
+    const qs: string[] = [];
 
-	const append = (key: string, value: any) => {
-		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-	};
+    const append = (key: string, value: any) => {
+        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+    };
 
-	const process = (key: string, value: any) => {
-		if (value) {
-			if (Array.isArray(value)) {
-				value.forEach(v => {
-					process(key, v);
-				});
-			} else if (typeof value === 'object') {
-				Object.entries(value).forEach(([k, v]) => {
-					process(\`\${key}[\${k}]\`, v);
-				});
-			} else {
-				append(key, value);
-			}
-		}
-	};
+    const process = (key: string, value: any) => {
+        if (value) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(\`\${key}[\${k}]\`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
 
-	Object.entries(params).forEach(([key, value]) => {
-		process(key, value);
-	});
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
 
-	if (qs.length > 0) {
-		return \`?\${qs.join('&')}\`;
-	}
+    if (qs.length > 0) {
+        return \`?\${qs.join('&')}\`;
+    }
 
-	return '';
+    return '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-	const encoder = config.ENCODE_PATH || encodeURI;
+    const encoder = config.ENCODE_PATH || encodeURI;
 
-	const path = options.url
-		.replace('{api-version}', config.VERSION)
-		.replace(/{(.*?)}/g, (substring: string, group: string) => {
-			if (options.path?.hasOwnProperty(group)) {
-				return encoder(String(options.path[group]));
-			}
-			return substring;
-		});
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
 
-	const url = \`\${config.BASE}\${path}\`;
-	if (options.query) {
-		return \`\${url}\${getQueryString(options.query)}\`;
-	}
-	return url;
+    const url = \`\${config.BASE}\${path}\`;
+    if (options.query) {
+        return \`\${url}\${getQueryString(options.query)}\`;
+    }
+    return url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-	if (options.formData) {
-		const formData = new FormData();
+    if (options.formData) {
+        const formData = new FormData();
 
-		const process = (key: string, value: any) => {
-			if (isString(value) || isBlob(value)) {
-				formData.append(key, value);
-			} else {
-				formData.append(key, JSON.stringify(value));
-			}
-		};
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
 
-		Object.entries(options.formData)
-			.filter(([_, value]) => value)
-			.forEach(([key, value]) => {
-				if (Array.isArray(value)) {
-					value.forEach(v => process(key, v));
-				} else {
-					process(key, value);
-				}
-			});
+        Object.entries(options.formData)
+            .filter(([_, value]) => value)
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
 
-		return formData;
-	}
-	return undefined;
+        return formData;
+    }
+    return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-	if (typeof resolver === 'function') {
-		return (resolver as Resolver<T>)(options);
-	}
-	return resolver;
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-	const [token, username, password, additionalHeaders] = await Promise.all([
-		resolve(options, config.TOKEN),
-		resolve(options, config.USERNAME),
-		resolve(options, config.PASSWORD),
-		resolve(options, config.HEADERS),
-	]);
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
 
-	const headers = Object.entries({
-		Accept: 'application/json',
-		...additionalHeaders,
-		...options.headers,
-	})
-		.filter(([_, value]) => value)
-		.reduce((headers, [key, value]) => ({
-			...headers,
-			[key]: String(value),
-		}), {} as Record<string, string>);
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+    })
+        .filter(([_, value]) => value)
+        .reduce(
+            (headers, [key, value]) => ({
+                ...headers,
+                [key]: String(value),
+            }),
+            {} as Record<string, string>
+        );
 
-	if (isStringWithValue(token)) {
-		headers['Authorization'] = \`Bearer \${token}\`;
-	}
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = \`Bearer \${token}\`;
+    }
 
-	if (isStringWithValue(username) && isStringWithValue(password)) {
-		const credentials = base64(\`\${username}:\${password}\`);
-		headers['Authorization'] = \`Basic \${credentials}\`;
-	}
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(\`\${username}:\${password}\`);
+        headers['Authorization'] = \`Basic \${credentials}\`;
+    }
 
-	if (options.body !== undefined) {
-		if (options.mediaType) {
-			headers['Content-Type'] = options.mediaType;
-		} else if (isBlob(options.body)) {
-			headers['Content-Type'] = options.body.type || 'application/octet-stream';
-		} else if (isString(options.body)) {
-			headers['Content-Type'] = 'text/plain';
-		} else if (!isFormData(options.body)) {
-			headers['Content-Type'] = 'application/json';
-		}
-	}
+    if (options.body !== undefined) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
 
-	return new Headers(headers);
+    return new Headers(headers);
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-	if (options.body !== undefined) {
-		if (options.mediaType?.includes('/json')) {
-			return JSON.stringify(options.body)
-		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-			return options.body;
-		} else {
-			return JSON.stringify(options.body);
-		}
-	}
-	return undefined;
+    if (options.body !== undefined) {
+        if (options.mediaType?.includes('/json')) {
+            return JSON.stringify(options.body);
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+            return options.body;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return undefined;
 };
 
 export const sendRequest = async (
-	config: OpenAPIConfig,
-	options: ApiRequestOptions,
-	url: string,
-	body: any,
-	formData: FormData | undefined,
-	headers: Headers,
-	onCancel: OnCancel
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Headers,
+    onCancel: OnCancel
 ): Promise<Response> => {
-	const controller = new AbortController();
+    const controller = new AbortController();
 
-	const request: RequestInit = {
-		headers,
-		body: body ?? formData,
-		method: options.method,
-		signal: controller.signal,
-	};
+    const request: RequestInit = {
+        headers,
+        body: body ?? formData,
+        method: options.method,
+        signal: controller.signal,
+    };
 
-	if (config.WITH_CREDENTIALS) {
-		request.credentials = config.CREDENTIALS;
-	}
+    if (config.WITH_CREDENTIALS) {
+        request.credentials = config.CREDENTIALS;
+    }
 
-	onCancel(() => controller.abort());
+    onCancel(() => controller.abort());
 
-	return await fetch(url, request);
+    return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-	if (responseHeader) {
-		const content = response.headers.get(responseHeader);
-		if (isString(content)) {
-			return content;
-		}
-	}
-	return undefined;
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
 };
 
 export const getResponseBody = async (response: Response): Promise<any> => {
-	if (response.status !== 204) {
-		try {
-			const contentType = response.headers.get('Content-Type');
-			if (contentType) {
-				const jsonTypes = ['application/json', 'application/problem+json'];
-				const binaryTypes = ['audio/', 'image/', 'video/'];
-				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+    if (response.status !== 204) {
+        try {
+            const contentType = response.headers.get('Content-Type');
+            if (contentType) {
+                const jsonTypes = ['application/json', 'application/problem+json'];
+                const binaryTypes = ['audio/', 'image/', 'video/'];
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
                 const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
-				if (isJSON) {
-					return await response.json();
-				} else if (isBinary) {}
-					return await response.blob();
-				} else {
-					return await response.text();
-				}
-			}
-		} catch (error) {
-			console.error(error);
-		}
-	}
-	return undefined;
+                if (isJSON) {
+                    return await response.json();
+                } else if (isBinary) {
+                    return await response.blob();
+                } else {
+                    return await response.text();
+                }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-	const errors: Record<number, string> = {
-		400: 'Bad Request',
-		401: 'Unauthorized',
-		403: 'Forbidden',
-		404: 'Not Found',
-		500: 'Internal Server Error',
-		502: 'Bad Gateway',
-		503: 'Service Unavailable',
-		...options.errors,
-	}
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    };
 
-	const error = errors[result.status];
-	if (error) {
-		throw new ApiError(options, result, error);
-	}
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
 
-	if (!result.ok) {
-		const errorStatus = result.status ?? 'unknown';
-		const errorStatusText = result.statusText ?? 'unknown';
-		const errorBody = (() => {
-			try {
-				return JSON.stringify(result.body, null, 2);
-			} catch (e) {
-				return undefined;
-			}
-		})();
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
 
-		throw new ApiError(options, result,
-			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
-		);
-	}
+        throw new ApiError(
+            options,
+            result,
+            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+        );
+    }
 };
 
 /**
@@ -522,35 +527,36 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-	return new CancelablePromise(async (resolve, reject, onCancel) => {
-		try {
-			const url = getUrl(config, options);
-			const formData = getFormData(options);
-			const body = getRequestBody(options);
-			const headers = await getHeaders(config, options);
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options);
 
-			if (!onCancel.isCancelled) {
-				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-				const responseBody = await getResponseBody(response);
-				const responseHeader = getResponseHeader(response, options.responseHeader);
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+                const responseBody = await getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
-					url,
-					ok: response.ok,
-					status: response.status,
-					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
-				};
+                const result: ApiResult = {
+                    url,
+                    ok: response.ok,
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
 
-				catchErrorCodes(options, result);
+                catchErrorCodes(options, result);
 
-				resolve(result.body);
-			}
-		} catch (error) {
-			reject(error);
-		}
-	});
-};"
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+"
 `;
 
 exports[`v2 should generate: test/generated/v2/core/types.ts 1`] = `
@@ -3104,277 +3110,282 @@ import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export const isString = (value: any): value is string => {
-	return typeof value === 'string';
+    return typeof value === 'string';
 };
 
 export const isStringWithValue = (value: any): value is string => {
-	return isString(value) && value !== '';
+    return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-	return (
-		typeof value === 'object' &&
-		typeof value.type === 'string' &&
-		typeof value.stream === 'function' &&
-		typeof value.arrayBuffer === 'function' &&
-		typeof value.constructor === 'function' &&
-		typeof value.constructor.name === 'string' &&
-		/^(Blob|File)$/.test(value.constructor.name) &&
-		/^(Blob|File)$/.test(value[Symbol.toStringTag])
-	);
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
 };
 
 export const isFormData = (value: any): value is FormData => {
-	return value instanceof FormData;
+    return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-	try {
-		return btoa(str);
-	} catch (err) {
-		// @ts-ignore
-		return Buffer.from(str).toString('base64');
-	}
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-	const qs: string[] = [];
+    const qs: string[] = [];
 
-	const append = (key: string, value: any) => {
-		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-	};
+    const append = (key: string, value: any) => {
+        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+    };
 
-	const process = (key: string, value: any) => {
-		if (value) {
-			if (Array.isArray(value)) {
-				value.forEach(v => {
-					process(key, v);
-				});
-			} else if (typeof value === 'object') {
-				Object.entries(value).forEach(([k, v]) => {
-					process(\`\${key}[\${k}]\`, v);
-				});
-			} else {
-				append(key, value);
-			}
-		}
-	};
+    const process = (key: string, value: any) => {
+        if (value) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(\`\${key}[\${k}]\`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
 
-	Object.entries(params).forEach(([key, value]) => {
-		process(key, value);
-	});
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
 
-	if (qs.length > 0) {
-		return \`?\${qs.join('&')}\`;
-	}
+    if (qs.length > 0) {
+        return \`?\${qs.join('&')}\`;
+    }
 
-	return '';
+    return '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-	const encoder = config.ENCODE_PATH || encodeURI;
+    const encoder = config.ENCODE_PATH || encodeURI;
 
-	const path = options.url
-		.replace('{api-version}', config.VERSION)
-		.replace(/{(.*?)}/g, (substring: string, group: string) => {
-			if (options.path?.hasOwnProperty(group)) {
-				return encoder(String(options.path[group]));
-			}
-			return substring;
-		});
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
 
-	const url = \`\${config.BASE}\${path}\`;
-	if (options.query) {
-		return \`\${url}\${getQueryString(options.query)}\`;
-	}
-	return url;
+    const url = \`\${config.BASE}\${path}\`;
+    if (options.query) {
+        return \`\${url}\${getQueryString(options.query)}\`;
+    }
+    return url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-	if (options.formData) {
-		const formData = new FormData();
+    if (options.formData) {
+        const formData = new FormData();
 
-		const process = (key: string, value: any) => {
-			if (isString(value) || isBlob(value)) {
-				formData.append(key, value);
-			} else {
-				formData.append(key, JSON.stringify(value));
-			}
-		};
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
 
-		Object.entries(options.formData)
-			.filter(([_, value]) => value)
-			.forEach(([key, value]) => {
-				if (Array.isArray(value)) {
-					value.forEach(v => process(key, v));
-				} else {
-					process(key, value);
-				}
-			});
+        Object.entries(options.formData)
+            .filter(([_, value]) => value)
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
 
-		return formData;
-	}
-	return undefined;
+        return formData;
+    }
+    return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-	if (typeof resolver === 'function') {
-		return (resolver as Resolver<T>)(options);
-	}
-	return resolver;
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-	const [token, username, password, additionalHeaders] = await Promise.all([
-		resolve(options, config.TOKEN),
-		resolve(options, config.USERNAME),
-		resolve(options, config.PASSWORD),
-		resolve(options, config.HEADERS),
-	]);
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
 
-	const headers = Object.entries({
-		Accept: 'application/json',
-		...additionalHeaders,
-		...options.headers,
-	})
-		.filter(([_, value]) => value)
-		.reduce((headers, [key, value]) => ({
-			...headers,
-			[key]: String(value),
-		}), {} as Record<string, string>);
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+    })
+        .filter(([_, value]) => value)
+        .reduce(
+            (headers, [key, value]) => ({
+                ...headers,
+                [key]: String(value),
+            }),
+            {} as Record<string, string>
+        );
 
-	if (isStringWithValue(token)) {
-		headers['Authorization'] = \`Bearer \${token}\`;
-	}
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = \`Bearer \${token}\`;
+    }
 
-	if (isStringWithValue(username) && isStringWithValue(password)) {
-		const credentials = base64(\`\${username}:\${password}\`);
-		headers['Authorization'] = \`Basic \${credentials}\`;
-	}
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(\`\${username}:\${password}\`);
+        headers['Authorization'] = \`Basic \${credentials}\`;
+    }
 
-	if (options.body !== undefined) {
-		if (options.mediaType) {
-			headers['Content-Type'] = options.mediaType;
-		} else if (isBlob(options.body)) {
-			headers['Content-Type'] = options.body.type || 'application/octet-stream';
-		} else if (isString(options.body)) {
-			headers['Content-Type'] = 'text/plain';
-		} else if (!isFormData(options.body)) {
-			headers['Content-Type'] = 'application/json';
-		}
-	}
+    if (options.body !== undefined) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
 
-	return new Headers(headers);
+    return new Headers(headers);
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-	if (options.body !== undefined) {
-		if (options.mediaType?.includes('/json')) {
-			return JSON.stringify(options.body)
-		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-			return options.body;
-		} else {
-			return JSON.stringify(options.body);
-		}
-	}
-	return undefined;
+    if (options.body !== undefined) {
+        if (options.mediaType?.includes('/json')) {
+            return JSON.stringify(options.body);
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+            return options.body;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return undefined;
 };
 
 export const sendRequest = async (
-	config: OpenAPIConfig,
-	options: ApiRequestOptions,
-	url: string,
-	body: any,
-	formData: FormData | undefined,
-	headers: Headers,
-	onCancel: OnCancel
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Headers,
+    onCancel: OnCancel
 ): Promise<Response> => {
-	const controller = new AbortController();
+    const controller = new AbortController();
 
-	const request: RequestInit = {
-		headers,
-		body: body ?? formData,
-		method: options.method,
-		signal: controller.signal,
-	};
+    const request: RequestInit = {
+        headers,
+        body: body ?? formData,
+        method: options.method,
+        signal: controller.signal,
+    };
 
-	if (config.WITH_CREDENTIALS) {
-		request.credentials = config.CREDENTIALS;
-	}
+    if (config.WITH_CREDENTIALS) {
+        request.credentials = config.CREDENTIALS;
+    }
 
-	onCancel(() => controller.abort());
+    onCancel(() => controller.abort());
 
-	return await fetch(url, request);
+    return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-	if (responseHeader) {
-		const content = response.headers.get(responseHeader);
-		if (isString(content)) {
-			return content;
-		}
-	}
-	return undefined;
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
 };
 
 export const getResponseBody = async (response: Response): Promise<any> => {
-	if (response.status !== 204) {
-		try {
-			const contentType = response.headers.get('Content-Type');
-			if (contentType) {
-				const jsonTypes = ['application/json', 'application/problem+json'];
-				const binaryTypes = ['audio/', 'image/', 'video/'];
-				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+    if (response.status !== 204) {
+        try {
+            const contentType = response.headers.get('Content-Type');
+            if (contentType) {
+                const jsonTypes = ['application/json', 'application/problem+json'];
+                const binaryTypes = ['audio/', 'image/', 'video/'];
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
                 const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
-				if (isJSON) {
-					return await response.json();
-				} else if (isBinary) {}
-					return await response.blob();
-				} else {
-					return await response.text();
-				}
-			}
-		} catch (error) {
-			console.error(error);
-		}
-	}
-	return undefined;
+                if (isJSON) {
+                    return await response.json();
+                } else if (isBinary) {
+                    return await response.blob();
+                } else {
+                    return await response.text();
+                }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-	const errors: Record<number, string> = {
-		400: 'Bad Request',
-		401: 'Unauthorized',
-		403: 'Forbidden',
-		404: 'Not Found',
-		500: 'Internal Server Error',
-		502: 'Bad Gateway',
-		503: 'Service Unavailable',
-		...options.errors,
-	}
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    };
 
-	const error = errors[result.status];
-	if (error) {
-		throw new ApiError(options, result, error);
-	}
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
 
-	if (!result.ok) {
-		const errorStatus = result.status ?? 'unknown';
-		const errorStatusText = result.statusText ?? 'unknown';
-		const errorBody = (() => {
-			try {
-				return JSON.stringify(result.body, null, 2);
-			} catch (e) {
-				return undefined;
-			}
-		})();
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
 
-		throw new ApiError(options, result,
-			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
-		);
-	}
+        throw new ApiError(
+            options,
+            result,
+            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+        );
+    }
 };
 
 /**
@@ -3385,35 +3396,36 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-	return new CancelablePromise(async (resolve, reject, onCancel) => {
-		try {
-			const url = getUrl(config, options);
-			const formData = getFormData(options);
-			const body = getRequestBody(options);
-			const headers = await getHeaders(config, options);
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options);
 
-			if (!onCancel.isCancelled) {
-				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-				const responseBody = await getResponseBody(response);
-				const responseHeader = getResponseHeader(response, options.responseHeader);
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+                const responseBody = await getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
-					url,
-					ok: response.ok,
-					status: response.status,
-					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
-				};
+                const result: ApiResult = {
+                    url,
+                    ok: response.ok,
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
 
-				catchErrorCodes(options, result);
+                catchErrorCodes(options, result);
 
-				resolve(result.body);
-			}
-		} catch (error) {
-			reject(error);
-		}
-	});
-};"
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+"
 `;
 
 exports[`v3 should generate optional argument: test/generated/v3_options/core/types.ts 1`] = `
@@ -3869,277 +3881,282 @@ import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export const isString = (value: any): value is string => {
-	return typeof value === 'string';
+    return typeof value === 'string';
 };
 
 export const isStringWithValue = (value: any): value is string => {
-	return isString(value) && value !== '';
+    return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-	return (
-		typeof value === 'object' &&
-		typeof value.type === 'string' &&
-		typeof value.stream === 'function' &&
-		typeof value.arrayBuffer === 'function' &&
-		typeof value.constructor === 'function' &&
-		typeof value.constructor.name === 'string' &&
-		/^(Blob|File)$/.test(value.constructor.name) &&
-		/^(Blob|File)$/.test(value[Symbol.toStringTag])
-	);
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
 };
 
 export const isFormData = (value: any): value is FormData => {
-	return value instanceof FormData;
+    return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-	try {
-		return btoa(str);
-	} catch (err) {
-		// @ts-ignore
-		return Buffer.from(str).toString('base64');
-	}
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-	const qs: string[] = [];
+    const qs: string[] = [];
 
-	const append = (key: string, value: any) => {
-		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-	};
+    const append = (key: string, value: any) => {
+        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+    };
 
-	const process = (key: string, value: any) => {
-		if (value) {
-			if (Array.isArray(value)) {
-				value.forEach(v => {
-					process(key, v);
-				});
-			} else if (typeof value === 'object') {
-				Object.entries(value).forEach(([k, v]) => {
-					process(\`\${key}[\${k}]\`, v);
-				});
-			} else {
-				append(key, value);
-			}
-		}
-	};
+    const process = (key: string, value: any) => {
+        if (value) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(\`\${key}[\${k}]\`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
 
-	Object.entries(params).forEach(([key, value]) => {
-		process(key, value);
-	});
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
 
-	if (qs.length > 0) {
-		return \`?\${qs.join('&')}\`;
-	}
+    if (qs.length > 0) {
+        return \`?\${qs.join('&')}\`;
+    }
 
-	return '';
+    return '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-	const encoder = config.ENCODE_PATH || encodeURI;
+    const encoder = config.ENCODE_PATH || encodeURI;
 
-	const path = options.url
-		.replace('{api-version}', config.VERSION)
-		.replace(/{(.*?)}/g, (substring: string, group: string) => {
-			if (options.path?.hasOwnProperty(group)) {
-				return encoder(String(options.path[group]));
-			}
-			return substring;
-		});
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
 
-	const url = \`\${config.BASE}\${path}\`;
-	if (options.query) {
-		return \`\${url}\${getQueryString(options.query)}\`;
-	}
-	return url;
+    const url = \`\${config.BASE}\${path}\`;
+    if (options.query) {
+        return \`\${url}\${getQueryString(options.query)}\`;
+    }
+    return url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-	if (options.formData) {
-		const formData = new FormData();
+    if (options.formData) {
+        const formData = new FormData();
 
-		const process = (key: string, value: any) => {
-			if (isString(value) || isBlob(value)) {
-				formData.append(key, value);
-			} else {
-				formData.append(key, JSON.stringify(value));
-			}
-		};
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
 
-		Object.entries(options.formData)
-			.filter(([_, value]) => value)
-			.forEach(([key, value]) => {
-				if (Array.isArray(value)) {
-					value.forEach(v => process(key, v));
-				} else {
-					process(key, value);
-				}
-			});
+        Object.entries(options.formData)
+            .filter(([_, value]) => value)
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
 
-		return formData;
-	}
-	return undefined;
+        return formData;
+    }
+    return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-	if (typeof resolver === 'function') {
-		return (resolver as Resolver<T>)(options);
-	}
-	return resolver;
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-	const [token, username, password, additionalHeaders] = await Promise.all([
-		resolve(options, config.TOKEN),
-		resolve(options, config.USERNAME),
-		resolve(options, config.PASSWORD),
-		resolve(options, config.HEADERS),
-	]);
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
 
-	const headers = Object.entries({
-		Accept: 'application/json',
-		...additionalHeaders,
-		...options.headers,
-	})
-		.filter(([_, value]) => value)
-		.reduce((headers, [key, value]) => ({
-			...headers,
-			[key]: String(value),
-		}), {} as Record<string, string>);
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+    })
+        .filter(([_, value]) => value)
+        .reduce(
+            (headers, [key, value]) => ({
+                ...headers,
+                [key]: String(value),
+            }),
+            {} as Record<string, string>
+        );
 
-	if (isStringWithValue(token)) {
-		headers['Authorization'] = \`Bearer \${token}\`;
-	}
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = \`Bearer \${token}\`;
+    }
 
-	if (isStringWithValue(username) && isStringWithValue(password)) {
-		const credentials = base64(\`\${username}:\${password}\`);
-		headers['Authorization'] = \`Basic \${credentials}\`;
-	}
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(\`\${username}:\${password}\`);
+        headers['Authorization'] = \`Basic \${credentials}\`;
+    }
 
-	if (options.body !== undefined) {
-		if (options.mediaType) {
-			headers['Content-Type'] = options.mediaType;
-		} else if (isBlob(options.body)) {
-			headers['Content-Type'] = options.body.type || 'application/octet-stream';
-		} else if (isString(options.body)) {
-			headers['Content-Type'] = 'text/plain';
-		} else if (!isFormData(options.body)) {
-			headers['Content-Type'] = 'application/json';
-		}
-	}
+    if (options.body !== undefined) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
 
-	return new Headers(headers);
+    return new Headers(headers);
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-	if (options.body !== undefined) {
-		if (options.mediaType?.includes('/json')) {
-			return JSON.stringify(options.body)
-		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-			return options.body;
-		} else {
-			return JSON.stringify(options.body);
-		}
-	}
-	return undefined;
+    if (options.body !== undefined) {
+        if (options.mediaType?.includes('/json')) {
+            return JSON.stringify(options.body);
+        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+            return options.body;
+        } else {
+            return JSON.stringify(options.body);
+        }
+    }
+    return undefined;
 };
 
 export const sendRequest = async (
-	config: OpenAPIConfig,
-	options: ApiRequestOptions,
-	url: string,
-	body: any,
-	formData: FormData | undefined,
-	headers: Headers,
-	onCancel: OnCancel
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Headers,
+    onCancel: OnCancel
 ): Promise<Response> => {
-	const controller = new AbortController();
+    const controller = new AbortController();
 
-	const request: RequestInit = {
-		headers,
-		body: body ?? formData,
-		method: options.method,
-		signal: controller.signal,
-	};
+    const request: RequestInit = {
+        headers,
+        body: body ?? formData,
+        method: options.method,
+        signal: controller.signal,
+    };
 
-	if (config.WITH_CREDENTIALS) {
-		request.credentials = config.CREDENTIALS;
-	}
+    if (config.WITH_CREDENTIALS) {
+        request.credentials = config.CREDENTIALS;
+    }
 
-	onCancel(() => controller.abort());
+    onCancel(() => controller.abort());
 
-	return await fetch(url, request);
+    return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-	if (responseHeader) {
-		const content = response.headers.get(responseHeader);
-		if (isString(content)) {
-			return content;
-		}
-	}
-	return undefined;
+    if (responseHeader) {
+        const content = response.headers.get(responseHeader);
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
 };
 
 export const getResponseBody = async (response: Response): Promise<any> => {
-	if (response.status !== 204) {
-		try {
-			const contentType = response.headers.get('Content-Type');
-			if (contentType) {
-				const jsonTypes = ['application/json', 'application/problem+json'];
-				const binaryTypes = ['audio/', 'image/', 'video/'];
-				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+    if (response.status !== 204) {
+        try {
+            const contentType = response.headers.get('Content-Type');
+            if (contentType) {
+                const jsonTypes = ['application/json', 'application/problem+json'];
+                const binaryTypes = ['audio/', 'image/', 'video/'];
+                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
                 const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
-				if (isJSON) {
-					return await response.json();
-				} else if (isBinary) {}
-					return await response.blob();
-				} else {
-					return await response.text();
-				}
-			}
-		} catch (error) {
-			console.error(error);
-		}
-	}
-	return undefined;
+                if (isJSON) {
+                    return await response.json();
+                } else if (isBinary) {
+                    return await response.blob();
+                } else {
+                    return await response.text();
+                }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-	const errors: Record<number, string> = {
-		400: 'Bad Request',
-		401: 'Unauthorized',
-		403: 'Forbidden',
-		404: 'Not Found',
-		500: 'Internal Server Error',
-		502: 'Bad Gateway',
-		503: 'Service Unavailable',
-		...options.errors,
-	}
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    };
 
-	const error = errors[result.status];
-	if (error) {
-		throw new ApiError(options, result, error);
-	}
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
 
-	if (!result.ok) {
-		const errorStatus = result.status ?? 'unknown';
-		const errorStatusText = result.statusText ?? 'unknown';
-		const errorBody = (() => {
-			try {
-				return JSON.stringify(result.body, null, 2);
-			} catch (e) {
-				return undefined;
-			}
-		})();
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
 
-		throw new ApiError(options, result,
-			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
-		);
-	}
+        throw new ApiError(
+            options,
+            result,
+            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+        );
+    }
 };
 
 /**
@@ -4150,35 +4167,36 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-	return new CancelablePromise(async (resolve, reject, onCancel) => {
-		try {
-			const url = getUrl(config, options);
-			const formData = getFormData(options);
-			const body = getRequestBody(options);
-			const headers = await getHeaders(config, options);
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options);
 
-			if (!onCancel.isCancelled) {
-				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-				const responseBody = await getResponseBody(response);
-				const responseHeader = getResponseHeader(response, options.responseHeader);
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+                const responseBody = await getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
 
-				const result: ApiResult = {
-					url,
-					ok: response.ok,
-					status: response.status,
-					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
-				};
+                const result: ApiResult = {
+                    url,
+                    ok: response.ok,
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
 
-				catchErrorCodes(options, result);
+                catchErrorCodes(options, result);
 
-				resolve(result.body);
-			}
-		} catch (error) {
-			reject(error);
-		}
-	});
-};"
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+"
 `;
 
 exports[`v3 should generate: test/generated/v3/core/types.ts 1`] = `

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -241,278 +241,277 @@ import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export const isString = (value: any): value is string => {
-    return typeof value === 'string';
+	return typeof value === 'string';
 };
 
 export const isStringWithValue = (value: any): value is string => {
-    return isString(value) && value !== '';
+	return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-    return (
-        typeof value === 'object' &&
-        typeof value.type === 'string' &&
-        typeof value.stream === 'function' &&
-        typeof value.arrayBuffer === 'function' &&
-        typeof value.constructor === 'function' &&
-        typeof value.constructor.name === 'string' &&
-        /^(Blob|File)$/.test(value.constructor.name) &&
-        /^(Blob|File)$/.test(value[Symbol.toStringTag])
-    );
+	return (
+		typeof value === 'object' &&
+		typeof value.type === 'string' &&
+		typeof value.stream === 'function' &&
+		typeof value.arrayBuffer === 'function' &&
+		typeof value.constructor === 'function' &&
+		typeof value.constructor.name === 'string' &&
+		/^(Blob|File)$/.test(value.constructor.name) &&
+		/^(Blob|File)$/.test(value[Symbol.toStringTag])
+	);
 };
 
 export const isFormData = (value: any): value is FormData => {
-    return value instanceof FormData;
+	return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-    try {
-        return btoa(str);
-    } catch (err) {
-        // @ts-ignore
-        return Buffer.from(str).toString('base64');
-    }
+	try {
+		return btoa(str);
+	} catch (err) {
+		// @ts-ignore
+		return Buffer.from(str).toString('base64');
+	}
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-    const qs: string[] = [];
+	const qs: string[] = [];
 
-    const append = (key: string, value: any) => {
-        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-    };
+	const append = (key: string, value: any) => {
+		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+	};
 
-    const process = (key: string, value: any) => {
-        if (value) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
-            } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(\`\${key}[\${k}]\`, v);
-                });
-            } else {
-                append(key, value);
-            }
-        }
-    };
+	const process = (key: string, value: any) => {
+		if (value) {
+			if (Array.isArray(value)) {
+				value.forEach(v => {
+					process(key, v);
+				});
+			} else if (typeof value === 'object') {
+				Object.entries(value).forEach(([k, v]) => {
+					process(\`\${key}[\${k}]\`, v);
+				});
+			} else {
+				append(key, value);
+			}
+		}
+	};
 
-    Object.entries(params).forEach(([key, value]) => {
-        process(key, value);
-    });
+	Object.entries(params).forEach(([key, value]) => {
+		process(key, value);
+	});
 
-    if (qs.length > 0) {
-        return \`?\${qs.join('&')}\`;
-    }
+	if (qs.length > 0) {
+		return \`?\${qs.join('&')}\`;
+	}
 
-    return '';
+	return '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-    const encoder = config.ENCODE_PATH || encodeURI;
+	const encoder = config.ENCODE_PATH || encodeURI;
 
-    const path = options.url
-        .replace('{api-version}', config.VERSION)
-        .replace(/{(.*?)}/g, (substring: string, group: string) => {
-            if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
-            }
-            return substring;
-        });
+	const path = options.url
+		.replace('{api-version}', config.VERSION)
+		.replace(/{(.*?)}/g, (substring: string, group: string) => {
+			if (options.path?.hasOwnProperty(group)) {
+				return encoder(String(options.path[group]));
+			}
+			return substring;
+		});
 
-    const url = \`\${config.BASE}\${path}\`;
-    if (options.query) {
-        return \`\${url}\${getQueryString(options.query)}\`;
-    }
-    return url;
+	const url = \`\${config.BASE}\${path}\`;
+	if (options.query) {
+		return \`\${url}\${getQueryString(options.query)}\`;
+	}
+	return url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-    if (options.formData) {
-        const formData = new FormData();
+	if (options.formData) {
+		const formData = new FormData();
 
-        const process = (key: string, value: any) => {
-            if (isString(value) || isBlob(value)) {
-                formData.append(key, value);
-            } else {
-                formData.append(key, JSON.stringify(value));
-            }
-        };
+		const process = (key: string, value: any) => {
+			if (isString(value) || isBlob(value)) {
+				formData.append(key, value);
+			} else {
+				formData.append(key, JSON.stringify(value));
+			}
+		};
 
-        Object.entries(options.formData)
-            .filter(([_, value]) => value)
-            .forEach(([key, value]) => {
-                if (Array.isArray(value)) {
-                    value.forEach(v => process(key, v));
-                } else {
-                    process(key, value);
-                }
-            });
+		Object.entries(options.formData)
+			.filter(([_, value]) => value)
+			.forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					value.forEach(v => process(key, v));
+				} else {
+					process(key, value);
+				}
+			});
 
-        return formData;
-    }
-    return undefined;
+		return formData;
+	}
+	return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-    if (typeof resolver === 'function') {
-        return (resolver as Resolver<T>)(options);
-    }
-    return resolver;
+	if (typeof resolver === 'function') {
+		return (resolver as Resolver<T>)(options);
+	}
+	return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-    const [token, username, password, additionalHeaders] = await Promise.all([
-        resolve(options, config.TOKEN),
-        resolve(options, config.USERNAME),
-        resolve(options, config.PASSWORD),
-        resolve(options, config.HEADERS),
-    ]);
+	const [token, username, password, additionalHeaders] = await Promise.all([
+		resolve(options, config.TOKEN),
+		resolve(options, config.USERNAME),
+		resolve(options, config.PASSWORD),
+		resolve(options, config.HEADERS),
+	]);
 
-    const headers = Object.entries({
-        Accept: 'application/json',
-        ...additionalHeaders,
-        ...options.headers,
-    })
-        .filter(([_, value]) => value)
-        .reduce(
-            (headers, [key, value]) => ({
-                ...headers,
-                [key]: String(value),
-            }),
-            {} as Record<string, string>
-        );
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => value)
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
 
-    if (isStringWithValue(token)) {
-        headers['Authorization'] = \`Bearer \${token}\`;
-    }
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
 
-    if (isStringWithValue(username) && isStringWithValue(password)) {
-        const credentials = base64(\`\${username}:\${password}\`);
-        headers['Authorization'] = \`Basic \${credentials}\`;
-    }
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
 
-    if (options.body !== undefined) {
-        if (options.mediaType) {
-            headers['Content-Type'] = options.mediaType;
-        } else if (isBlob(options.body)) {
-            headers['Content-Type'] = options.body.type || 'application/octet-stream';
-        } else if (isString(options.body)) {
-            headers['Content-Type'] = 'text/plain';
-        } else if (!isFormData(options.body)) {
-            headers['Content-Type'] = 'application/json';
-        }
-    }
+	if (options.body !== undefined) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
 
-    return new Headers(headers);
+	return new Headers(headers);
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-    if (options.body !== undefined) {
-        if (options.mediaType?.includes('/json')) {
-            return JSON.stringify(options.body);
-        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-            return options.body;
-        } else {
-            return JSON.stringify(options.body);
-        }
-    }
-    return undefined;
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
 };
 
 export const sendRequest = async (
-    config: OpenAPIConfig,
-    options: ApiRequestOptions,
-    url: string,
-    body: any,
-    formData: FormData | undefined,
-    headers: Headers,
-    onCancel: OnCancel
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
 ): Promise<Response> => {
-    const controller = new AbortController();
+	const controller = new AbortController();
 
-    const request: RequestInit = {
-        headers,
-        body: body ?? formData,
-        method: options.method,
-        signal: controller.signal,
-    };
+	const request: RequestInit = {
+		headers,
+		body: body ?? formData,
+		method: options.method,
+		signal: controller.signal,
+	};
 
-    if (config.WITH_CREDENTIALS) {
-        request.credentials = config.CREDENTIALS;
-    }
+	if (config.WITH_CREDENTIALS) {
+		request.credentials = config.CREDENTIALS;
+	}
 
-    onCancel(() => controller.abort());
+	onCancel(() => controller.abort());
 
-    return await fetch(url, request);
+	return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-    if (responseHeader) {
-        const content = response.headers.get(responseHeader);
-        if (isString(content)) {
-            return content;
-        }
-    }
-    return undefined;
+	if (responseHeader) {
+		const content = response.headers.get(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
 };
 
 export const getResponseBody = async (response: Response): Promise<any> => {
-    if (response.status !== 204) {
-        try {
-            const contentType = response.headers.get('Content-Type');
-            if (contentType) {
-                const jsonTypes = ['application/json', 'application/problem+json'];
-                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
-                if (isJSON) {
-                    return await response.json();
-                } else {
-                    return await response.text();
-                }
-            }
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    return undefined;
+	if (response.status !== 204) {
+		try {
+			const contentType = response.headers.get('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json'];
+				const binaryTypes = ['audio/', 'image/', 'video/'];
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return await response.json();
+				} else if (isBinary) {}
+					return await response.blob();
+				} else {
+					return await response.text();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-    const errors: Record<number, string> = {
-        400: 'Bad Request',
-        401: 'Unauthorized',
-        403: 'Forbidden',
-        404: 'Not Found',
-        500: 'Internal Server Error',
-        502: 'Bad Gateway',
-        503: 'Service Unavailable',
-        ...options.errors,
-    };
+	const errors: Record<number, string> = {
+		400: 'Bad Request',
+		401: 'Unauthorized',
+		403: 'Forbidden',
+		404: 'Not Found',
+		500: 'Internal Server Error',
+		502: 'Bad Gateway',
+		503: 'Service Unavailable',
+		...options.errors,
+	}
 
-    const error = errors[result.status];
-    if (error) {
-        throw new ApiError(options, result, error);
-    }
+	const error = errors[result.status];
+	if (error) {
+		throw new ApiError(options, result, error);
+	}
 
-    if (!result.ok) {
-        const errorStatus = result.status ?? 'unknown';
-        const errorStatusText = result.statusText ?? 'unknown';
-        const errorBody = (() => {
-            try {
-                return JSON.stringify(result.body, null, 2);
-            } catch (e) {
-                return undefined;
-            }
-        })();
+	if (!result.ok) {
+		const errorStatus = result.status ?? 'unknown';
+		const errorStatusText = result.statusText ?? 'unknown';
+		const errorBody = (() => {
+			try {
+				return JSON.stringify(result.body, null, 2);
+			} catch (e) {
+				return undefined;
+			}
+		})();
 
-        throw new ApiError(
-            options,
-            result,
-            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
-        );
-    }
+		throw new ApiError(options, result,
+			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+		);
+	}
 };
 
 /**
@@ -523,36 +522,35 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            const url = getUrl(config, options);
-            const formData = getFormData(options);
-            const body = getRequestBody(options);
-            const headers = await getHeaders(config, options);
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
 
-            if (!onCancel.isCancelled) {
-                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-                const responseBody = await getResponseBody(response);
-                const responseHeader = getResponseHeader(response, options.responseHeader);
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+				const responseBody = await getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-                const result: ApiResult = {
-                    url,
-                    ok: response.ok,
-                    status: response.status,
-                    statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
-                };
+				const result: ApiResult = {
+					url,
+					ok: response.ok,
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
 
-                catchErrorCodes(options, result);
+				catchErrorCodes(options, result);
 
-                resolve(result.body);
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
-};
-"
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};"
 `;
 
 exports[`v2 should generate: test/generated/v2/core/types.ts 1`] = `
@@ -3106,278 +3104,277 @@ import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export const isString = (value: any): value is string => {
-    return typeof value === 'string';
+	return typeof value === 'string';
 };
 
 export const isStringWithValue = (value: any): value is string => {
-    return isString(value) && value !== '';
+	return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-    return (
-        typeof value === 'object' &&
-        typeof value.type === 'string' &&
-        typeof value.stream === 'function' &&
-        typeof value.arrayBuffer === 'function' &&
-        typeof value.constructor === 'function' &&
-        typeof value.constructor.name === 'string' &&
-        /^(Blob|File)$/.test(value.constructor.name) &&
-        /^(Blob|File)$/.test(value[Symbol.toStringTag])
-    );
+	return (
+		typeof value === 'object' &&
+		typeof value.type === 'string' &&
+		typeof value.stream === 'function' &&
+		typeof value.arrayBuffer === 'function' &&
+		typeof value.constructor === 'function' &&
+		typeof value.constructor.name === 'string' &&
+		/^(Blob|File)$/.test(value.constructor.name) &&
+		/^(Blob|File)$/.test(value[Symbol.toStringTag])
+	);
 };
 
 export const isFormData = (value: any): value is FormData => {
-    return value instanceof FormData;
+	return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-    try {
-        return btoa(str);
-    } catch (err) {
-        // @ts-ignore
-        return Buffer.from(str).toString('base64');
-    }
+	try {
+		return btoa(str);
+	} catch (err) {
+		// @ts-ignore
+		return Buffer.from(str).toString('base64');
+	}
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-    const qs: string[] = [];
+	const qs: string[] = [];
 
-    const append = (key: string, value: any) => {
-        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-    };
+	const append = (key: string, value: any) => {
+		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+	};
 
-    const process = (key: string, value: any) => {
-        if (value) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
-            } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(\`\${key}[\${k}]\`, v);
-                });
-            } else {
-                append(key, value);
-            }
-        }
-    };
+	const process = (key: string, value: any) => {
+		if (value) {
+			if (Array.isArray(value)) {
+				value.forEach(v => {
+					process(key, v);
+				});
+			} else if (typeof value === 'object') {
+				Object.entries(value).forEach(([k, v]) => {
+					process(\`\${key}[\${k}]\`, v);
+				});
+			} else {
+				append(key, value);
+			}
+		}
+	};
 
-    Object.entries(params).forEach(([key, value]) => {
-        process(key, value);
-    });
+	Object.entries(params).forEach(([key, value]) => {
+		process(key, value);
+	});
 
-    if (qs.length > 0) {
-        return \`?\${qs.join('&')}\`;
-    }
+	if (qs.length > 0) {
+		return \`?\${qs.join('&')}\`;
+	}
 
-    return '';
+	return '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-    const encoder = config.ENCODE_PATH || encodeURI;
+	const encoder = config.ENCODE_PATH || encodeURI;
 
-    const path = options.url
-        .replace('{api-version}', config.VERSION)
-        .replace(/{(.*?)}/g, (substring: string, group: string) => {
-            if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
-            }
-            return substring;
-        });
+	const path = options.url
+		.replace('{api-version}', config.VERSION)
+		.replace(/{(.*?)}/g, (substring: string, group: string) => {
+			if (options.path?.hasOwnProperty(group)) {
+				return encoder(String(options.path[group]));
+			}
+			return substring;
+		});
 
-    const url = \`\${config.BASE}\${path}\`;
-    if (options.query) {
-        return \`\${url}\${getQueryString(options.query)}\`;
-    }
-    return url;
+	const url = \`\${config.BASE}\${path}\`;
+	if (options.query) {
+		return \`\${url}\${getQueryString(options.query)}\`;
+	}
+	return url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-    if (options.formData) {
-        const formData = new FormData();
+	if (options.formData) {
+		const formData = new FormData();
 
-        const process = (key: string, value: any) => {
-            if (isString(value) || isBlob(value)) {
-                formData.append(key, value);
-            } else {
-                formData.append(key, JSON.stringify(value));
-            }
-        };
+		const process = (key: string, value: any) => {
+			if (isString(value) || isBlob(value)) {
+				formData.append(key, value);
+			} else {
+				formData.append(key, JSON.stringify(value));
+			}
+		};
 
-        Object.entries(options.formData)
-            .filter(([_, value]) => value)
-            .forEach(([key, value]) => {
-                if (Array.isArray(value)) {
-                    value.forEach(v => process(key, v));
-                } else {
-                    process(key, value);
-                }
-            });
+		Object.entries(options.formData)
+			.filter(([_, value]) => value)
+			.forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					value.forEach(v => process(key, v));
+				} else {
+					process(key, value);
+				}
+			});
 
-        return formData;
-    }
-    return undefined;
+		return formData;
+	}
+	return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-    if (typeof resolver === 'function') {
-        return (resolver as Resolver<T>)(options);
-    }
-    return resolver;
+	if (typeof resolver === 'function') {
+		return (resolver as Resolver<T>)(options);
+	}
+	return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-    const [token, username, password, additionalHeaders] = await Promise.all([
-        resolve(options, config.TOKEN),
-        resolve(options, config.USERNAME),
-        resolve(options, config.PASSWORD),
-        resolve(options, config.HEADERS),
-    ]);
+	const [token, username, password, additionalHeaders] = await Promise.all([
+		resolve(options, config.TOKEN),
+		resolve(options, config.USERNAME),
+		resolve(options, config.PASSWORD),
+		resolve(options, config.HEADERS),
+	]);
 
-    const headers = Object.entries({
-        Accept: 'application/json',
-        ...additionalHeaders,
-        ...options.headers,
-    })
-        .filter(([_, value]) => value)
-        .reduce(
-            (headers, [key, value]) => ({
-                ...headers,
-                [key]: String(value),
-            }),
-            {} as Record<string, string>
-        );
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => value)
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
 
-    if (isStringWithValue(token)) {
-        headers['Authorization'] = \`Bearer \${token}\`;
-    }
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
 
-    if (isStringWithValue(username) && isStringWithValue(password)) {
-        const credentials = base64(\`\${username}:\${password}\`);
-        headers['Authorization'] = \`Basic \${credentials}\`;
-    }
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
 
-    if (options.body !== undefined) {
-        if (options.mediaType) {
-            headers['Content-Type'] = options.mediaType;
-        } else if (isBlob(options.body)) {
-            headers['Content-Type'] = options.body.type || 'application/octet-stream';
-        } else if (isString(options.body)) {
-            headers['Content-Type'] = 'text/plain';
-        } else if (!isFormData(options.body)) {
-            headers['Content-Type'] = 'application/json';
-        }
-    }
+	if (options.body !== undefined) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
 
-    return new Headers(headers);
+	return new Headers(headers);
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-    if (options.body !== undefined) {
-        if (options.mediaType?.includes('/json')) {
-            return JSON.stringify(options.body);
-        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-            return options.body;
-        } else {
-            return JSON.stringify(options.body);
-        }
-    }
-    return undefined;
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
 };
 
 export const sendRequest = async (
-    config: OpenAPIConfig,
-    options: ApiRequestOptions,
-    url: string,
-    body: any,
-    formData: FormData | undefined,
-    headers: Headers,
-    onCancel: OnCancel
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
 ): Promise<Response> => {
-    const controller = new AbortController();
+	const controller = new AbortController();
 
-    const request: RequestInit = {
-        headers,
-        body: body ?? formData,
-        method: options.method,
-        signal: controller.signal,
-    };
+	const request: RequestInit = {
+		headers,
+		body: body ?? formData,
+		method: options.method,
+		signal: controller.signal,
+	};
 
-    if (config.WITH_CREDENTIALS) {
-        request.credentials = config.CREDENTIALS;
-    }
+	if (config.WITH_CREDENTIALS) {
+		request.credentials = config.CREDENTIALS;
+	}
 
-    onCancel(() => controller.abort());
+	onCancel(() => controller.abort());
 
-    return await fetch(url, request);
+	return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-    if (responseHeader) {
-        const content = response.headers.get(responseHeader);
-        if (isString(content)) {
-            return content;
-        }
-    }
-    return undefined;
+	if (responseHeader) {
+		const content = response.headers.get(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
 };
 
 export const getResponseBody = async (response: Response): Promise<any> => {
-    if (response.status !== 204) {
-        try {
-            const contentType = response.headers.get('Content-Type');
-            if (contentType) {
-                const jsonTypes = ['application/json', 'application/problem+json'];
-                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
-                if (isJSON) {
-                    return await response.json();
-                } else {
-                    return await response.text();
-                }
-            }
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    return undefined;
+	if (response.status !== 204) {
+		try {
+			const contentType = response.headers.get('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json'];
+				const binaryTypes = ['audio/', 'image/', 'video/'];
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return await response.json();
+				} else if (isBinary) {}
+					return await response.blob();
+				} else {
+					return await response.text();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-    const errors: Record<number, string> = {
-        400: 'Bad Request',
-        401: 'Unauthorized',
-        403: 'Forbidden',
-        404: 'Not Found',
-        500: 'Internal Server Error',
-        502: 'Bad Gateway',
-        503: 'Service Unavailable',
-        ...options.errors,
-    };
+	const errors: Record<number, string> = {
+		400: 'Bad Request',
+		401: 'Unauthorized',
+		403: 'Forbidden',
+		404: 'Not Found',
+		500: 'Internal Server Error',
+		502: 'Bad Gateway',
+		503: 'Service Unavailable',
+		...options.errors,
+	}
 
-    const error = errors[result.status];
-    if (error) {
-        throw new ApiError(options, result, error);
-    }
+	const error = errors[result.status];
+	if (error) {
+		throw new ApiError(options, result, error);
+	}
 
-    if (!result.ok) {
-        const errorStatus = result.status ?? 'unknown';
-        const errorStatusText = result.statusText ?? 'unknown';
-        const errorBody = (() => {
-            try {
-                return JSON.stringify(result.body, null, 2);
-            } catch (e) {
-                return undefined;
-            }
-        })();
+	if (!result.ok) {
+		const errorStatus = result.status ?? 'unknown';
+		const errorStatusText = result.statusText ?? 'unknown';
+		const errorBody = (() => {
+			try {
+				return JSON.stringify(result.body, null, 2);
+			} catch (e) {
+				return undefined;
+			}
+		})();
 
-        throw new ApiError(
-            options,
-            result,
-            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
-        );
-    }
+		throw new ApiError(options, result,
+			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+		);
+	}
 };
 
 /**
@@ -3388,36 +3385,35 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            const url = getUrl(config, options);
-            const formData = getFormData(options);
-            const body = getRequestBody(options);
-            const headers = await getHeaders(config, options);
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
 
-            if (!onCancel.isCancelled) {
-                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-                const responseBody = await getResponseBody(response);
-                const responseHeader = getResponseHeader(response, options.responseHeader);
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+				const responseBody = await getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-                const result: ApiResult = {
-                    url,
-                    ok: response.ok,
-                    status: response.status,
-                    statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
-                };
+				const result: ApiResult = {
+					url,
+					ok: response.ok,
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
 
-                catchErrorCodes(options, result);
+				catchErrorCodes(options, result);
 
-                resolve(result.body);
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
-};
-"
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};"
 `;
 
 exports[`v3 should generate optional argument: test/generated/v3_options/core/types.ts 1`] = `
@@ -3873,278 +3869,277 @@ import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export const isString = (value: any): value is string => {
-    return typeof value === 'string';
+	return typeof value === 'string';
 };
 
 export const isStringWithValue = (value: any): value is string => {
-    return isString(value) && value !== '';
+	return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-    return (
-        typeof value === 'object' &&
-        typeof value.type === 'string' &&
-        typeof value.stream === 'function' &&
-        typeof value.arrayBuffer === 'function' &&
-        typeof value.constructor === 'function' &&
-        typeof value.constructor.name === 'string' &&
-        /^(Blob|File)$/.test(value.constructor.name) &&
-        /^(Blob|File)$/.test(value[Symbol.toStringTag])
-    );
+	return (
+		typeof value === 'object' &&
+		typeof value.type === 'string' &&
+		typeof value.stream === 'function' &&
+		typeof value.arrayBuffer === 'function' &&
+		typeof value.constructor === 'function' &&
+		typeof value.constructor.name === 'string' &&
+		/^(Blob|File)$/.test(value.constructor.name) &&
+		/^(Blob|File)$/.test(value[Symbol.toStringTag])
+	);
 };
 
 export const isFormData = (value: any): value is FormData => {
-    return value instanceof FormData;
+	return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-    try {
-        return btoa(str);
-    } catch (err) {
-        // @ts-ignore
-        return Buffer.from(str).toString('base64');
-    }
+	try {
+		return btoa(str);
+	} catch (err) {
+		// @ts-ignore
+		return Buffer.from(str).toString('base64');
+	}
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-    const qs: string[] = [];
+	const qs: string[] = [];
 
-    const append = (key: string, value: any) => {
-        qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
-    };
+	const append = (key: string, value: any) => {
+		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+	};
 
-    const process = (key: string, value: any) => {
-        if (value) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
-            } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(\`\${key}[\${k}]\`, v);
-                });
-            } else {
-                append(key, value);
-            }
-        }
-    };
+	const process = (key: string, value: any) => {
+		if (value) {
+			if (Array.isArray(value)) {
+				value.forEach(v => {
+					process(key, v);
+				});
+			} else if (typeof value === 'object') {
+				Object.entries(value).forEach(([k, v]) => {
+					process(\`\${key}[\${k}]\`, v);
+				});
+			} else {
+				append(key, value);
+			}
+		}
+	};
 
-    Object.entries(params).forEach(([key, value]) => {
-        process(key, value);
-    });
+	Object.entries(params).forEach(([key, value]) => {
+		process(key, value);
+	});
 
-    if (qs.length > 0) {
-        return \`?\${qs.join('&')}\`;
-    }
+	if (qs.length > 0) {
+		return \`?\${qs.join('&')}\`;
+	}
 
-    return '';
+	return '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-    const encoder = config.ENCODE_PATH || encodeURI;
+	const encoder = config.ENCODE_PATH || encodeURI;
 
-    const path = options.url
-        .replace('{api-version}', config.VERSION)
-        .replace(/{(.*?)}/g, (substring: string, group: string) => {
-            if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
-            }
-            return substring;
-        });
+	const path = options.url
+		.replace('{api-version}', config.VERSION)
+		.replace(/{(.*?)}/g, (substring: string, group: string) => {
+			if (options.path?.hasOwnProperty(group)) {
+				return encoder(String(options.path[group]));
+			}
+			return substring;
+		});
 
-    const url = \`\${config.BASE}\${path}\`;
-    if (options.query) {
-        return \`\${url}\${getQueryString(options.query)}\`;
-    }
-    return url;
+	const url = \`\${config.BASE}\${path}\`;
+	if (options.query) {
+		return \`\${url}\${getQueryString(options.query)}\`;
+	}
+	return url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-    if (options.formData) {
-        const formData = new FormData();
+	if (options.formData) {
+		const formData = new FormData();
 
-        const process = (key: string, value: any) => {
-            if (isString(value) || isBlob(value)) {
-                formData.append(key, value);
-            } else {
-                formData.append(key, JSON.stringify(value));
-            }
-        };
+		const process = (key: string, value: any) => {
+			if (isString(value) || isBlob(value)) {
+				formData.append(key, value);
+			} else {
+				formData.append(key, JSON.stringify(value));
+			}
+		};
 
-        Object.entries(options.formData)
-            .filter(([_, value]) => value)
-            .forEach(([key, value]) => {
-                if (Array.isArray(value)) {
-                    value.forEach(v => process(key, v));
-                } else {
-                    process(key, value);
-                }
-            });
+		Object.entries(options.formData)
+			.filter(([_, value]) => value)
+			.forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					value.forEach(v => process(key, v));
+				} else {
+					process(key, value);
+				}
+			});
 
-        return formData;
-    }
-    return undefined;
+		return formData;
+	}
+	return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-    if (typeof resolver === 'function') {
-        return (resolver as Resolver<T>)(options);
-    }
-    return resolver;
+	if (typeof resolver === 'function') {
+		return (resolver as Resolver<T>)(options);
+	}
+	return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-    const [token, username, password, additionalHeaders] = await Promise.all([
-        resolve(options, config.TOKEN),
-        resolve(options, config.USERNAME),
-        resolve(options, config.PASSWORD),
-        resolve(options, config.HEADERS),
-    ]);
+	const [token, username, password, additionalHeaders] = await Promise.all([
+		resolve(options, config.TOKEN),
+		resolve(options, config.USERNAME),
+		resolve(options, config.PASSWORD),
+		resolve(options, config.HEADERS),
+	]);
 
-    const headers = Object.entries({
-        Accept: 'application/json',
-        ...additionalHeaders,
-        ...options.headers,
-    })
-        .filter(([_, value]) => value)
-        .reduce(
-            (headers, [key, value]) => ({
-                ...headers,
-                [key]: String(value),
-            }),
-            {} as Record<string, string>
-        );
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => value)
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
 
-    if (isStringWithValue(token)) {
-        headers['Authorization'] = \`Bearer \${token}\`;
-    }
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
 
-    if (isStringWithValue(username) && isStringWithValue(password)) {
-        const credentials = base64(\`\${username}:\${password}\`);
-        headers['Authorization'] = \`Basic \${credentials}\`;
-    }
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
 
-    if (options.body !== undefined) {
-        if (options.mediaType) {
-            headers['Content-Type'] = options.mediaType;
-        } else if (isBlob(options.body)) {
-            headers['Content-Type'] = options.body.type || 'application/octet-stream';
-        } else if (isString(options.body)) {
-            headers['Content-Type'] = 'text/plain';
-        } else if (!isFormData(options.body)) {
-            headers['Content-Type'] = 'application/json';
-        }
-    }
+	if (options.body !== undefined) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
 
-    return new Headers(headers);
+	return new Headers(headers);
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-    if (options.body !== undefined) {
-        if (options.mediaType?.includes('/json')) {
-            return JSON.stringify(options.body);
-        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-            return options.body;
-        } else {
-            return JSON.stringify(options.body);
-        }
-    }
-    return undefined;
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
 };
 
 export const sendRequest = async (
-    config: OpenAPIConfig,
-    options: ApiRequestOptions,
-    url: string,
-    body: any,
-    formData: FormData | undefined,
-    headers: Headers,
-    onCancel: OnCancel
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
 ): Promise<Response> => {
-    const controller = new AbortController();
+	const controller = new AbortController();
 
-    const request: RequestInit = {
-        headers,
-        body: body ?? formData,
-        method: options.method,
-        signal: controller.signal,
-    };
+	const request: RequestInit = {
+		headers,
+		body: body ?? formData,
+		method: options.method,
+		signal: controller.signal,
+	};
 
-    if (config.WITH_CREDENTIALS) {
-        request.credentials = config.CREDENTIALS;
-    }
+	if (config.WITH_CREDENTIALS) {
+		request.credentials = config.CREDENTIALS;
+	}
 
-    onCancel(() => controller.abort());
+	onCancel(() => controller.abort());
 
-    return await fetch(url, request);
+	return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-    if (responseHeader) {
-        const content = response.headers.get(responseHeader);
-        if (isString(content)) {
-            return content;
-        }
-    }
-    return undefined;
+	if (responseHeader) {
+		const content = response.headers.get(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
 };
 
 export const getResponseBody = async (response: Response): Promise<any> => {
-    if (response.status !== 204) {
-        try {
-            const contentType = response.headers.get('Content-Type');
-            if (contentType) {
-                const jsonTypes = ['application/json', 'application/problem+json'];
-                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
-                if (isJSON) {
-                    return await response.json();
-                } else {
-                    return await response.text();
-                }
-            }
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    return undefined;
+	if (response.status !== 204) {
+		try {
+			const contentType = response.headers.get('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json'];
+				const binaryTypes = ['audio/', 'image/', 'video/'];
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return await response.json();
+				} else if (isBinary) {}
+					return await response.blob();
+				} else {
+					return await response.text();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-    const errors: Record<number, string> = {
-        400: 'Bad Request',
-        401: 'Unauthorized',
-        403: 'Forbidden',
-        404: 'Not Found',
-        500: 'Internal Server Error',
-        502: 'Bad Gateway',
-        503: 'Service Unavailable',
-        ...options.errors,
-    };
+	const errors: Record<number, string> = {
+		400: 'Bad Request',
+		401: 'Unauthorized',
+		403: 'Forbidden',
+		404: 'Not Found',
+		500: 'Internal Server Error',
+		502: 'Bad Gateway',
+		503: 'Service Unavailable',
+		...options.errors,
+	}
 
-    const error = errors[result.status];
-    if (error) {
-        throw new ApiError(options, result, error);
-    }
+	const error = errors[result.status];
+	if (error) {
+		throw new ApiError(options, result, error);
+	}
 
-    if (!result.ok) {
-        const errorStatus = result.status ?? 'unknown';
-        const errorStatusText = result.statusText ?? 'unknown';
-        const errorBody = (() => {
-            try {
-                return JSON.stringify(result.body, null, 2);
-            } catch (e) {
-                return undefined;
-            }
-        })();
+	if (!result.ok) {
+		const errorStatus = result.status ?? 'unknown';
+		const errorStatusText = result.statusText ?? 'unknown';
+		const errorBody = (() => {
+			try {
+				return JSON.stringify(result.body, null, 2);
+			} catch (e) {
+				return undefined;
+			}
+		})();
 
-        throw new ApiError(
-            options,
-            result,
-            \`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
-        );
-    }
+		throw new ApiError(options, result,
+			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+		);
+	}
 };
 
 /**
@@ -4155,36 +4150,35 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            const url = getUrl(config, options);
-            const formData = getFormData(options);
-            const body = getRequestBody(options);
-            const headers = await getHeaders(config, options);
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
 
-            if (!onCancel.isCancelled) {
-                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-                const responseBody = await getResponseBody(response);
-                const responseHeader = getResponseHeader(response, options.responseHeader);
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+				const responseBody = await getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-                const result: ApiResult = {
-                    url,
-                    ok: response.ok,
-                    status: response.status,
-                    statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
-                };
+				const result: ApiResult = {
+					url,
+					ok: response.ok,
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
 
-                catchErrorCodes(options, result);
+				catchErrorCodes(options, result);
 
-                resolve(result.body);
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
-};
-"
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};"
 `;
 
 exports[`v3 should generate: test/generated/v3/core/types.ts 1`] = `

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -7630,7 +7630,7 @@ export class FileResponseService {
             method: 'GET',
             url: '/api/v{api-version}/file/{id}',
             path: {
-                id: id,
+                id,
             },
         });
     }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4393,6 +4393,7 @@ export { DeprecatedService } from './services/DeprecatedService';
 export { DescriptionsService } from './services/DescriptionsService';
 export { DuplicateService } from './services/DuplicateService';
 export { ErrorService } from './services/ErrorService';
+export { FileResponseService } from './services/FileResponseService';
 export { FormDataService } from './services/FormDataService';
 export { HeaderService } from './services/HeaderService';
 export { MultipartService } from './services/MultipartService';
@@ -7588,6 +7589,30 @@ export class ErrorService {
                 501: \`Custom message: Not Implemented\`,
                 502: \`Custom message: Bad Gateway\`,
                 503: \`Custom message: Service Unavailable\`,
+            },
+        });
+    }
+}
+"
+`;
+
+exports[`v3 should generate: test/generated/v3/services/FileResponseService.ts 1`] = `
+"import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+
+export class FileResponseService {
+    /**
+     * @param id
+     * @returns binary Success
+     * @throws ApiError
+     */
+    public static fileResponse(id: string): CancelablePromise<Blob> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v{api-version}/file/{id}',
+            path: {
+                id: id,
             },
         });
     }

--- a/test/e2e/v3.fetch.spec.ts
+++ b/test/e2e/v3.fetch.spec.ts
@@ -75,6 +75,14 @@ describe('v3.fetch', () => {
         expect(result).toBeDefined();
     });
 
+    it('support blob response data', async () => {
+        const result = await browser.evaluate(async () => {
+            const { FileResponseService } = (window as any).api;
+            return await FileResponseService.fileResponse('test');
+        });
+        expect(result).toBeDefined();
+    });
+
     it('can abort the request', async () => {
         let error;
         try {

--- a/test/e2e/v3.node.spec.ts
+++ b/test/e2e/v3.node.spec.ts
@@ -62,6 +62,12 @@ describe('v3.node', () => {
         expect(result).toBeDefined();
     });
 
+    it('support blob response data', async () => {
+        const { FileResponseService } = require('./generated/v3/node/index.js');
+        const result = await FileResponseService.fileResponse('test');
+        expect(result).toBeDefined();
+    });
+
     it('can abort the request', async () => {
         let error;
         try {

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1229,6 +1229,49 @@
                 }
             }
         },
+        "/api/v{api-version}/file/{id}": {
+            "get": {
+                "tags": [
+                    "FileResponse"
+                ],
+                "operationId": "FileResponse",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "api-version",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "audio/*": {
+                                "schema": {
+                                    "type": "file"
+                                }
+                            },
+                            "video/*": {
+                                "schema": {
+                                    "type": "file"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v{api-version}/complex": {
             "get": {
                 "tags": [


### PR DESCRIPTION
I have been applying a patch to my generated files up until now to apply this change. When sending file responses with FastAPI (specifically video/audio in my cases) this will properly handle the response.

NOTE: there may be content types missing but I think this may be a good start.