### PR TITLE
revert(package): remove package manager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,5 @@
         "tslib": "2.6.2",
         "typescript": "5.4.3",
         "vitest": "1.4.0"
-    },
-    "packageManager": "npm@10.5.0+sha256.17ca6e08e7633b624e8f870db81a78f46afe119de62bcaf0a7407574139198fc"
+    }
 }


### PR DESCRIPTION
This is an [experimental](https://nodejs.org/api/packages.html#packagemanager) setting that makes it hard to link package locally through Yarn to use with other codebases that do not use npm