### PR TITLE
feat(client): use FormData from node-fetch in node client

### DIFF
--- a/.changeset/warm-buttons-brake.md
+++ b/.changeset/warm-buttons-brake.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+use FormData from node-fetch in node client

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -1,5 +1,4 @@
-import FormData from 'form-data';
-import fetch, { Headers } from 'node-fetch';
+import fetch, { FormData, Headers } from 'node-fetch';
 import type { RequestInit, Response } from 'node-fetch';
 
 import { ApiError } from './ApiError';


### PR DESCRIPTION
see comment: https://github.com/hey-api/openapi-ts/issues/29#issuecomment-2026463323 

NOTE: this will fix the issue for the node client, axios will still have bug when appending blob

The `node-fetch` library provides FormData directly, and it is much more in line with the built in FormData (stabilizing in node 21)