### PR TITLE
chore(ci): use concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}=${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Build, Lint, Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "44 20 * * 3"
 
+concurrency:
+  group: ${{ github.workflow }}=${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}=${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   upload:
     name: Upload


### PR DESCRIPTION
Prevent backup in github actions. Only run latest commit in CI and if previous CI was running for that branch, cancel it.