### PR TITLE
fix(docs): correct link to `UserConfig` interface source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ export default {
 
 ### Config API
 
-You can view the complete list of options in the [UserConfig](./src/types/config.ts) interface.
+You can view the complete list of options in the [UserConfig](./packages/openapi-ts/src/types/config.ts) interface.
 
 ## Interceptors
 


### PR DESCRIPTION
Fixes https://github.com/hey-api/openapi-ts/issues/233