### PR TITLE
chore(client): use compiler api to generate service imports

### DIFF
--- a/packages/openapi-ts/src/compiler/index.ts
+++ b/packages/openapi-ts/src/compiler/index.ts
@@ -7,9 +7,12 @@ import * as types from './types';
 import { tsNodeToString } from './utils';
 
 export class TypeScriptFile extends Array<ts.Node> {
+    public override toString(seperator: string = '\n') {
+        return this.map(v => tsNodeToString(v)).join(seperator);
+    }
+
     public write(file: PathOrFileDescriptor, seperator: string = '\n') {
-        const items = this.map(i => tsNodeToString(i));
-        writeFileSync(file, items.join(seperator));
+        writeFileSync(file, this.toString(seperator));
     }
 }
 

--- a/packages/openapi-ts/src/compiler/module.ts
+++ b/packages/openapi-ts/src/compiler/module.ts
@@ -10,7 +10,7 @@ import { ots } from './utils';
 export const createExportAllDeclaration = (module: string) =>
     ts.factory.createExportDeclaration(undefined, false, undefined, ots.string(module));
 
-type ImportItem = { name: string; isTypeOnly?: boolean } | string;
+type ImportItem = { name: string; isTypeOnly?: boolean; alias?: string } | string;
 
 /**
  * Create a named export declaration. Example: `export { X } from './y'`.
@@ -29,8 +29,12 @@ export const createNamedExportDeclarations = (
         isAllTypes,
         ts.factory.createNamedExports(
             items.map(item => {
-                const { name, isTypeOnly = undefined } = typeof item === 'string' ? { name: item } : item;
-                return ots.export(name, isAllTypes ? false : Boolean(isTypeOnly));
+                const {
+                    name,
+                    isTypeOnly = undefined,
+                    alias = undefined,
+                } = typeof item === 'string' ? { name: item } : item;
+                return ots.export(name, isAllTypes ? false : Boolean(isTypeOnly), alias);
             })
         ),
         ots.string(module)
@@ -78,8 +82,12 @@ export const createNamedImportDeclarations = (
             undefined,
             ts.factory.createNamedImports(
                 items.map(item => {
-                    const { name, isTypeOnly = undefined } = typeof item === 'string' ? { name: item } : item;
-                    return ots.import(name, isAllTypes ? false : Boolean(isTypeOnly));
+                    const {
+                        name,
+                        isTypeOnly = undefined,
+                        alias = undefined,
+                    } = typeof item === 'string' ? { name: item } : item;
+                    return ots.import(name, isAllTypes ? false : Boolean(isTypeOnly), alias);
                 })
             )
         ),

--- a/packages/openapi-ts/src/compiler/utils.ts
+++ b/packages/openapi-ts/src/compiler/utils.ts
@@ -24,18 +24,22 @@ export function tsNodeToString(node: ts.Node): string {
 export const ots = {
     // Create a boolean expression based on value.
     boolean: (value: boolean) => (value ? ts.factory.createTrue() : ts.factory.createFalse()),
-    export: (name: string, isTypeOnly?: boolean) =>
-        ts.factory.createExportSpecifier(
+    export: (name: string, isTypeOnly?: boolean, alias?: string) => {
+        const n = ts.factory.createIdentifier(encodeURIComponent(name));
+        return ts.factory.createExportSpecifier(
             isTypeOnly ?? false,
-            undefined,
-            ts.factory.createIdentifier(encodeURIComponent(name))
-        ),
-    import: (name: string, isTypeOnly?: boolean) =>
-        ts.factory.createImportSpecifier(
+            alias ? n : undefined,
+            alias ? ts.factory.createIdentifier(encodeURIComponent(alias)) : n
+        );
+    },
+    import: (name: string, isTypeOnly?: boolean, alias?: string) => {
+        const n = ts.factory.createIdentifier(encodeURIComponent(name));
+        return ts.factory.createImportSpecifier(
             isTypeOnly ?? false,
-            undefined,
-            ts.factory.createIdentifier(encodeURIComponent(name))
-        ),
+            alias ? n : undefined,
+            alias ? ts.factory.createIdentifier(encodeURIComponent(alias)) : n
+        );
+    },
     // Create a numeric expression, handling negative numbers.
     number: (value: number) => {
         if (value < 0) {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/services.ts.snap
@@ -1,7 +1,6 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type {
     ModelWithString,
     ModelThatExtends,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/services.ts.snap
@@ -1,7 +1,6 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type {
     ModelWithArrayReadOnlyAndWriteOnly,
     ModelWithReadOnlyAndWriteOnly,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/services.ts.snap
@@ -3,7 +3,6 @@ import { HttpClient } from '@angular/common/http';
 import type { Observable } from 'rxjs';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type {
     ModelWithArrayReadOnlyAndWriteOnly,
     ModelWithReadOnlyAndWriteOnly,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/services.ts.snap
@@ -1,6 +1,5 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import type { BaseHttpRequest } from './core/BaseHttpRequest';
-
 import type {
     ModelWithArrayReadOnlyAndWriteOnly,
     ModelWithReadOnlyAndWriteOnly,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/services.ts.snap
@@ -1,7 +1,6 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type {
     ModelWithArrayReadOnlyAndWriteOnly,
     ModelWithReadOnlyAndWriteOnly,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_experimental/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_experimental/services.ts.snap
@@ -1,7 +1,6 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type {
     ModelWithArrayReadOnlyAndWriteOnly,
     ModelWithReadOnlyAndWriteOnly,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/services.ts.snap
@@ -1,7 +1,6 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type { ModelWithString } from './models';
 
 export class DefaultsService {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/services.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/services.ts.snap
@@ -1,7 +1,6 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-
 import type { ModelWithString } from './models';
 
 export type DefaultsData = {


### PR DESCRIPTION
- Add ability to import and export using alias.
- Add toString to TypeScriptFile class (This should be used instead of tsNodeToString everywhere outside of compiler code)
- Update services import to use compiler api