### PR TITLE
fix(client): export APIResult when using serviceResponse as 'response'

### DIFF
--- a/.changeset/five-owls-accept.md
+++ b/.changeset/five-owls-accept.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(client): export APIResult when using serviceResponse as 'response'

--- a/packages/openapi-ts/src/utils/write/index.ts
+++ b/packages/openapi-ts/src/utils/write/index.ts
@@ -18,6 +18,9 @@ export const writeClientIndex = async (client: Client, outputPath: string, confi
     }
     if (config.exportCore) {
         file.push(compiler.export.named('ApiError', './core/ApiError'));
+        if (config.serviceResponse === 'response') {
+            file.push(compiler.export.named({ isTypeOnly: true, name: 'ApiResult' }, './core/ApiResult'));
+        }
         if (config.name) {
             file.push(compiler.export.named('BaseHttpRequest', './core/BaseHttpRequest'));
         }


### PR DESCRIPTION
closes: #282