### PR TITLE
fix(compiler): ensure backticked strings are escaped properly

### DIFF
--- a/.changeset/two-elephants-heal.md
+++ b/.changeset/two-elephants-heal.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: ensure strings with both single/double quotes and backticks are escaped properly ([#310](https://github.com/hey-api/openapi-ts/pull/310))

--- a/packages/openapi-ts/src/compiler/utils.ts
+++ b/packages/openapi-ts/src/compiler/utils.ts
@@ -70,7 +70,7 @@ export const ots = {
             !value.startsWith('`') &&
             !value.endsWith('`')
         ) {
-            value = `\`${value}\``;
+            value = `\`${value.replace(/`/g, '\\`')}\``;
         }
         const text = encodeURIComponent(value);
         if (value.startsWith('`')) {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/schemas.ts.snap
@@ -11,6 +11,11 @@ export const $CommentWithBackticks = {
     type: 'integer',
 } as const;
 
+export const $CommentWithBackticksAndQuotes = {
+    description: `Testing backticks and quotes in string: \`backticks\`, 'quotes', "double quotes" and \`\`\`multiple backticks\`\`\` should work`,
+    type: 'integer',
+} as const;
+
 export const $CommentWithSlashes = {
     description: 'Testing slashes in string: \backwards\\ and /forwards/// should work',
     type: 'integer',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/schemas.ts.snap
@@ -11,6 +11,11 @@ export const $CommentWithBackticks = {
     type: 'integer',
 } as const;
 
+export const $CommentWithBackticksAndQuotes = {
+    description: `Testing backticks and quotes in string: \`backticks\`, 'quotes', "double quotes" and \`\`\`multiple backticks\`\`\` should work`,
+    type: 'integer',
+} as const;
+
 export const $CommentWithSlashes = {
     description: 'Testing slashes in string: \backwards\\ and /forwards/// should work',
     type: 'integer',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/schemas.ts.snap
@@ -11,6 +11,11 @@ export const $CommentWithBackticks = {
     type: 'integer',
 } as const;
 
+export const $CommentWithBackticksAndQuotes = {
+    description: `Testing backticks and quotes in string: \`backticks\`, 'quotes', "double quotes" and \`\`\`multiple backticks\`\`\` should work`,
+    type: 'integer',
+} as const;
+
 export const $CommentWithSlashes = {
     description: 'Testing slashes in string: \backwards\\ and /forwards/// should work',
     type: 'integer',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_date/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_date/schemas.ts.snap
@@ -11,6 +11,11 @@ export const $CommentWithBackticks = {
     type: 'integer',
 } as const;
 
+export const $CommentWithBackticksAndQuotes = {
+    description: `Testing backticks and quotes in string: \`backticks\`, 'quotes', "double quotes" and \`\`\`multiple backticks\`\`\` should work`,
+    type: 'integer',
+} as const;
+
 export const $CommentWithSlashes = {
     description: 'Testing slashes in string: \backwards\\ and /forwards/// should work',
     type: 'integer',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/schemas.ts.snap
@@ -11,6 +11,11 @@ export const $CommentWithBackticks = {
     type: 'integer',
 } as const;
 
+export const $CommentWithBackticksAndQuotes = {
+    description: `Testing backticks and quotes in string: \`backticks\`, 'quotes', "double quotes" and \`\`\`multiple backticks\`\`\` should work`,
+    type: 'integer',
+} as const;
+
 export const $CommentWithSlashes = {
     description: 'Testing slashes in string: \backwards\\ and /forwards/// should work',
     type: 'integer',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_experimental/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_experimental/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_experimental/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_experimental/schemas.ts.snap
@@ -11,6 +11,11 @@ export const $CommentWithBackticks = {
     type: 'integer',
 } as const;
 
+export const $CommentWithBackticksAndQuotes = {
+    description: `Testing backticks and quotes in string: \`backticks\`, 'quotes', "double quotes" and \`\`\`multiple backticks\`\`\` should work`,
+    type: 'integer',
+} as const;
+
 export const $CommentWithSlashes = {
     description: 'Testing slashes in string: \backwards\\ and /forwards/// should work',
     type: 'integer',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/models.ts.snap
@@ -12,6 +12,11 @@ export type CommentWithBreaks = number;
 export type CommentWithBackticks = number;
 
 /**
+ * Testing backticks and quotes in string: `backticks`, 'quotes', "double quotes" and ```multiple backticks``` should work
+ */
+export type CommentWithBackticksAndQuotes = number;
+
+/**
  * Testing slashes in string: \backwards\\\ and /forwards/// should work
  */
 export type CommentWithSlashes = number;

--- a/packages/openapi-ts/test/spec/v2.json
+++ b/packages/openapi-ts/test/spec/v2.json
@@ -967,6 +967,10 @@
             "description": "Testing backticks in string: `backticks` and ```multiple backticks``` should work",
             "type": "integer"
         },
+        "CommentWithBackticksAndQuotes": {
+            "description": "Testing backticks and quotes in string: `backticks`, 'quotes', \"double quotes\" and ```multiple backticks``` should work",
+            "type": "integer"
+        },
         "CommentWithSlashes": {
             "description": "Testing slashes in string: \\backwards\\\\\\ and /forwards/// should work",
             "type": "integer"

--- a/packages/openapi-ts/test/spec/v3.json
+++ b/packages/openapi-ts/test/spec/v3.json
@@ -1733,6 +1733,10 @@
                 "description": "Testing backticks in string: `backticks` and ```multiple backticks``` should work",
                 "type": "integer"
             },
+            "CommentWithBackticksAndQuotes": {
+                "description": "Testing backticks and quotes in string: `backticks`, 'quotes', \"double quotes\" and ```multiple backticks``` should work",
+                "type": "integer"
+            },
             "CommentWithSlashes": {
                 "description": "Testing slashes in string: \\backwards\\\\\\ and /forwards/// should work",
                 "type": "integer"


### PR DESCRIPTION
Fixes #309.

The code made an assumption that if single/double quotes are used it can safely add backticks instead. This turned out to be not true for descriptions that used both.

This change makes quick work of it by just escaping all backticks in this particular conditional branch.