### PR TITLE
replace dashes in schema names

### DIFF
--- a/packages/openapi-ts/src/utils/write/schemas.ts
+++ b/packages/openapi-ts/src/utils/write/schemas.ts
@@ -12,6 +12,8 @@ export const writeClientSchemas = async (openApi: OpenApi, outputPath: string): 
     const file = new TypeScriptFile();
 
     const addSchema = (name: string, obj: any) => {
+        // openapi might add dashes to schema names, which breaks the whole TS file
+        name = name.replace(/-/g, '_');
         const expression = compiler.types.object(obj);
         const statement = compiler.export.asConst(name, expression);
         file.add(statement);


### PR DESCRIPTION
For a reason I did not identify deeper, OpenAPI sometimes includes dashes (`-`) in schema names. This happened for me when using FastAPI Swagger docs as input.

As the schema name from the spec is used as a function/variable expression in the generated `schemas.ts` file and dashes are not allowed as identifiers, this breaks the whole file. 

This is a simple fix for me, but it might make sense to sanitise this to a set of allowed identifier characters in TS/JS.