### PR TITLE
fix: run prettier check with lint

### DIFF
--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -47,7 +47,7 @@
         "dev": "rimraf dist && pnpm build-bundle --watch",
         "format": "prettier --write .",
         "lint:fix": "prettier --check . && eslint . --fix",
-        "lint": "eslint .",
+        "lint": "prettier --check . && eslint .",
         "prepublishOnly": "pnpm build",
         "test:coverage": "vitest run --config vitest.config.unit.ts --coverage",
         "test:e2e": "vitest run --config vitest.config.e2e.ts",

--- a/packages/openapi-ts/src/utils/write/type.ts
+++ b/packages/openapi-ts/src/utils/write/type.ts
@@ -30,7 +30,7 @@ const typeArray = (model: Model) => {
         model.maxItems === model.minItems &&
         model.maxItems <= 100
     ) {
-        const types = toType(model.link)
+        const types = toType(model.link);
         const tuple = compiler.typedef.tuple(Array(model.maxItems).fill(types), model.isNullable);
         return tuple;
     }


### PR DESCRIPTION
Run `prettier --check` when linting to ensure CI catches any formatting issues