### PR TITLE
chore: compiler type generation cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ coverage
 # test files
 test/generated
 test/e2e/generated
+
+# error files
+openapi-ts-error-*

--- a/packages/openapi-ts/src/compiler/index.ts
+++ b/packages/openapi-ts/src/compiler/index.ts
@@ -9,7 +9,7 @@ import { addLeadingComment, tsNodeToString } from './utils';
 
 export type { Property } from './typedef';
 export type { Comments } from './utils';
-export type { Node } from 'typescript';
+export type { Node, TypeNode } from 'typescript';
 
 export class TypeScriptFile {
     private _headers: Array<string> = [];
@@ -74,5 +74,8 @@ export const compiler = {
         array: types.createArrayType,
         enum: types.createEnumDeclaration,
         object: types.createObjectType,
+    },
+    utils: {
+        toString: tsNodeToString,
     },
 };

--- a/packages/openapi-ts/src/utils/write/models.ts
+++ b/packages/openapi-ts/src/utils/write/models.ts
@@ -60,8 +60,7 @@ const processType = (client: Client, model: Model) => {
         model.description && escapeComment(model.description),
         model.deprecated && '@deprecated',
     ];
-    const type = toType(model);
-    return compiler.typedef.alias(model.name, type!, comment);
+    return compiler.typedef.alias(model.name, toType(model), comment);
 };
 
 const processModel = (client: Client, model: Model) => {
@@ -120,7 +119,7 @@ const processServiceTypes = (services: Service[]) => {
                     }
 
                     operation.results.forEach(result => {
-                        resMap.set(result.code, toType(result)!);
+                        resMap.set(result.code, compiler.utils.toString(toType(result)));
                     });
                 }
             }
@@ -235,7 +234,7 @@ const processServiceTypes = (services: Service[]) => {
         type: '',
     });
     const namespace = serviceExportedNamespace();
-    return compiler.typedef.alias(namespace, type!);
+    return compiler.typedef.alias(namespace, type);
 };
 
 /**


### PR DESCRIPTION
- Make `tsNodeToString` a compiler util
- gitignore generated error files
- make all typedef functions allow passing ts.TypeNode directly
- convert `toType` to be *almost* purely compiler api (all functions now return ts.TypeNode but inside of some functions we still do some toString)