### PR TITLE
fix: inconsistent indentation in models file when not using `format: true`

### DIFF
--- a/.changeset/khaki-roses-smell.md
+++ b/.changeset/khaki-roses-smell.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: inconsistent indentation in models file when not using `format: true`

--- a/packages/openapi-ts/src/utils/write/models.ts
+++ b/packages/openapi-ts/src/utils/write/models.ts
@@ -151,15 +151,12 @@ const processServiceTypes = (services: Service[]) => {
                 const reqResParameters = Array.isArray(baseOrResMap)
                     ? baseOrResMap
                     : Array.from(baseOrResMap).map(([code, base]) => {
+                          // TODO: move query params into separate query key
                           const value: Model = {
                               ...emptyModel,
                               ...base,
-                              base: compiler.utils.toString(toType(base)),
-                              export: 'reference',
                               isRequired: true,
                               name: String(code),
-                              // TODO: move query params into separate query key
-                              properties: [],
                           };
                           return value;
                       });

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/models.ts.snap
@@ -614,6 +614,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -621,7 +624,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: any;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -629,18 +638,33 @@ export type $OpenApiTs = {
     '/api/v{api-version}/response': {
         get: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -648,6 +672,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -655,6 +682,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -722,9 +752,21 @@ export type $OpenApiTs = {
                 parameterString: string;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: unknown;
             };
         };
@@ -748,6 +790,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -755,6 +800,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -768,6 +816,9 @@ export type $OpenApiTs = {
                 status: string;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -781,6 +832,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: NonAsciiStringæøåÆØÅöôêÊ字符串;
             };
         };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/models.ts.snap
@@ -868,6 +868,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/simple/$count': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 200: Model_From_Zendesk;
             };
         };
@@ -1147,6 +1150,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1154,7 +1160,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1167,13 +1179,25 @@ export type $OpenApiTs = {
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -1181,6 +1205,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1188,6 +1215,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1255,9 +1285,21 @@ export type $OpenApiTs = {
                 parameterString: string | null;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: Record<string, unknown>;
             };
         };
@@ -1281,6 +1323,9 @@ export type $OpenApiTs = {
                 id: string;
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: Blob | File;
             };
         };
@@ -1304,6 +1349,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -1327,6 +1375,9 @@ export type $OpenApiTs = {
                 };
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: ModelWithString;
             };
         };
@@ -1342,6 +1393,9 @@ export type $OpenApiTs = {
         };
         get: {
             res: {
+                /**
+                 * OK
+                 */
                 200: {
                     file?: Blob | File;
                     metadata?: {
@@ -1355,6 +1409,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -1368,6 +1425,9 @@ export type $OpenApiTs = {
                 status: number;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -1381,6 +1441,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<NonAsciiStringæøåÆØÅöôêÊ字符串>;
             };
         };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/models.ts.snap
@@ -759,6 +759,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/simple/$count': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 200: Model_From_Zendesk;
             };
         };
@@ -1038,6 +1041,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1045,7 +1051,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1058,13 +1070,25 @@ export type $OpenApiTs = {
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -1072,6 +1096,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1079,6 +1106,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1146,9 +1176,21 @@ export type $OpenApiTs = {
                 parameterString: string | null;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: Record<string, unknown>;
             };
         };
@@ -1172,6 +1214,9 @@ export type $OpenApiTs = {
                 id: string;
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: Blob | File;
             };
         };
@@ -1195,6 +1240,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -1218,6 +1266,9 @@ export type $OpenApiTs = {
                 };
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: ModelWithString;
             };
         };
@@ -1233,6 +1284,9 @@ export type $OpenApiTs = {
         };
         get: {
             res: {
+                /**
+                 * OK
+                 */
                 200: {
                     file?: Blob | File;
                     metadata?: {
@@ -1246,6 +1300,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -1259,6 +1316,9 @@ export type $OpenApiTs = {
                 status: number;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -1272,6 +1332,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<NonAsciiStringæøåÆØÅöôêÊ字符串>;
             };
         };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/models.ts.snap
@@ -868,6 +868,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/simple/$count': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 200: Model_From_Zendesk;
             };
         };
@@ -1147,6 +1150,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1154,7 +1160,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1167,13 +1179,25 @@ export type $OpenApiTs = {
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -1181,6 +1205,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1188,6 +1215,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1255,9 +1285,21 @@ export type $OpenApiTs = {
                 parameterString: string | null;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: Record<string, unknown>;
             };
         };
@@ -1281,6 +1323,9 @@ export type $OpenApiTs = {
                 id: string;
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: Blob | File;
             };
         };
@@ -1304,6 +1349,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -1327,6 +1375,9 @@ export type $OpenApiTs = {
                 };
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: ModelWithString;
             };
         };
@@ -1342,6 +1393,9 @@ export type $OpenApiTs = {
         };
         get: {
             res: {
+                /**
+                 * OK
+                 */
                 200: {
                     file?: Blob | File;
                     metadata?: {
@@ -1355,6 +1409,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -1368,6 +1425,9 @@ export type $OpenApiTs = {
                 status: number;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -1381,6 +1441,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<NonAsciiStringæøåÆØÅöôêÊ字符串>;
             };
         };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_date/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_date/models.ts.snap
@@ -29,6 +29,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/simple/$count': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 200: Model_From_Zendesk;
             };
         };
@@ -308,6 +311,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -315,7 +321,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -328,13 +340,25 @@ export type $OpenApiTs = {
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -342,6 +366,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -349,6 +376,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -416,9 +446,21 @@ export type $OpenApiTs = {
                 parameterString: string | null;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: Record<string, unknown>;
             };
         };
@@ -442,6 +484,9 @@ export type $OpenApiTs = {
                 id: string;
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: Blob | File;
             };
         };
@@ -465,6 +510,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -488,6 +536,9 @@ export type $OpenApiTs = {
                 };
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: ModelWithString;
             };
         };
@@ -503,6 +554,9 @@ export type $OpenApiTs = {
         };
         get: {
             res: {
+                /**
+                 * OK
+                 */
                 200: {
                     file?: Blob | File;
                     metadata?: {
@@ -516,6 +570,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -529,6 +586,9 @@ export type $OpenApiTs = {
                 status: number;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -542,6 +602,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<NonAsciiStringæøåÆØÅöôêÊ字符串>;
             };
         };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/models.ts.snap
@@ -808,6 +808,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/simple/$count': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 200: Model_From_Zendesk;
             };
         };
@@ -1087,6 +1090,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1094,7 +1100,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1107,13 +1119,25 @@ export type $OpenApiTs = {
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -1121,6 +1145,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1128,6 +1155,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1195,9 +1225,21 @@ export type $OpenApiTs = {
                 parameterString: string | null;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: Record<string, unknown>;
             };
         };
@@ -1221,6 +1263,9 @@ export type $OpenApiTs = {
                 id: string;
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: Blob | File;
             };
         };
@@ -1244,6 +1289,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -1267,6 +1315,9 @@ export type $OpenApiTs = {
                 };
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: ModelWithString;
             };
         };
@@ -1282,6 +1333,9 @@ export type $OpenApiTs = {
         };
         get: {
             res: {
+                /**
+                 * OK
+                 */
                 200: {
                     file?: Blob | File;
                     metadata?: {
@@ -1295,6 +1349,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -1308,6 +1365,9 @@ export type $OpenApiTs = {
                 status: number;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -1321,6 +1381,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<NonAsciiStringæøåÆØÅöôêÊ字符串>;
             };
         };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/models.ts.snap
@@ -759,6 +759,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/simple/$count': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 200: Model_From_Zendesk;
             };
         };
@@ -1038,6 +1041,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/no-content': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1045,7 +1051,13 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/response-and-no-content': {
         get: {
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1058,13 +1070,25 @@ export type $OpenApiTs = {
         };
         post: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
             };
         };
         put: {
             res: {
+                /**
+                 * Message for default response
+                 */
                 200: ModelWithString;
+                /**
+                 * Message for 201 response
+                 */
                 201: ModelThatExtends;
+                /**
+                 * Message for 202 response
+                 */
                 202: ModelThatExtendsExtends;
             };
         };
@@ -1072,6 +1096,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/a': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1079,6 +1106,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/multiple-tags/b': {
         get: {
             res: {
+                /**
+                 * Success
+                 */
                 204: void;
             };
         };
@@ -1146,9 +1176,21 @@ export type $OpenApiTs = {
                 parameterString: string | null;
             };
             res: {
+                /**
+                 * Response is a simple number
+                 */
                 200: number;
+                /**
+                 * Response is a simple string
+                 */
                 201: string;
+                /**
+                 * Response is a simple boolean
+                 */
                 202: boolean;
+                /**
+                 * Response is a simple object
+                 */
                 203: Record<string, unknown>;
             };
         };
@@ -1172,6 +1214,9 @@ export type $OpenApiTs = {
                 id: string;
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: Blob | File;
             };
         };
@@ -1195,6 +1240,9 @@ export type $OpenApiTs = {
                 parameterReference: ModelWithString;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<ModelWithString>;
             };
         };
@@ -1218,6 +1266,9 @@ export type $OpenApiTs = {
                 };
             };
             res: {
+                /**
+                 * Success
+                 */
                 200: ModelWithString;
             };
         };
@@ -1233,6 +1284,9 @@ export type $OpenApiTs = {
         };
         get: {
             res: {
+                /**
+                 * OK
+                 */
                 200: {
                     file?: Blob | File;
                     metadata?: {
@@ -1246,6 +1300,9 @@ export type $OpenApiTs = {
     '/api/v{api-version}/header': {
         post: {
             res: {
+                /**
+                 * Successful response
+                 */
                 200: string;
             };
         };
@@ -1259,6 +1316,9 @@ export type $OpenApiTs = {
                 status: number;
             };
             res: {
+                /**
+                 * Custom message: Successful response
+                 */
                 200: any;
             };
         };
@@ -1272,6 +1332,9 @@ export type $OpenApiTs = {
                 nonAsciiParamæøåÆøÅöôêÊ: number;
             };
             res: {
+                /**
+                 * Successful response
+                 */
                 200: Array<NonAsciiStringæøåÆØÅöôêÊ字符串>;
             };
         };


### PR DESCRIPTION
closes: #321 

And the added benefit of additional spec comments making it through.