### PR TITLE
fix: handle decoding models with `%` in description

### DIFF
--- a/.changeset/thick-lemons-yell.md
+++ b/.changeset/thick-lemons-yell.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: handle decoding models with `%` in description

--- a/packages/openapi-ts/src/compiler/utils.ts
+++ b/packages/openapi-ts/src/compiler/utils.ts
@@ -114,7 +114,7 @@ export const addLeadingComment = (
     ts.addSyntheticLeadingComment(
         node,
         ts.SyntaxKind.MultiLineCommentTrivia,
-        ['*', ...comments.map(row => ` * ${row}`), ' '].join('\n'),
+        encodeURIComponent(['*', ...comments.map(row => ` * ${row}`), ' '].join('\n')),
         hasTrailingNewLine
     );
     return '';

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/models.ts.snap
@@ -679,6 +679,11 @@ export type NullableObject = {
     foo?: string;
 } | null;
 
+/**
+ * Some % character
+ */
+export type CharactersInDescription = string;
+
 export type ModelWithNullableObject = {
     data?: NullableObject;
 };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/schemas.ts.snap
@@ -1383,6 +1383,11 @@ export const $NullableObject = {
     default: null,
 } as const;
 
+export const $CharactersInDescription = {
+    type: 'string',
+    description: 'Some % character',
+} as const;
+
 export const $ModelWithNullableObject = {
     type: 'object',
     properties: {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/models.ts.snap
@@ -679,6 +679,11 @@ export type NullableObject = {
     foo?: string;
 } | null;
 
+/**
+ * Some % character
+ */
+export type CharactersInDescription = string;
+
 export type ModelWithNullableObject = {
     data?: NullableObject;
 };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/schemas.ts.snap
@@ -1383,6 +1383,11 @@ export const $NullableObject = {
     default: null,
 } as const;
 
+export const $CharactersInDescription = {
+    type: 'string',
+    description: 'Some % character',
+} as const;
+
 export const $ModelWithNullableObject = {
     type: 'object',
     properties: {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/models.ts.snap
@@ -679,6 +679,11 @@ export type NullableObject = {
     foo?: string;
 } | null;
 
+/**
+ * Some % character
+ */
+export type CharactersInDescription = string;
+
 export type ModelWithNullableObject = {
     data?: NullableObject;
 };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_date/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_date/schemas.ts.snap
@@ -1383,6 +1383,11 @@ export const $NullableObject = {
     default: null,
 } as const;
 
+export const $CharactersInDescription = {
+    type: 'string',
+    description: 'Some % character',
+} as const;
+
 export const $ModelWithNullableObject = {
     type: 'object',
     properties: {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/models.ts.snap
@@ -679,6 +679,11 @@ export type NullableObject = {
     foo?: string;
 } | null;
 
+/**
+ * Some % character
+ */
+export type CharactersInDescription = string;
+
 export type ModelWithNullableObject = {
     data?: NullableObject;
 };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/schemas.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/schemas.ts.snap
@@ -1383,6 +1383,11 @@ export const $NullableObject = {
     default: null,
 } as const;
 
+export const $CharactersInDescription = {
+    type: 'string',
+    description: 'Some % character',
+} as const;
+
 export const $ModelWithNullableObject = {
     type: 'object',
     properties: {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/models.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/models.ts.snap
@@ -679,6 +679,11 @@ export type NullableObject = {
     foo?: string;
 } | null;
 
+/**
+ * Some % character
+ */
+export type CharactersInDescription = string;
+
 export type ModelWithNullableObject = {
     data?: NullableObject;
 };

--- a/packages/openapi-ts/test/spec/v3.json
+++ b/packages/openapi-ts/test/spec/v3.json
@@ -2920,6 +2920,10 @@
                 },
                 "default": null
             },
+            "CharactersInDescription": {
+                "type": "string",
+                "description": "Some % character"
+            },
             "ModelWithNullableObject": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
closes: #293 