### PR TITLE
docs: small wording and organization changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
     <p align="center">✨ Turn your OpenAPI specification into a beautiful TypeScript client.</p>
 </div>
 
-## GitHub Integration (coming soon)
-
-Automatically update your code when the APIs it depends on change. [Find out more](https://heyapi.vercel.app/openapi-ts/integrations.html).
-
-## Migrating from OpenAPI Typescript Codegen?
-
-Please read our [migration guide](https://heyapi.vercel.app/openapi-ts/migrating.html#openapi-typescript-codegen).
+> [!IMPORTANT]
+> Migrating from [openapi-typescript-codegen](https://github.com/ferdikoomen/openapi-typescript-codegen)?
+>
+> Please read our [migration guide](https://heyapi.vercel.app/openapi-ts/migrating.html#openapi-typescript-codegen).
 
 ## Documentation
 
 Please visit our [website](https://heyapi.vercel.app/) for documentation, guides, migrating, and more.
 
+## GitHub Integration (coming soon)
+
+Automatically update your code when the APIs it depends on change. [Find out more](https://heyapi.vercel.app/openapi-ts/integrations.html).
+
 ## Contributing
 
-Want to get involved? Please refer to the [contributing guide](https://heyapi.vercel.app/contributing.html).
+Want to get involved? Please refer to [`docs/contributing.md`](./docs/contributing.md).

--- a/docs/openapi-ts/get-started.md
+++ b/docs/openapi-ts/get-started.md
@@ -5,15 +5,15 @@ description: Get started with @hey-api/openapi-ts.
 
 # Get Started
 
-`openapi-ts` allows you to create TypeScript interfaces, REST clients, and JSON Schemas from an OpenAPI specification.
+`openapi-ts` allows you to generate TypeScript interfaces, REST clients, and JSON Schemas from an OpenAPI specification.
 
 ## Features
 
 - use with CLI, Node.js, or npx
 - export TypeScript interfaces from OpenAPI v2.0, v3.0, and v3.1 specifications
+- create fetch, axios, angular, node.js, or xhr REST clients
 - support JSON or YAML input files
 - support external references using [json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser/)
-- create fetch, axios, angular, node.js, or xhr REST clients
 - export JSON Schemas from OpenAPI specifications
 - abortable requests through cancellable promise pattern
 
@@ -30,18 +30,23 @@ Congratulations on creating your first client! 🎉
 ## Installation
 
 ::: code-group
+
 ```sh [npm]
 npm install @hey-api/openapi-ts --save-dev
 ```
+
 ```sh [pnpm]
 pnpm add @hey-api/openapi-ts -D
 ```
+
 ```sh [yarn]
 yarn add @hey-api/openapi-ts -D
 ```
+
 ```sh [bun]
 bun add @hey-api/openapi-ts -D
 ```
+
 :::
 
 If you want to use `openapi-ts` with CLI, add a script to your `package.json` file
@@ -55,12 +60,12 @@ If you want to use `openapi-ts` with CLI, add a script to your `package.json` fi
 You can also generate your client programmatically by importing `openapi-ts` in a `.ts` file.
 
 ```ts
-import { createClient } from '@hey-api/openapi-ts'
+import { createClient } from '@hey-api/openapi-ts';
 
 createClient({
   input: 'path/to/openapi.json',
   output: 'src/client',
-})
+});
 ```
 
 ::: warning

--- a/packages/openapi-ts/README.md
+++ b/packages/openapi-ts/README.md
@@ -4,7 +4,7 @@
   <p align="center">✨ Turn your OpenAPI specification into a beautiful TypeScript client.</p>
 </div>
 
-`openapi-ts` allows you to create TypeScript interfaces, REST clients, and JSON Schemas from an OpenAPI specification.
+`openapi-ts` allows you to generate TypeScript interfaces, REST clients, and JSON Schemas from an OpenAPI specification.
 
 ## Features
 
@@ -16,17 +16,17 @@
 -   export JSON Schemas from OpenAPI specifications
 -   abortable requests through cancellable promise pattern
 
+## Documentation
+
+Please visit our [website](https://heyapi.vercel.app/) for documentation, guides, migrating, and more.
+
 ## GitHub Integration (coming soon)
 
 Automatically update your code when the APIs it depends on change. [Find out more](https://heyapi.vercel.app/openapi-ts/integrations.html).
 
-## Migrating from OpenAPI Typescript Codegen?
+## Migrating from [openapi-typescript-codegen](https://github.com/ferdikoomen/openapi-typescript-codegen)?
 
 Please read our [migration guide](https://heyapi.vercel.app/openapi-ts/migrating.html#openapi-typescript-codegen).
-
-## Documentation
-
-Please visit our [website](https://heyapi.vercel.app/) for documentation, guides, migrating, and more.
 
 ## Contributing
 


### PR DESCRIPTION
- Wording: "create" -> "generate". Helps to clarify this is *codegen*, not runtime introspection or anything like that.
- Link to github contributing.md rather than website contributing.md from the github readme to let the reader stay in github
- Use the quote "IMPORTANT" syntax for migration callout