### PR TITLE
fix: revert to generating commonjs for esm and commonjs support

### DIFF
--- a/.changeset/thick-fishes-search.md
+++ b/.changeset/thick-fishes-search.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: revert to generating commonjs for esm and commonjs support

--- a/packages/openapi-ts/bin/index.cjs
+++ b/packages/openapi-ts/bin/index.cjs
@@ -2,13 +2,11 @@
 
 'use strict';
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
+const { writeFileSync } = require('fs');
+const { resolve } = require('path');
 
-import camelCase from 'camelcase';
-import { program } from 'commander';
-
-const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)).toString());
+const { program } = require('commander');
+const pkg = require('../package.json');
 
 const params = program
     .name(Object.keys(pkg.bin)[0])
@@ -53,7 +51,7 @@ const processParams = (obj, booleanKeys) => {
         if (typeof value === 'string') {
             const parsedValue = stringToBoolean(value);
             delete obj[key];
-            obj[camelCase(key)] = parsedValue;
+            obj[key] = parsedValue;
         }
     }
     return obj;
@@ -62,7 +60,7 @@ const processParams = (obj, booleanKeys) => {
 async function start() {
     let userConfig;
     try {
-        const { createClient } = await import(new URL('../dist/node/index.js', import.meta.url));
+        const { createClient } = require(resolve(__dirname, '../dist/node/index.cjs'));
         userConfig = processParams(params, [
             'dryRun',
             'exportCore',
@@ -80,7 +78,7 @@ async function start() {
     } catch (error) {
         if (!userConfig.dryRun) {
             const logName = `openapi-ts-error-${Date.now()}.log`;
-            const logPath = path.resolve(process.cwd(), logName);
+            const logPath = resolve(process.cwd(), logName);
             writeFileSync(logPath, `${error.message}\n${error.stack}`);
             console.error(`🔥 Unexpected error occurred. Log saved to ${logPath}`);
         }

--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -27,10 +27,10 @@
         "angular",
         "node"
     ],
-    "main": "./dist/node/index.js",
+    "main": "./dist/node/index.cjs",
     "types": "./dist/node/index.d.ts",
     "bin": {
-        "openapi-ts": "bin/index.js"
+        "openapi-ts": "bin/index.cjs"
     },
     "files": [
         "bin",

--- a/packages/openapi-ts/rollup.config.ts
+++ b/packages/openapi-ts/rollup.config.ts
@@ -52,13 +52,20 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url)).toString());
 
+// ESM only dependencies are not treated as external so that we can fully support CommonJS and ESM
+const esmDependencies = ['camelcase'];
+
+export const externalDependencies = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)].filter(
+    dependency => !esmDependencies.includes(dependency)
+);
+
 function createConfig(isProduction: boolean) {
     return defineConfig({
-        external: [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)],
+        external: externalDependencies,
         input: path.resolve(__dirname, 'src/node/index.ts'),
         output: {
-            file: path.resolve(__dirname, 'dist/node/index.js'),
-            format: 'esm',
+            file: path.resolve(__dirname, 'dist/node/index.cjs'),
+            format: 'cjs',
         },
         plugins: [
             nodeResolve({ preferBuiltins: true }),
@@ -67,7 +74,6 @@ function createConfig(isProduction: boolean) {
                 tsconfig: path.resolve(__dirname, 'src/node/tsconfig.json'),
             }),
             commonjs({
-                extensions: ['.js'],
                 sourceMap: false,
             }),
             json(),

--- a/packages/openapi-ts/rollup.dts.config.ts
+++ b/packages/openapi-ts/rollup.dts.config.ts
@@ -1,20 +1,16 @@
-import { readFileSync } from 'node:fs';
-
 import { defineConfig } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
-const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url)).toString());
-
-const external = [/^node:*/, ...Object.keys(pkg.dependencies), ...Object.keys(pkg.devDependencies)];
+import { externalDependencies } from './rollup.config';
 
 export default defineConfig({
-    external,
+    external: externalDependencies,
     input: {
         index: './temp/node/index.d.ts',
     },
     output: {
         dir: './dist/node',
-        format: 'esm',
+        format: 'cjs',
     },
     plugins: [dts({ respectExternal: true })],
 });

--- a/packages/openapi-ts/test/bin.spec.ts
+++ b/packages/openapi-ts/test/bin.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 describe('bin', () => {
     it('supports required parameters', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -19,7 +19,7 @@ describe('bin', () => {
 
     it('generates angular client', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -35,7 +35,7 @@ describe('bin', () => {
 
     it('generates axios client', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -51,7 +51,7 @@ describe('bin', () => {
 
     it('generates fetch client', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -67,7 +67,7 @@ describe('bin', () => {
 
     it('generates node client', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -83,7 +83,7 @@ describe('bin', () => {
 
     it('generates xhr client', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -99,7 +99,7 @@ describe('bin', () => {
 
     it('supports all parameters', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -124,7 +124,7 @@ describe('bin', () => {
 
     it('supports regexp parameters', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -142,7 +142,7 @@ describe('bin', () => {
 
     it('formats output with Prettier', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -154,7 +154,7 @@ describe('bin', () => {
 
     it('lints output with ESLint', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -166,14 +166,14 @@ describe('bin', () => {
     });
 
     it('throws error without parameters', () => {
-        const result = sync('node', ['./bin/index.js', '--dry-run', 'true']);
+        const result = sync('node', ['./bin/index.cjs', '--dry-run', 'true']);
         expect(result.stdout.toString()).toBe('');
         expect(result.stderr.toString()).toContain('Unexpected error occurred');
     });
 
     it('throws error with wrong parameters', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -187,7 +187,7 @@ describe('bin', () => {
     });
 
     it('displays help', () => {
-        const result = sync('node', ['./bin/index.js', '--help', '--dry-run', 'true']);
+        const result = sync('node', ['./bin/index.cjs', '--help', '--dry-run', 'true']);
         expect(result.stdout.toString()).toContain(`Usage: openapi-ts [options]`);
         expect(result.stdout.toString()).toContain(`-i, --input <value>`);
         expect(result.stdout.toString()).toContain(`-o, --output <value>`);
@@ -198,7 +198,7 @@ describe('bin', () => {
 describe('cli', () => {
     it('handles false booleans', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -240,7 +240,7 @@ describe('cli', () => {
 
     it('handles true booleans', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',
@@ -282,7 +282,7 @@ describe('cli', () => {
 
     it('handles optional booleans', () => {
         const result = sync('node', [
-            './bin/index.js',
+            './bin/index.cjs',
             '--input',
             './test/spec/v3.json',
             '--output',


### PR DESCRIPTION
closes: #405 

This is how the original package had its rollup config