### PR TITLE
feat: automatically handle dates in query string

### DIFF
--- a/.changeset/fifty-lamps-collect.md
+++ b/.changeset/fifty-lamps-collect.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+feat: automatically handle dates in query string

--- a/packages/openapi-ts/src/templates/core/functions/getQueryString.hbs
+++ b/packages/openapi-ts/src/templates/core/functions/getQueryString.hbs
@@ -11,8 +11,8 @@ export const getQueryString = (params: Record<string, unknown>): string => {
 		}
 
 		if (value instanceof Date) {
-      append(key, value.toISOString());
-    } else if (Array.isArray(value)) {
+			append(key, value.toISOString());
+		} else if (Array.isArray(value)) {
 			value.forEach(v => encodePair(key, v));
 		} else if (typeof value === 'object') {
 			Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/src/templates/core/functions/getQueryString.hbs
+++ b/packages/openapi-ts/src/templates/core/functions/getQueryString.hbs
@@ -10,7 +10,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
 			return;
 		}
 
-		if (Array.isArray(value)) {
+		if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
 			value.forEach(v => encodePair(key, v));
 		} else if (typeof value === 'object') {
 			Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/core/request.ts.snap
@@ -42,7 +42,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/core/request.ts.snap
@@ -42,7 +42,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/core/request.ts.snap
@@ -46,7 +46,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios/core/request.ts.snap
@@ -54,7 +54,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/core/request.ts.snap
@@ -42,7 +42,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/core/request.ts.snap
@@ -42,7 +42,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/core/request.ts.snap
@@ -42,7 +42,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_node/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_node/core/request.ts.snap
@@ -45,7 +45,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/core/request.ts.snap
@@ -42,7 +42,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr/core/request.ts.snap
@@ -46,7 +46,9 @@ export const getQueryString = (params: Record<string, unknown>): string => {
       return;
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
       value.forEach((v) => encodePair(key, v));
     } else if (typeof value === 'object') {
       Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));


### PR DESCRIPTION
When a date is passed to the query string, especially when using the _useDateType_ option, it silently fails to convert the date. 
Since the URL and query is not passed to the interceptor, there is no opportunity to correct this. 

This change will automatically convert dates to an ISO date string which should be accepted by most platforms.