### PR TITLE
fix: do not destructure data when using use options

### DIFF
--- a/.changeset/chatty-brooms-obey.md
+++ b/.changeset/chatty-brooms-obey.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: do not destructure data when using use options

--- a/packages/openapi-ts/src/utils/write/services.ts
+++ b/packages/openapi-ts/src/utils/write/services.ts
@@ -102,11 +102,12 @@ const toOperationComment = (operation: Operation) => {
 };
 
 const toRequestOptions = (operation: Operation) => {
+  const config = getConfig();
   const toObj = (parameters: OperationParameter[]) =>
     parameters.reduce(
       (prev, curr) => {
         const key = curr.prop;
-        const value = curr.name;
+        const value = config.useOptions ? `data.${curr.name}` : curr.name;
         if (key === value) {
           prev[key] = key;
         } else if (escapeName(key) === key) {
@@ -166,31 +167,9 @@ const toRequestOptions = (operation: Operation) => {
   });
 };
 
-export const toDestructuredData = (operation: Operation) => {
-  const config = getConfig();
-  if (!config.useOptions || !operation.parameters.length) {
-    return '';
-  }
-  const obj: Record<string, unknown> = {};
-  operation.parameters.forEach((p) => {
-    obj[p.name] = p.name;
-  });
-  const node = compiler.types.object({
-    identifiers: Object.keys(obj),
-    obj,
-    shorthand: true,
-  });
-  return `const ${compiler.utils.toString(node)} = data;`;
-};
-
 const toOperationStatements = (operation: Operation) => {
   const config = getConfig();
   const statements: any[] = [];
-  // If using options we destructor the parameter
-  if (config.useOptions && operation.parameters.length) {
-    statements.push(compiler.utils.toNode(toDestructuredData(operation)));
-  }
-
   const requestOptions = compiler.utils.toString(toRequestOptions(operation));
   if (config.name) {
     statements.push(

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/services.gen.ts.snap
@@ -106,24 +106,17 @@ export class DescriptionsService {
   public static callWithDescriptions(
     data: $OpenApiTs['/api/v{api-version}/descriptions/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterWithBreaks,
-      parameterWithBackticks,
-      parameterWithSlashes,
-      parameterWithExpressionPlaceholders,
-      parameterWithQuotes,
-      parameterWithReservedCharacters,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/descriptions/',
       query: {
-        parameterWithBreaks,
-        parameterWithBackticks,
-        parameterWithSlashes,
-        parameterWithExpressionPlaceholders,
-        parameterWithQuotes,
-        parameterWithReservedCharacters,
+        parameterWithBreaks: data.parameterWithBreaks,
+        parameterWithBackticks: data.parameterWithBackticks,
+        parameterWithSlashes: data.parameterWithSlashes,
+        parameterWithExpressionPlaceholders:
+          data.parameterWithExpressionPlaceholders,
+        parameterWithQuotes: data.parameterWithQuotes,
+        parameterWithReservedCharacters: data.parameterWithReservedCharacters,
       },
     });
   }
@@ -142,27 +135,20 @@ export class ParametersService {
   public static callWithParameters(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameterPath}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterBody,
-      parameterPath,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameterPath}',
       path: {
-        parameterPath,
+        parameterPath: data.parameterPath,
       },
       headers: {
-        parameterHeader,
+        parameterHeader: data.parameterHeader,
       },
       query: {
-        parameterQuery,
+        parameterQuery: data.parameterQuery,
       },
       formData: {
-        parameterForm,
+        parameterForm: data.parameterForm,
       },
       body: parameterBody,
     });
@@ -183,33 +169,23 @@ export class ParametersService {
   public static callWithWeirdParameterNames(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterBody,
-      parameterPath1,
-      parameterPath2,
-      parameterPath3,
-      _default,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
       path: {
-        'parameter.path.1': parameterPath1,
-        'parameter-path-2': parameterPath2,
-        'PARAMETER-PATH-3': parameterPath3,
+        'parameter.path.1': data.parameterPath1,
+        'parameter-path-2': data.parameterPath2,
+        'PARAMETER-PATH-3': data.parameterPath3,
       },
       headers: {
-        'parameter.header': parameterHeader,
+        'parameter.header': data.parameterHeader,
       },
       query: {
-        default: _default,
-        'parameter-query': parameterQuery,
+        default: data._default,
+        'parameter-query': data.parameterQuery,
       },
       formData: {
-        parameter_form: parameterForm,
+        parameter_form: data.parameterForm,
       },
       body: parameterBody,
     });
@@ -229,22 +205,15 @@ export class DefaultsService {
   public static callWithDefaultParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['get']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -261,22 +230,15 @@ export class DefaultsService {
   public static callWithDefaultOptionalParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -296,28 +258,23 @@ export class DefaultsService {
   public static callToTestOrderOfParams(
     data: $OpenApiTs['/api/v{api-version}/defaults']['put']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterStringWithNoDefault,
-      parameterOptionalStringWithDefault,
-      parameterOptionalStringWithEmptyDefault,
-      parameterOptionalStringWithNoDefault,
-      parameterStringWithDefault,
-      parameterStringWithEmptyDefault,
-      parameterStringNullableWithNoDefault,
-      parameterStringNullableWithDefault,
-    } = data;
     return __request(OpenAPI, {
       method: 'PUT',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterOptionalStringWithDefault,
-        parameterOptionalStringWithEmptyDefault,
-        parameterOptionalStringWithNoDefault,
-        parameterStringWithDefault,
-        parameterStringWithEmptyDefault,
-        parameterStringWithNoDefault,
-        parameterStringNullableWithNoDefault,
-        parameterStringNullableWithDefault,
+        parameterOptionalStringWithDefault:
+          data.parameterOptionalStringWithDefault,
+        parameterOptionalStringWithEmptyDefault:
+          data.parameterOptionalStringWithEmptyDefault,
+        parameterOptionalStringWithNoDefault:
+          data.parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault: data.parameterStringWithDefault,
+        parameterStringWithEmptyDefault: data.parameterStringWithEmptyDefault,
+        parameterStringWithNoDefault: data.parameterStringWithNoDefault,
+        parameterStringNullableWithNoDefault:
+          data.parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault:
+          data.parameterStringNullableWithDefault,
       },
     });
   }
@@ -551,22 +508,15 @@ export class CollectionFormatService {
   public static collectionFormat(
     data: $OpenApiTs['/api/v{api-version}/collectionFormat']['get']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterArrayCsv,
-      parameterArraySsv,
-      parameterArrayTsv,
-      parameterArrayPipes,
-      parameterArrayMulti,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/collectionFormat',
       query: {
-        parameterArrayCSV: parameterArrayCsv,
-        parameterArraySSV: parameterArraySsv,
-        parameterArrayTSV: parameterArrayTsv,
-        parameterArrayPipes,
-        parameterArrayMulti,
+        parameterArrayCSV: data.parameterArrayCsv,
+        parameterArraySSV: data.parameterArraySsv,
+        parameterArrayTSV: data.parameterArrayTsv,
+        parameterArrayPipes: data.parameterArrayPipes,
+        parameterArrayMulti: data.parameterArrayMulti,
       },
     });
   }
@@ -597,30 +547,20 @@ export class TypesService {
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][202]
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][203]
   > {
-    const {
-      parameterArray,
-      parameterDictionary,
-      parameterEnum,
-      parameterNumber,
-      parameterString,
-      parameterBoolean,
-      parameterObject,
-      id,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/types',
       path: {
-        id,
+        id: data.id,
       },
       query: {
-        parameterNumber,
-        parameterString,
-        parameterBoolean,
-        parameterObject,
-        parameterArray,
-        parameterDictionary,
-        parameterEnum,
+        parameterNumber: data.parameterNumber,
+        parameterString: data.parameterString,
+        parameterBoolean: data.parameterBoolean,
+        parameterObject: data.parameterObject,
+        parameterArray: data.parameterArray,
+        parameterDictionary: data.parameterDictionary,
+        parameterEnum: data.parameterEnum,
       },
     });
   }
@@ -639,13 +579,12 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex']['get']['res'][200]
   > {
-    const { parameterObject, parameterReference } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/complex',
       query: {
-        parameterObject,
-        parameterReference,
+        parameterObject: data.parameterObject,
+        parameterReference: data.parameterReference,
       },
       errors: {
         400: '400 server error',
@@ -687,12 +626,11 @@ export class ErrorService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/error']['post']['res'][200]
   > {
-    const { status } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/error',
       query: {
-        status,
+        status: data.status,
       },
       errors: {
         500: 'Custom message: Internal Server Error',
@@ -716,12 +654,11 @@ export class NonAsciiÆøåÆøÅöôêÊService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串']['post']['res'][200]
   > {
-    const { nonAsciiParamæøåÆøÅöôêÊ } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
       query: {
-        nonAsciiParamæøåÆØÅöôêÊ: nonAsciiParamæøåÆøÅöôêÊ,
+        nonAsciiParamæøåÆØÅöôêÊ: data.nonAsciiParamæøåÆøÅöôêÊ,
       },
     });
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/services.gen.ts.snap
@@ -27,7 +27,6 @@ export class DefaultService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/no-tag']['post']['res'][200]
   > {
-    const { requestBody } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/no-tag',
@@ -132,13 +131,12 @@ export class ParametersService {
   public static deleteFoo(
     data: $OpenApiTs['/api/v{api-version}/foo/{foo}/bar/{bar}']['delete']['req'],
   ): CancelablePromise<void> {
-    const { foo, bar } = data;
     return __request(OpenAPI, {
       method: 'DELETE',
       url: '/api/v{api-version}/foo/{foo}/bar/{bar}',
       path: {
-        foo,
-        bar,
+        foo: data.foo,
+        bar: data.bar,
       },
     });
   }
@@ -158,35 +156,25 @@ export class ParametersService {
   public static callWithParameters(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameterPath}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      fooAllOfEnum,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      parameterPath,
-      requestBody,
-      fooRefEnum,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameterPath}',
       path: {
-        parameterPath,
+        parameterPath: data.parameterPath,
       },
       cookies: {
-        parameterCookie,
+        parameterCookie: data.parameterCookie,
       },
       headers: {
-        parameterHeader,
+        parameterHeader: data.parameterHeader,
       },
       query: {
-        foo_ref_enum: fooRefEnum,
-        foo_all_of_enum: fooAllOfEnum,
-        parameterQuery,
+        foo_ref_enum: data.fooRefEnum,
+        foo_all_of_enum: data.fooAllOfEnum,
+        parameterQuery: data.parameterQuery,
       },
       formData: {
-        parameterForm,
+        parameterForm: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -209,37 +197,26 @@ export class ParametersService {
   public static callWithWeirdParameterNames(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      requestBody,
-      parameterPath1,
-      parameterPath2,
-      parameterPath3,
-      _default,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
       path: {
-        'parameter.path.1': parameterPath1,
-        'parameter-path-2': parameterPath2,
-        'PARAMETER-PATH-3': parameterPath3,
+        'parameter.path.1': data.parameterPath1,
+        'parameter-path-2': data.parameterPath2,
+        'PARAMETER-PATH-3': data.parameterPath3,
       },
       cookies: {
-        'PARAMETER-COOKIE': parameterCookie,
+        'PARAMETER-COOKIE': data.parameterCookie,
       },
       headers: {
-        'parameter.header': parameterHeader,
+        'parameter.header': data.parameterHeader,
       },
       query: {
-        default: _default,
-        'parameter-query': parameterQuery,
+        default: data._default,
+        'parameter-query': data.parameterQuery,
       },
       formData: {
-        parameter_form: parameterForm,
+        parameter_form: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -255,12 +232,11 @@ export class ParametersService {
   public static getCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['get']['req'],
   ): CancelablePromise<void> {
-    const { requestBody, parameter } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -276,12 +252,11 @@ export class ParametersService {
   public static postCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter, requestBody } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -306,24 +281,17 @@ export class DescriptionsService {
   public static callWithDescriptions(
     data: $OpenApiTs['/api/v{api-version}/descriptions/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterWithBreaks,
-      parameterWithBackticks,
-      parameterWithSlashes,
-      parameterWithExpressionPlaceholders,
-      parameterWithQuotes,
-      parameterWithReservedCharacters,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/descriptions/',
       query: {
-        parameterWithBreaks,
-        parameterWithBackticks,
-        parameterWithSlashes,
-        parameterWithExpressionPlaceholders,
-        parameterWithQuotes,
-        parameterWithReservedCharacters,
+        parameterWithBreaks: data.parameterWithBreaks,
+        parameterWithBackticks: data.parameterWithBackticks,
+        parameterWithSlashes: data.parameterWithSlashes,
+        parameterWithExpressionPlaceholders:
+          data.parameterWithExpressionPlaceholders,
+        parameterWithQuotes: data.parameterWithQuotes,
+        parameterWithReservedCharacters: data.parameterWithReservedCharacters,
       },
     });
   }
@@ -339,12 +307,11 @@ export class DeprecatedService {
   public static deprecatedCall(
     data: $OpenApiTs['/api/v{api-version}/parameters/deprecated']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/deprecated',
       headers: {
-        parameter,
+        parameter: data.parameter,
       },
     });
   }
@@ -360,12 +327,11 @@ export class RequestBodyService {
   public static postApiRequestBody(
     data: $OpenApiTs['/api/v{api-version}/requestBody/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { parameter, foo } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/requestBody/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: foo,
       mediaType: 'application/json',
@@ -383,12 +349,11 @@ export class FormDataService {
   public static postApiFormData(
     data: $OpenApiTs['/api/v{api-version}/formData/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { parameter, formData } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/formData/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       formData,
       mediaType: 'multipart/form-data',
@@ -409,22 +374,15 @@ export class DefaultsService {
   public static callWithDefaultParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['get']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -441,22 +399,15 @@ export class DefaultsService {
   public static callWithDefaultOptionalParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -476,28 +427,23 @@ export class DefaultsService {
   public static callToTestOrderOfParams(
     data: $OpenApiTs['/api/v{api-version}/defaults']['put']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterStringWithNoDefault,
-      parameterOptionalStringWithDefault,
-      parameterOptionalStringWithEmptyDefault,
-      parameterOptionalStringWithNoDefault,
-      parameterStringWithDefault,
-      parameterStringWithEmptyDefault,
-      parameterStringNullableWithNoDefault,
-      parameterStringNullableWithDefault,
-    } = data;
     return __request(OpenAPI, {
       method: 'PUT',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterOptionalStringWithDefault,
-        parameterOptionalStringWithEmptyDefault,
-        parameterOptionalStringWithNoDefault,
-        parameterStringWithDefault,
-        parameterStringWithEmptyDefault,
-        parameterStringWithNoDefault,
-        parameterStringNullableWithNoDefault,
-        parameterStringNullableWithDefault,
+        parameterOptionalStringWithDefault:
+          data.parameterOptionalStringWithDefault,
+        parameterOptionalStringWithEmptyDefault:
+          data.parameterOptionalStringWithEmptyDefault,
+        parameterOptionalStringWithNoDefault:
+          data.parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault: data.parameterStringWithDefault,
+        parameterStringWithEmptyDefault: data.parameterStringWithEmptyDefault,
+        parameterStringWithNoDefault: data.parameterStringWithNoDefault,
+        parameterStringNullableWithNoDefault:
+          data.parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault:
+          data.parameterStringNullableWithDefault,
       },
     });
   }
@@ -731,22 +677,15 @@ export class CollectionFormatService {
   public static collectionFormat(
     data: $OpenApiTs['/api/v{api-version}/collectionFormat']['get']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterArrayCsv,
-      parameterArraySsv,
-      parameterArrayTsv,
-      parameterArrayPipes,
-      parameterArrayMulti,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/collectionFormat',
       query: {
-        parameterArrayCSV: parameterArrayCsv,
-        parameterArraySSV: parameterArraySsv,
-        parameterArrayTSV: parameterArrayTsv,
-        parameterArrayPipes,
-        parameterArrayMulti,
+        parameterArrayCSV: data.parameterArrayCsv,
+        parameterArraySSV: data.parameterArraySsv,
+        parameterArrayTSV: data.parameterArrayTsv,
+        parameterArrayPipes: data.parameterArrayPipes,
+        parameterArrayMulti: data.parameterArrayMulti,
       },
     });
   }
@@ -777,30 +716,20 @@ export class TypesService {
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][202]
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][203]
   > {
-    const {
-      parameterArray,
-      parameterDictionary,
-      parameterEnum,
-      parameterNumber,
-      parameterString,
-      parameterBoolean,
-      parameterObject,
-      id,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/types',
       path: {
-        id,
+        id: data.id,
       },
       query: {
-        parameterNumber,
-        parameterString,
-        parameterBoolean,
-        parameterObject,
-        parameterArray,
-        parameterDictionary,
-        parameterEnum,
+        parameterNumber: data.parameterNumber,
+        parameterString: data.parameterString,
+        parameterBoolean: data.parameterBoolean,
+        parameterObject: data.parameterObject,
+        parameterArray: data.parameterArray,
+        parameterDictionary: data.parameterDictionary,
+        parameterEnum: data.parameterEnum,
       },
     });
   }
@@ -818,12 +747,11 @@ export class UploadService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/upload']['post']['res'][200]
   > {
-    const { file } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/upload',
       formData: {
-        file,
+        file: data.file,
       },
     });
   }
@@ -841,12 +769,11 @@ export class FileResponseService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/file/{id}']['get']['res'][200]
   > {
-    const { id } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/file/{id}',
       path: {
-        id,
+        id: data.id,
       },
     });
   }
@@ -865,13 +792,12 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex']['get']['res'][200]
   > {
-    const { parameterObject, parameterReference } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/complex',
       query: {
-        parameterObject,
-        parameterReference,
+        parameterObject: data.parameterObject,
+        parameterReference: data.parameterReference,
       },
       errors: {
         400: '400 `server` error',
@@ -892,12 +818,11 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex/{id}']['put']['res'][200]
   > {
-    const { id, requestBody } = data;
     return __request(OpenAPI, {
       method: 'PUT',
       url: '/api/v{api-version}/complex/{id}',
       path: {
-        id,
+        id: data.id,
       },
       body: requestBody,
       mediaType: 'application/json-patch+json',
@@ -914,7 +839,6 @@ export class MultipartService {
   public static multipartRequest(
     data: $OpenApiTs['/api/v{api-version}/multipart']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { formData } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/multipart',
@@ -969,12 +893,11 @@ export class ErrorService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/error']['post']['res'][200]
   > {
-    const { status } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/error',
       query: {
-        status,
+        status: data.status,
       },
       errors: {
         500: 'Custom message: Internal Server Error',
@@ -998,12 +921,11 @@ export class NonAsciiÆøåÆøÅöôêÊService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串']['post']['res'][200]
   > {
-    const { nonAsciiParamæøåÆøÅöôêÊ } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
       query: {
-        nonAsciiParamæøåÆØÅöôêÊ: nonAsciiParamæøåÆøÅöôêÊ,
+        nonAsciiParamæøåÆØÅöôêÊ: data.nonAsciiParamæøåÆøÅöôêÊ,
       },
     });
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/services.gen.ts.snap
@@ -32,7 +32,6 @@ export class DefaultService {
   public postServiceWithEmptyTag(
     data: $OpenApiTs['/api/v{api-version}/no-tag']['post']['req'],
   ): Observable<$OpenApiTs['/api/v{api-version}/no-tag']['post']['res'][200]> {
-    const { requestBody } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/no-tag',
@@ -147,13 +146,12 @@ export class ParametersService {
   public deleteFoo(
     data: $OpenApiTs['/api/v{api-version}/foo/{foo}/bar/{bar}']['delete']['req'],
   ): Observable<void> {
-    const { foo, bar } = data;
     return __request(OpenAPI, this.http, {
       method: 'DELETE',
       url: '/api/v{api-version}/foo/{foo}/bar/{bar}',
       path: {
-        foo,
-        bar,
+        foo: data.foo,
+        bar: data.bar,
       },
     });
   }
@@ -173,35 +171,25 @@ export class ParametersService {
   public callWithParameters(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameterPath}']['post']['req'],
   ): Observable<void> {
-    const {
-      parameterHeader,
-      fooAllOfEnum,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      parameterPath,
-      requestBody,
-      fooRefEnum,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameterPath}',
       path: {
-        parameterPath,
+        parameterPath: data.parameterPath,
       },
       cookies: {
-        parameterCookie,
+        parameterCookie: data.parameterCookie,
       },
       headers: {
-        parameterHeader,
+        parameterHeader: data.parameterHeader,
       },
       query: {
-        foo_ref_enum: fooRefEnum,
-        foo_all_of_enum: fooAllOfEnum,
-        parameterQuery,
+        foo_ref_enum: data.fooRefEnum,
+        foo_all_of_enum: data.fooAllOfEnum,
+        parameterQuery: data.parameterQuery,
       },
       formData: {
-        parameterForm,
+        parameterForm: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -224,37 +212,26 @@ export class ParametersService {
   public callWithWeirdParameterNames(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}']['post']['req'],
   ): Observable<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      requestBody,
-      parameterPath1,
-      parameterPath2,
-      parameterPath3,
-      _default,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
       path: {
-        'parameter.path.1': parameterPath1,
-        'parameter-path-2': parameterPath2,
-        'PARAMETER-PATH-3': parameterPath3,
+        'parameter.path.1': data.parameterPath1,
+        'parameter-path-2': data.parameterPath2,
+        'PARAMETER-PATH-3': data.parameterPath3,
       },
       cookies: {
-        'PARAMETER-COOKIE': parameterCookie,
+        'PARAMETER-COOKIE': data.parameterCookie,
       },
       headers: {
-        'parameter.header': parameterHeader,
+        'parameter.header': data.parameterHeader,
       },
       query: {
-        default: _default,
-        'parameter-query': parameterQuery,
+        default: data._default,
+        'parameter-query': data.parameterQuery,
       },
       formData: {
-        parameter_form: parameterForm,
+        parameter_form: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -270,12 +247,11 @@ export class ParametersService {
   public getCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['get']['req'],
   ): Observable<void> {
-    const { requestBody, parameter } = data;
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -291,12 +267,11 @@ export class ParametersService {
   public postCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['post']['req'],
   ): Observable<void> {
-    const { parameter, requestBody } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -326,24 +301,17 @@ export class DescriptionsService {
   public callWithDescriptions(
     data: $OpenApiTs['/api/v{api-version}/descriptions/']['post']['req'] = {},
   ): Observable<void> {
-    const {
-      parameterWithBreaks,
-      parameterWithBackticks,
-      parameterWithSlashes,
-      parameterWithExpressionPlaceholders,
-      parameterWithQuotes,
-      parameterWithReservedCharacters,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/descriptions/',
       query: {
-        parameterWithBreaks,
-        parameterWithBackticks,
-        parameterWithSlashes,
-        parameterWithExpressionPlaceholders,
-        parameterWithQuotes,
-        parameterWithReservedCharacters,
+        parameterWithBreaks: data.parameterWithBreaks,
+        parameterWithBackticks: data.parameterWithBackticks,
+        parameterWithSlashes: data.parameterWithSlashes,
+        parameterWithExpressionPlaceholders:
+          data.parameterWithExpressionPlaceholders,
+        parameterWithQuotes: data.parameterWithQuotes,
+        parameterWithReservedCharacters: data.parameterWithReservedCharacters,
       },
     });
   }
@@ -364,12 +332,11 @@ export class DeprecatedService {
   public deprecatedCall(
     data: $OpenApiTs['/api/v{api-version}/parameters/deprecated']['post']['req'],
   ): Observable<void> {
-    const { parameter } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/deprecated',
       headers: {
-        parameter,
+        parameter: data.parameter,
       },
     });
   }
@@ -390,12 +357,11 @@ export class RequestBodyService {
   public postApiRequestBody(
     data: $OpenApiTs['/api/v{api-version}/requestBody/']['post']['req'] = {},
   ): Observable<void> {
-    const { parameter, foo } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/requestBody/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: foo,
       mediaType: 'application/json',
@@ -418,12 +384,11 @@ export class FormDataService {
   public postApiFormData(
     data: $OpenApiTs['/api/v{api-version}/formData/']['post']['req'] = {},
   ): Observable<void> {
-    const { parameter, formData } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/formData/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       formData,
       mediaType: 'multipart/form-data',
@@ -449,22 +414,15 @@ export class DefaultsService {
   public callWithDefaultParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['get']['req'] = {},
   ): Observable<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -481,22 +439,15 @@ export class DefaultsService {
   public callWithDefaultOptionalParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['post']['req'] = {},
   ): Observable<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -516,28 +467,23 @@ export class DefaultsService {
   public callToTestOrderOfParams(
     data: $OpenApiTs['/api/v{api-version}/defaults']['put']['req'],
   ): Observable<void> {
-    const {
-      parameterStringWithNoDefault,
-      parameterOptionalStringWithDefault,
-      parameterOptionalStringWithEmptyDefault,
-      parameterOptionalStringWithNoDefault,
-      parameterStringWithDefault,
-      parameterStringWithEmptyDefault,
-      parameterStringNullableWithNoDefault,
-      parameterStringNullableWithDefault,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'PUT',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterOptionalStringWithDefault,
-        parameterOptionalStringWithEmptyDefault,
-        parameterOptionalStringWithNoDefault,
-        parameterStringWithDefault,
-        parameterStringWithEmptyDefault,
-        parameterStringWithNoDefault,
-        parameterStringNullableWithNoDefault,
-        parameterStringNullableWithDefault,
+        parameterOptionalStringWithDefault:
+          data.parameterOptionalStringWithDefault,
+        parameterOptionalStringWithEmptyDefault:
+          data.parameterOptionalStringWithEmptyDefault,
+        parameterOptionalStringWithNoDefault:
+          data.parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault: data.parameterStringWithDefault,
+        parameterStringWithEmptyDefault: data.parameterStringWithEmptyDefault,
+        parameterStringWithNoDefault: data.parameterStringWithNoDefault,
+        parameterStringNullableWithNoDefault:
+          data.parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault:
+          data.parameterStringNullableWithDefault,
       },
     });
   }
@@ -806,22 +752,15 @@ export class CollectionFormatService {
   public collectionFormat(
     data: $OpenApiTs['/api/v{api-version}/collectionFormat']['get']['req'],
   ): Observable<void> {
-    const {
-      parameterArrayCsv,
-      parameterArraySsv,
-      parameterArrayTsv,
-      parameterArrayPipes,
-      parameterArrayMulti,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/v{api-version}/collectionFormat',
       query: {
-        parameterArrayCSV: parameterArrayCsv,
-        parameterArraySSV: parameterArraySsv,
-        parameterArrayTSV: parameterArrayTsv,
-        parameterArrayPipes,
-        parameterArrayMulti,
+        parameterArrayCSV: data.parameterArrayCsv,
+        parameterArraySSV: data.parameterArraySsv,
+        parameterArrayTSV: data.parameterArrayTsv,
+        parameterArrayPipes: data.parameterArrayPipes,
+        parameterArrayMulti: data.parameterArrayMulti,
       },
     });
   }
@@ -857,30 +796,20 @@ export class TypesService {
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][202]
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][203]
   > {
-    const {
-      parameterArray,
-      parameterDictionary,
-      parameterEnum,
-      parameterNumber,
-      parameterString,
-      parameterBoolean,
-      parameterObject,
-      id,
-    } = data;
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/v{api-version}/types',
       path: {
-        id,
+        id: data.id,
       },
       query: {
-        parameterNumber,
-        parameterString,
-        parameterBoolean,
-        parameterObject,
-        parameterArray,
-        parameterDictionary,
-        parameterEnum,
+        parameterNumber: data.parameterNumber,
+        parameterString: data.parameterString,
+        parameterBoolean: data.parameterBoolean,
+        parameterObject: data.parameterObject,
+        parameterArray: data.parameterArray,
+        parameterDictionary: data.parameterDictionary,
+        parameterEnum: data.parameterEnum,
       },
     });
   }
@@ -901,12 +830,11 @@ export class UploadService {
   public uploadFile(
     data: $OpenApiTs['/api/v{api-version}/upload']['post']['req'],
   ): Observable<$OpenApiTs['/api/v{api-version}/upload']['post']['res'][200]> {
-    const { file } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/upload',
       formData: {
-        file,
+        file: data.file,
       },
     });
   }
@@ -929,12 +857,11 @@ export class FileResponseService {
   ): Observable<
     $OpenApiTs['/api/v{api-version}/file/{id}']['get']['res'][200]
   > {
-    const { id } = data;
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/v{api-version}/file/{id}',
       path: {
-        id,
+        id: data.id,
       },
     });
   }
@@ -956,13 +883,12 @@ export class ComplexService {
   public complexTypes(
     data: $OpenApiTs['/api/v{api-version}/complex']['get']['req'],
   ): Observable<$OpenApiTs['/api/v{api-version}/complex']['get']['res'][200]> {
-    const { parameterObject, parameterReference } = data;
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/v{api-version}/complex',
       query: {
-        parameterObject,
-        parameterReference,
+        parameterObject: data.parameterObject,
+        parameterReference: data.parameterReference,
       },
       errors: {
         400: '400 `server` error',
@@ -983,12 +909,11 @@ export class ComplexService {
   ): Observable<
     $OpenApiTs['/api/v{api-version}/complex/{id}']['put']['res'][200]
   > {
-    const { id, requestBody } = data;
     return __request(OpenAPI, this.http, {
       method: 'PUT',
       url: '/api/v{api-version}/complex/{id}',
       path: {
-        id,
+        id: data.id,
       },
       body: requestBody,
       mediaType: 'application/json-patch+json',
@@ -1010,7 +935,6 @@ export class MultipartService {
   public multipartRequest(
     data: $OpenApiTs['/api/v{api-version}/multipart']['post']['req'] = {},
   ): Observable<void> {
-    const { formData } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/multipart',
@@ -1073,12 +997,11 @@ export class ErrorService {
   public testErrorCode(
     data: $OpenApiTs['/api/v{api-version}/error']['post']['req'],
   ): Observable<$OpenApiTs['/api/v{api-version}/error']['post']['res'][200]> {
-    const { status } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/error',
       query: {
-        status,
+        status: data.status,
       },
       errors: {
         500: 'Custom message: Internal Server Error',
@@ -1107,12 +1030,11 @@ export class NonAsciiÆøåÆøÅöôêÊService {
   ): Observable<
     $OpenApiTs['/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串']['post']['res'][200]
   > {
-    const { nonAsciiParamæøåÆøÅöôêÊ } = data;
     return __request(OpenAPI, this.http, {
       method: 'POST',
       url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
       query: {
-        nonAsciiParamæøåÆØÅöôêÊ: nonAsciiParamæøåÆøÅöôêÊ,
+        nonAsciiParamæøåÆØÅöôêÊ: data.nonAsciiParamæøåÆøÅöôêÊ,
       },
     });
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/services.gen.ts.snap
@@ -28,7 +28,6 @@ export class DefaultService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/no-tag']['post']['res'][200]
   > {
-    const { requestBody } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/no-tag',
@@ -137,13 +136,12 @@ export class ParametersService {
   public deleteFoo(
     data: $OpenApiTs['/api/v{api-version}/foo/{foo}/bar/{bar}']['delete']['req'],
   ): CancelablePromise<void> {
-    const { foo, bar } = data;
     return this.httpRequest.request({
       method: 'DELETE',
       url: '/api/v{api-version}/foo/{foo}/bar/{bar}',
       path: {
-        foo,
-        bar,
+        foo: data.foo,
+        bar: data.bar,
       },
     });
   }
@@ -163,35 +161,25 @@ export class ParametersService {
   public callWithParameters(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameterPath}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      fooAllOfEnum,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      parameterPath,
-      requestBody,
-      fooRefEnum,
-    } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameterPath}',
       path: {
-        parameterPath,
+        parameterPath: data.parameterPath,
       },
       cookies: {
-        parameterCookie,
+        parameterCookie: data.parameterCookie,
       },
       headers: {
-        parameterHeader,
+        parameterHeader: data.parameterHeader,
       },
       query: {
-        foo_ref_enum: fooRefEnum,
-        foo_all_of_enum: fooAllOfEnum,
-        parameterQuery,
+        foo_ref_enum: data.fooRefEnum,
+        foo_all_of_enum: data.fooAllOfEnum,
+        parameterQuery: data.parameterQuery,
       },
       formData: {
-        parameterForm,
+        parameterForm: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -214,37 +202,26 @@ export class ParametersService {
   public callWithWeirdParameterNames(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      requestBody,
-      parameterPath1,
-      parameterPath2,
-      parameterPath3,
-      _default,
-    } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
       path: {
-        'parameter.path.1': parameterPath1,
-        'parameter-path-2': parameterPath2,
-        'PARAMETER-PATH-3': parameterPath3,
+        'parameter.path.1': data.parameterPath1,
+        'parameter-path-2': data.parameterPath2,
+        'PARAMETER-PATH-3': data.parameterPath3,
       },
       cookies: {
-        'PARAMETER-COOKIE': parameterCookie,
+        'PARAMETER-COOKIE': data.parameterCookie,
       },
       headers: {
-        'parameter.header': parameterHeader,
+        'parameter.header': data.parameterHeader,
       },
       query: {
-        default: _default,
-        'parameter-query': parameterQuery,
+        default: data._default,
+        'parameter-query': data.parameterQuery,
       },
       formData: {
-        parameter_form: parameterForm,
+        parameter_form: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -260,12 +237,11 @@ export class ParametersService {
   public getCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['get']['req'],
   ): CancelablePromise<void> {
-    const { requestBody, parameter } = data;
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -281,12 +257,11 @@ export class ParametersService {
   public postCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter, requestBody } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -313,24 +288,17 @@ export class DescriptionsService {
   public callWithDescriptions(
     data: $OpenApiTs['/api/v{api-version}/descriptions/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterWithBreaks,
-      parameterWithBackticks,
-      parameterWithSlashes,
-      parameterWithExpressionPlaceholders,
-      parameterWithQuotes,
-      parameterWithReservedCharacters,
-    } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/descriptions/',
       query: {
-        parameterWithBreaks,
-        parameterWithBackticks,
-        parameterWithSlashes,
-        parameterWithExpressionPlaceholders,
-        parameterWithQuotes,
-        parameterWithReservedCharacters,
+        parameterWithBreaks: data.parameterWithBreaks,
+        parameterWithBackticks: data.parameterWithBackticks,
+        parameterWithSlashes: data.parameterWithSlashes,
+        parameterWithExpressionPlaceholders:
+          data.parameterWithExpressionPlaceholders,
+        parameterWithQuotes: data.parameterWithQuotes,
+        parameterWithReservedCharacters: data.parameterWithReservedCharacters,
       },
     });
   }
@@ -348,12 +316,11 @@ export class DeprecatedService {
   public deprecatedCall(
     data: $OpenApiTs['/api/v{api-version}/parameters/deprecated']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/parameters/deprecated',
       headers: {
-        parameter,
+        parameter: data.parameter,
       },
     });
   }
@@ -371,12 +338,11 @@ export class RequestBodyService {
   public postApiRequestBody(
     data: $OpenApiTs['/api/v{api-version}/requestBody/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { parameter, foo } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/requestBody/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: foo,
       mediaType: 'application/json',
@@ -396,12 +362,11 @@ export class FormDataService {
   public postApiFormData(
     data: $OpenApiTs['/api/v{api-version}/formData/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { parameter, formData } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/formData/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       formData,
       mediaType: 'multipart/form-data',
@@ -424,22 +389,15 @@ export class DefaultsService {
   public callWithDefaultParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['get']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -456,22 +414,15 @@ export class DefaultsService {
   public callWithDefaultOptionalParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -491,28 +442,23 @@ export class DefaultsService {
   public callToTestOrderOfParams(
     data: $OpenApiTs['/api/v{api-version}/defaults']['put']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterStringWithNoDefault,
-      parameterOptionalStringWithDefault,
-      parameterOptionalStringWithEmptyDefault,
-      parameterOptionalStringWithNoDefault,
-      parameterStringWithDefault,
-      parameterStringWithEmptyDefault,
-      parameterStringNullableWithNoDefault,
-      parameterStringNullableWithDefault,
-    } = data;
     return this.httpRequest.request({
       method: 'PUT',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterOptionalStringWithDefault,
-        parameterOptionalStringWithEmptyDefault,
-        parameterOptionalStringWithNoDefault,
-        parameterStringWithDefault,
-        parameterStringWithEmptyDefault,
-        parameterStringWithNoDefault,
-        parameterStringNullableWithNoDefault,
-        parameterStringNullableWithDefault,
+        parameterOptionalStringWithDefault:
+          data.parameterOptionalStringWithDefault,
+        parameterOptionalStringWithEmptyDefault:
+          data.parameterOptionalStringWithEmptyDefault,
+        parameterOptionalStringWithNoDefault:
+          data.parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault: data.parameterStringWithDefault,
+        parameterStringWithEmptyDefault: data.parameterStringWithEmptyDefault,
+        parameterStringWithNoDefault: data.parameterStringWithNoDefault,
+        parameterStringNullableWithNoDefault:
+          data.parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault:
+          data.parameterStringNullableWithDefault,
       },
     });
   }
@@ -760,22 +706,15 @@ export class CollectionFormatService {
   public collectionFormat(
     data: $OpenApiTs['/api/v{api-version}/collectionFormat']['get']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterArrayCsv,
-      parameterArraySsv,
-      parameterArrayTsv,
-      parameterArrayPipes,
-      parameterArrayMulti,
-    } = data;
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v{api-version}/collectionFormat',
       query: {
-        parameterArrayCSV: parameterArrayCsv,
-        parameterArraySSV: parameterArraySsv,
-        parameterArrayTSV: parameterArrayTsv,
-        parameterArrayPipes,
-        parameterArrayMulti,
+        parameterArrayCSV: data.parameterArrayCsv,
+        parameterArraySSV: data.parameterArraySsv,
+        parameterArrayTSV: data.parameterArrayTsv,
+        parameterArrayPipes: data.parameterArrayPipes,
+        parameterArrayMulti: data.parameterArrayMulti,
       },
     });
   }
@@ -808,30 +747,20 @@ export class TypesService {
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][202]
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][203]
   > {
-    const {
-      parameterArray,
-      parameterDictionary,
-      parameterEnum,
-      parameterNumber,
-      parameterString,
-      parameterBoolean,
-      parameterObject,
-      id,
-    } = data;
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v{api-version}/types',
       path: {
-        id,
+        id: data.id,
       },
       query: {
-        parameterNumber,
-        parameterString,
-        parameterBoolean,
-        parameterObject,
-        parameterArray,
-        parameterDictionary,
-        parameterEnum,
+        parameterNumber: data.parameterNumber,
+        parameterString: data.parameterString,
+        parameterBoolean: data.parameterBoolean,
+        parameterObject: data.parameterObject,
+        parameterArray: data.parameterArray,
+        parameterDictionary: data.parameterDictionary,
+        parameterEnum: data.parameterEnum,
       },
     });
   }
@@ -851,12 +780,11 @@ export class UploadService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/upload']['post']['res'][200]
   > {
-    const { file } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/upload',
       formData: {
-        file,
+        file: data.file,
       },
     });
   }
@@ -876,12 +804,11 @@ export class FileResponseService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/file/{id}']['get']['res'][200]
   > {
-    const { id } = data;
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v{api-version}/file/{id}',
       path: {
-        id,
+        id: data.id,
       },
     });
   }
@@ -902,13 +829,12 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex']['get']['res'][200]
   > {
-    const { parameterObject, parameterReference } = data;
     return this.httpRequest.request({
       method: 'GET',
       url: '/api/v{api-version}/complex',
       query: {
-        parameterObject,
-        parameterReference,
+        parameterObject: data.parameterObject,
+        parameterReference: data.parameterReference,
       },
       errors: {
         400: '400 `server` error',
@@ -929,12 +855,11 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex/{id}']['put']['res'][200]
   > {
-    const { id, requestBody } = data;
     return this.httpRequest.request({
       method: 'PUT',
       url: '/api/v{api-version}/complex/{id}',
       path: {
-        id,
+        id: data.id,
       },
       body: requestBody,
       mediaType: 'application/json-patch+json',
@@ -953,7 +878,6 @@ export class MultipartService {
   public multipartRequest(
     data: $OpenApiTs['/api/v{api-version}/multipart']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { formData } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/multipart',
@@ -1012,12 +936,11 @@ export class ErrorService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/error']['post']['res'][200]
   > {
-    const { status } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/error',
       query: {
-        status,
+        status: data.status,
       },
       errors: {
         500: 'Custom message: Internal Server Error',
@@ -1043,12 +966,11 @@ export class NonAsciiÆøåÆøÅöôêÊService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串']['post']['res'][200]
   > {
-    const { nonAsciiParamæøåÆøÅöôêÊ } = data;
     return this.httpRequest.request({
       method: 'POST',
       url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
       query: {
-        nonAsciiParamæøåÆØÅöôêÊ: nonAsciiParamæøåÆøÅöôêÊ,
+        nonAsciiParamæøåÆØÅöôêÊ: data.nonAsciiParamæøåÆøÅöôêÊ,
       },
     });
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/services.gen.ts.snap
@@ -27,7 +27,6 @@ export class DefaultService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/no-tag']['post']['res'][200]
   > {
-    const { requestBody } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/no-tag',
@@ -132,13 +131,12 @@ export class ParametersService {
   public static deleteFoo(
     data: $OpenApiTs['/api/v{api-version}/foo/{foo}/bar/{bar}']['delete']['req'],
   ): CancelablePromise<void> {
-    const { foo, bar } = data;
     return __request(OpenAPI, {
       method: 'DELETE',
       url: '/api/v{api-version}/foo/{foo}/bar/{bar}',
       path: {
-        foo,
-        bar,
+        foo: data.foo,
+        bar: data.bar,
       },
     });
   }
@@ -158,35 +156,25 @@ export class ParametersService {
   public static callWithParameters(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameterPath}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      fooAllOfEnum,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      parameterPath,
-      requestBody,
-      fooRefEnum,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameterPath}',
       path: {
-        parameterPath,
+        parameterPath: data.parameterPath,
       },
       cookies: {
-        parameterCookie,
+        parameterCookie: data.parameterCookie,
       },
       headers: {
-        parameterHeader,
+        parameterHeader: data.parameterHeader,
       },
       query: {
-        foo_ref_enum: fooRefEnum,
-        foo_all_of_enum: fooAllOfEnum,
-        parameterQuery,
+        foo_ref_enum: data.fooRefEnum,
+        foo_all_of_enum: data.fooAllOfEnum,
+        parameterQuery: data.parameterQuery,
       },
       formData: {
-        parameterForm,
+        parameterForm: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -209,37 +197,26 @@ export class ParametersService {
   public static callWithWeirdParameterNames(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      requestBody,
-      parameterPath1,
-      parameterPath2,
-      parameterPath3,
-      _default,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
       path: {
-        'parameter.path.1': parameterPath1,
-        'parameter-path-2': parameterPath2,
-        'PARAMETER-PATH-3': parameterPath3,
+        'parameter.path.1': data.parameterPath1,
+        'parameter-path-2': data.parameterPath2,
+        'PARAMETER-PATH-3': data.parameterPath3,
       },
       cookies: {
-        'PARAMETER-COOKIE': parameterCookie,
+        'PARAMETER-COOKIE': data.parameterCookie,
       },
       headers: {
-        'parameter.header': parameterHeader,
+        'parameter.header': data.parameterHeader,
       },
       query: {
-        default: _default,
-        'parameter-query': parameterQuery,
+        default: data._default,
+        'parameter-query': data.parameterQuery,
       },
       formData: {
-        parameter_form: parameterForm,
+        parameter_form: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -255,12 +232,11 @@ export class ParametersService {
   public static getCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['get']['req'],
   ): CancelablePromise<void> {
-    const { requestBody, parameter } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -276,12 +252,11 @@ export class ParametersService {
   public static postCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter, requestBody } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -306,24 +281,17 @@ export class DescriptionsService {
   public static callWithDescriptions(
     data: $OpenApiTs['/api/v{api-version}/descriptions/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterWithBreaks,
-      parameterWithBackticks,
-      parameterWithSlashes,
-      parameterWithExpressionPlaceholders,
-      parameterWithQuotes,
-      parameterWithReservedCharacters,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/descriptions/',
       query: {
-        parameterWithBreaks,
-        parameterWithBackticks,
-        parameterWithSlashes,
-        parameterWithExpressionPlaceholders,
-        parameterWithQuotes,
-        parameterWithReservedCharacters,
+        parameterWithBreaks: data.parameterWithBreaks,
+        parameterWithBackticks: data.parameterWithBackticks,
+        parameterWithSlashes: data.parameterWithSlashes,
+        parameterWithExpressionPlaceholders:
+          data.parameterWithExpressionPlaceholders,
+        parameterWithQuotes: data.parameterWithQuotes,
+        parameterWithReservedCharacters: data.parameterWithReservedCharacters,
       },
     });
   }
@@ -339,12 +307,11 @@ export class DeprecatedService {
   public static deprecatedCall(
     data: $OpenApiTs['/api/v{api-version}/parameters/deprecated']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/deprecated',
       headers: {
-        parameter,
+        parameter: data.parameter,
       },
     });
   }
@@ -360,12 +327,11 @@ export class RequestBodyService {
   public static postApiRequestBody(
     data: $OpenApiTs['/api/v{api-version}/requestBody/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { parameter, foo } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/requestBody/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: foo,
       mediaType: 'application/json',
@@ -383,12 +349,11 @@ export class FormDataService {
   public static postApiFormData(
     data: $OpenApiTs['/api/v{api-version}/formData/']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { parameter, formData } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/formData/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       formData,
       mediaType: 'multipart/form-data',
@@ -409,22 +374,15 @@ export class DefaultsService {
   public static callWithDefaultParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['get']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -441,22 +399,15 @@ export class DefaultsService {
   public static callWithDefaultOptionalParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -476,28 +427,23 @@ export class DefaultsService {
   public static callToTestOrderOfParams(
     data: $OpenApiTs['/api/v{api-version}/defaults']['put']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterStringWithNoDefault,
-      parameterOptionalStringWithDefault,
-      parameterOptionalStringWithEmptyDefault,
-      parameterOptionalStringWithNoDefault,
-      parameterStringWithDefault,
-      parameterStringWithEmptyDefault,
-      parameterStringNullableWithNoDefault,
-      parameterStringNullableWithDefault,
-    } = data;
     return __request(OpenAPI, {
       method: 'PUT',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterOptionalStringWithDefault,
-        parameterOptionalStringWithEmptyDefault,
-        parameterOptionalStringWithNoDefault,
-        parameterStringWithDefault,
-        parameterStringWithEmptyDefault,
-        parameterStringWithNoDefault,
-        parameterStringNullableWithNoDefault,
-        parameterStringNullableWithDefault,
+        parameterOptionalStringWithDefault:
+          data.parameterOptionalStringWithDefault,
+        parameterOptionalStringWithEmptyDefault:
+          data.parameterOptionalStringWithEmptyDefault,
+        parameterOptionalStringWithNoDefault:
+          data.parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault: data.parameterStringWithDefault,
+        parameterStringWithEmptyDefault: data.parameterStringWithEmptyDefault,
+        parameterStringWithNoDefault: data.parameterStringWithNoDefault,
+        parameterStringNullableWithNoDefault:
+          data.parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault:
+          data.parameterStringNullableWithDefault,
       },
     });
   }
@@ -731,22 +677,15 @@ export class CollectionFormatService {
   public static collectionFormat(
     data: $OpenApiTs['/api/v{api-version}/collectionFormat']['get']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterArrayCsv,
-      parameterArraySsv,
-      parameterArrayTsv,
-      parameterArrayPipes,
-      parameterArrayMulti,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/collectionFormat',
       query: {
-        parameterArrayCSV: parameterArrayCsv,
-        parameterArraySSV: parameterArraySsv,
-        parameterArrayTSV: parameterArrayTsv,
-        parameterArrayPipes,
-        parameterArrayMulti,
+        parameterArrayCSV: data.parameterArrayCsv,
+        parameterArraySSV: data.parameterArraySsv,
+        parameterArrayTSV: data.parameterArrayTsv,
+        parameterArrayPipes: data.parameterArrayPipes,
+        parameterArrayMulti: data.parameterArrayMulti,
       },
     });
   }
@@ -777,30 +716,20 @@ export class TypesService {
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][202]
     | $OpenApiTs['/api/v{api-version}/types']['get']['res'][203]
   > {
-    const {
-      parameterArray,
-      parameterDictionary,
-      parameterEnum,
-      parameterNumber,
-      parameterString,
-      parameterBoolean,
-      parameterObject,
-      id,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/types',
       path: {
-        id,
+        id: data.id,
       },
       query: {
-        parameterNumber,
-        parameterString,
-        parameterBoolean,
-        parameterObject,
-        parameterArray,
-        parameterDictionary,
-        parameterEnum,
+        parameterNumber: data.parameterNumber,
+        parameterString: data.parameterString,
+        parameterBoolean: data.parameterBoolean,
+        parameterObject: data.parameterObject,
+        parameterArray: data.parameterArray,
+        parameterDictionary: data.parameterDictionary,
+        parameterEnum: data.parameterEnum,
       },
     });
   }
@@ -818,12 +747,11 @@ export class UploadService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/upload']['post']['res'][200]
   > {
-    const { file } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/upload',
       formData: {
-        file,
+        file: data.file,
       },
     });
   }
@@ -841,12 +769,11 @@ export class FileResponseService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/file/{id}']['get']['res'][200]
   > {
-    const { id } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/file/{id}',
       path: {
-        id,
+        id: data.id,
       },
     });
   }
@@ -865,13 +792,12 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex']['get']['res'][200]
   > {
-    const { parameterObject, parameterReference } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/complex',
       query: {
-        parameterObject,
-        parameterReference,
+        parameterObject: data.parameterObject,
+        parameterReference: data.parameterReference,
       },
       errors: {
         400: '400 `server` error',
@@ -892,12 +818,11 @@ export class ComplexService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/complex/{id}']['put']['res'][200]
   > {
-    const { id, requestBody } = data;
     return __request(OpenAPI, {
       method: 'PUT',
       url: '/api/v{api-version}/complex/{id}',
       path: {
-        id,
+        id: data.id,
       },
       body: requestBody,
       mediaType: 'application/json-patch+json',
@@ -914,7 +839,6 @@ export class MultipartService {
   public static multipartRequest(
     data: $OpenApiTs['/api/v{api-version}/multipart']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const { formData } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/multipart',
@@ -969,12 +893,11 @@ export class ErrorService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/error']['post']['res'][200]
   > {
-    const { status } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/error',
       query: {
-        status,
+        status: data.status,
       },
       errors: {
         500: 'Custom message: Internal Server Error',
@@ -998,12 +921,11 @@ export class NonAsciiÆøåÆøÅöôêÊService {
   ): CancelablePromise<
     $OpenApiTs['/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串']['post']['res'][200]
   > {
-    const { nonAsciiParamæøåÆøÅöôêÊ } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
       query: {
-        nonAsciiParamæøåÆØÅöôêÊ: nonAsciiParamæøåÆøÅöôêÊ,
+        nonAsciiParamæøåÆØÅöôêÊ: data.nonAsciiParamæøåÆøÅöôêÊ,
       },
     });
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/services.gen.ts.snap
@@ -18,22 +18,15 @@ export class DefaultsService {
   public static callWithDefaultParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['get']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -50,22 +43,15 @@ export class DefaultsService {
   public static callWithDefaultOptionalParameters(
     data: $OpenApiTs['/api/v{api-version}/defaults']['post']['req'] = {},
   ): CancelablePromise<void> {
-    const {
-      parameterString,
-      parameterNumber,
-      parameterBoolean,
-      parameterEnum,
-      parameterModel,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterString,
-        parameterNumber,
-        parameterBoolean,
-        parameterEnum,
-        parameterModel,
+        parameterString: data.parameterString,
+        parameterNumber: data.parameterNumber,
+        parameterBoolean: data.parameterBoolean,
+        parameterEnum: data.parameterEnum,
+        parameterModel: data.parameterModel,
       },
     });
   }
@@ -85,28 +71,23 @@ export class DefaultsService {
   public static callToTestOrderOfParams(
     data: $OpenApiTs['/api/v{api-version}/defaults']['put']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterStringWithNoDefault,
-      parameterOptionalStringWithDefault,
-      parameterOptionalStringWithEmptyDefault,
-      parameterOptionalStringWithNoDefault,
-      parameterStringWithDefault,
-      parameterStringWithEmptyDefault,
-      parameterStringNullableWithNoDefault,
-      parameterStringNullableWithDefault,
-    } = data;
     return __request(OpenAPI, {
       method: 'PUT',
       url: '/api/v{api-version}/defaults',
       query: {
-        parameterOptionalStringWithDefault,
-        parameterOptionalStringWithEmptyDefault,
-        parameterOptionalStringWithNoDefault,
-        parameterStringWithDefault,
-        parameterStringWithEmptyDefault,
-        parameterStringWithNoDefault,
-        parameterStringNullableWithNoDefault,
-        parameterStringNullableWithDefault,
+        parameterOptionalStringWithDefault:
+          data.parameterOptionalStringWithDefault,
+        parameterOptionalStringWithEmptyDefault:
+          data.parameterOptionalStringWithEmptyDefault,
+        parameterOptionalStringWithNoDefault:
+          data.parameterOptionalStringWithNoDefault,
+        parameterStringWithDefault: data.parameterStringWithDefault,
+        parameterStringWithEmptyDefault: data.parameterStringWithEmptyDefault,
+        parameterStringWithNoDefault: data.parameterStringWithNoDefault,
+        parameterStringNullableWithNoDefault:
+          data.parameterStringNullableWithNoDefault,
+        parameterStringNullableWithDefault:
+          data.parameterStringNullableWithDefault,
       },
     });
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_services_name/services.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_services_name/services.gen.ts.snap
@@ -99,13 +99,12 @@ export class myAwesomeParametersApi {
   public static deleteFoo(
     data: $OpenApiTs['/api/v{api-version}/foo/{foo}/bar/{bar}']['delete']['req'],
   ): CancelablePromise<void> {
-    const { foo, bar } = data;
     return __request(OpenAPI, {
       method: 'DELETE',
       url: '/api/v{api-version}/foo/{foo}/bar/{bar}',
       path: {
-        foo,
-        bar,
+        foo: data.foo,
+        bar: data.bar,
       },
     });
   }
@@ -125,35 +124,25 @@ export class myAwesomeParametersApi {
   public static callWithParameters(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameterPath}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      fooAllOfEnum,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      parameterPath,
-      requestBody,
-      fooRefEnum,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameterPath}',
       path: {
-        parameterPath,
+        parameterPath: data.parameterPath,
       },
       cookies: {
-        parameterCookie,
+        parameterCookie: data.parameterCookie,
       },
       headers: {
-        parameterHeader,
+        parameterHeader: data.parameterHeader,
       },
       query: {
-        foo_ref_enum: fooRefEnum,
-        foo_all_of_enum: fooAllOfEnum,
-        parameterQuery,
+        foo_ref_enum: data.fooRefEnum,
+        foo_all_of_enum: data.fooAllOfEnum,
+        parameterQuery: data.parameterQuery,
       },
       formData: {
-        parameterForm,
+        parameterForm: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -176,37 +165,26 @@ export class myAwesomeParametersApi {
   public static callWithWeirdParameterNames(
     data: $OpenApiTs['/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}']['post']['req'],
   ): CancelablePromise<void> {
-    const {
-      parameterHeader,
-      parameterQuery,
-      parameterForm,
-      parameterCookie,
-      requestBody,
-      parameterPath1,
-      parameterPath2,
-      parameterPath3,
-      _default,
-    } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
       path: {
-        'parameter.path.1': parameterPath1,
-        'parameter-path-2': parameterPath2,
-        'PARAMETER-PATH-3': parameterPath3,
+        'parameter.path.1': data.parameterPath1,
+        'parameter-path-2': data.parameterPath2,
+        'PARAMETER-PATH-3': data.parameterPath3,
       },
       cookies: {
-        'PARAMETER-COOKIE': parameterCookie,
+        'PARAMETER-COOKIE': data.parameterCookie,
       },
       headers: {
-        'parameter.header': parameterHeader,
+        'parameter.header': data.parameterHeader,
       },
       query: {
-        default: _default,
-        'parameter-query': parameterQuery,
+        default: data._default,
+        'parameter-query': data.parameterQuery,
       },
       formData: {
-        parameter_form: parameterForm,
+        parameter_form: data.parameterForm,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -222,12 +200,11 @@ export class myAwesomeParametersApi {
   public static getCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['get']['req'],
   ): CancelablePromise<void> {
-    const { requestBody, parameter } = data;
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',
@@ -243,12 +220,11 @@ export class myAwesomeParametersApi {
   public static postCallWithOptionalParam(
     data: $OpenApiTs['/api/v{api-version}/parameters/']['post']['req'],
   ): CancelablePromise<void> {
-    const { parameter, requestBody } = data;
     return __request(OpenAPI, {
       method: 'POST',
       url: '/api/v{api-version}/parameters/',
       query: {
-        parameter,
+        parameter: data.parameter,
       },
       body: requestBody,
       mediaType: 'application/json',


### PR DESCRIPTION
This will prevent issues like `const { data } = data`