### PR TITLE
Add explicit type for jsr compliance

### DIFF
--- a/packages/client-core/src/cancelablePromise.ts
+++ b/packages/client-core/src/cancelablePromise.ts
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
     });
   }
 
-  get [Symbol.toStringTag]() {
+  get [Symbol.toStringTag]() : string {
     return 'Cancellable Promise';
   }
 

--- a/packages/client-core/src/cancelablePromise.ts
+++ b/packages/client-core/src/cancelablePromise.ts
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
     });
   }
 
-  get [Symbol.toStringTag]() : string {
+  get [Symbol.toStringTag](): string {
     return 'Cancellable Promise';
   }
 

--- a/packages/openapi-ts/src/templates/core/CancelablePromise.hbs
+++ b/packages/openapi-ts/src/templates/core/CancelablePromise.hbs
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_node/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_node/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr/core/CancelablePromise.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr/core/CancelablePromise.ts.snap
@@ -80,7 +80,7 @@ export class CancelablePromise<T> implements Promise<T> {
 		});
 	}
 
-	get [Symbol.toStringTag]() {
+	get [Symbol.toStringTag](): string {
 		return "Cancellable Promise";
 	}
 


### PR DESCRIPTION
We are trying to publish our client generated through openapi-ts to [jsr](https://jsr.io/). However, we run into the following error:

```sh

$ npx jsr publish --dry-run

Checking for slow types in the public API...
error[missing-explicit-return-type]: missing explicit return type in the public API
  --> /home/wendrul/windmill-dev/jsr/typescript-client/src/core/CancelablePromise.ts:83:6
   |
83 |   get [Symbol.toStringTag]() {
   |       ^^^^^^^^^^^^^^^^^^^^ this function is missing an explicit return type
   = hint: add an explicit return type to the function

  info: all functions in the public API must have an explicit return type
  docs: https://jsr.io/go/slow-type-missing-explicit-return-type
...
```

After doing this change the publish command succeeds.

For more info about jsr: https://jsr.io/#why-jsr
