### PR TITLE
fix: escape keys in schemas starting with digit but and containing non-digit characters

### DIFF
--- a/.changeset/few-chefs-tell.md
+++ b/.changeset/few-chefs-tell.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: escape keys in schemas starting with digit but containing non-digit characters

--- a/examples/openapi-ts-axios/package.json
+++ b/examples/openapi-ts-axios/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "openapi-ts": "openapi-ts",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hey-api/client-axios": "workspace:*",

--- a/examples/openapi-ts-fetch/package.json
+++ b/examples/openapi-ts-fetch/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "openapi-ts": "openapi-ts",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hey-api/client-fetch": "workspace:*",

--- a/packages/openapi-ts/src/compiler/types.ts
+++ b/packages/openapi-ts/src/compiler/types.ts
@@ -111,6 +111,14 @@ export const createObjectType = <T extends object>({
       }
       // Check key value equality before possibly modifying it
       const hasShorthandSupport = key === value;
+      if (
+        key.match(/^[0-9]/) &&
+        key.match(/\D+/g) &&
+        !key.startsWith("'") &&
+        !key.endsWith("'")
+      ) {
+        key = `'${key}'`;
+      }
       if (key.match(/\W/g) && !key.startsWith("'") && !key.endsWith("'")) {
         key = `'${key}'`;
       }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/schemas.gen.ts.snap
@@ -167,7 +167,7 @@ export const $ArrayWithProperties = {
     items: {
         type: 'object',
         properties: {
-            foo: {
+            '16x16': {
                 '$ref': '#/components/schemas/camelCaseCommentWithBreaks'
             },
             bar: {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/types.gen.ts.snap
@@ -134,7 +134,7 @@ export type ArrayWithArray = Array<Array<ModelWithString>>;
  * This is a simple array with properties
  */
 export type ArrayWithProperties = Array<{
-    foo?: camelCaseCommentWithBreaks;
+    '16x16'?: camelCaseCommentWithBreaks;
     bar?: string;
 }>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/types.gen.ts.snap
@@ -134,7 +134,7 @@ export type ArrayWithArray = Array<Array<ModelWithString>>;
  * This is a simple array with properties
  */
 export type ArrayWithProperties = Array<{
-    foo?: camelCaseCommentWithBreaks;
+    '16x16'?: camelCaseCommentWithBreaks;
     bar?: string;
 }>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/types.gen.ts.snap
@@ -134,7 +134,7 @@ export type ArrayWithArray = Array<Array<ModelWithString>>;
  * This is a simple array with properties
  */
 export type ArrayWithProperties = Array<{
-    foo?: camelCaseCommentWithBreaks;
+    '16x16'?: camelCaseCommentWithBreaks;
     bar?: string;
 }>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/types.gen.ts.snap
@@ -134,7 +134,7 @@ export type ArrayWithArray = Array<Array<ModelWithString>>;
  * This is a simple array with properties
  */
 export type ArrayWithProperties = Array<{
-    foo?: camelCaseCommentWithBreaks;
+    '16x16'?: camelCaseCommentWithBreaks;
     bar?: string;
 }>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/types.gen.ts.snap
@@ -134,7 +134,7 @@ export type ArrayWithArray = Array<Array<ModelWithString>>;
  * This is a simple array with properties
  */
 export type ArrayWithProperties = Array<{
-    foo?: camelCaseCommentWithBreaks;
+    '16x16'?: camelCaseCommentWithBreaks;
     bar?: string;
 }>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_pascalcase/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_pascalcase/types.gen.ts.snap
@@ -12,6 +12,6 @@ export type CamelCaseCommentWithBreaks = number;
  * This is a simple array with properties
  */
 export type ArrayWithProperties = Array<{
-    foo?: CamelCaseCommentWithBreaks;
+    '16x16'?: CamelCaseCommentWithBreaks;
     bar?: string;
 }>;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_schemas_form/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_schemas_form/schemas.gen.ts.snap
@@ -133,7 +133,7 @@ export const $ArrayWithProperties = {
     items: {
         type: 'object',
         properties: {
-            foo: {
+            '16x16': {
                 '$ref': '#/components/schemas/camelCaseCommentWithBreaks'
             },
             bar: {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_schemas_json/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_schemas_json/schemas.gen.ts.snap
@@ -167,7 +167,7 @@ export const $ArrayWithProperties = {
     items: {
         type: 'object',
         properties: {
-            foo: {
+            '16x16': {
                 '$ref': '#/components/schemas/camelCaseCommentWithBreaks'
             },
             bar: {

--- a/packages/openapi-ts/test/sample.cjs
+++ b/packages/openapi-ts/test/sample.cjs
@@ -8,7 +8,7 @@ const main = async () => {
     input: './test/spec/v3.json',
     output: './test/generated/v3/',
     schemas: {
-      export: false,
+      // export: false,
     },
     services: {
       // export: false,

--- a/packages/openapi-ts/test/spec/v3.json
+++ b/packages/openapi-ts/test/spec/v3.json
@@ -1797,7 +1797,7 @@
         "items": {
           "type": "object",
           "properties": {
-            "foo": {
+            "16x16": {
               "$ref": "#/components/schemas/camelCaseCommentWithBreaks"
             },
             "bar": {


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/496