### PR TITLE
fix: do not export inline enums

### DIFF
--- a/.changeset/modern-teachers-peel.md
+++ b/.changeset/modern-teachers-peel.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: do not export inline enums

--- a/packages/openapi-ts/src/utils/write/types.ts
+++ b/packages/openapi-ts/src/utils/write/types.ts
@@ -44,7 +44,16 @@ const processComposition = (client: Client, model: Model, onNode: OnNode) => {
   model.enums.forEach((enumerator) => processEnum(client, enumerator, onNode));
 };
 
-const processEnum = (client: Client, model: Model, onNode: OnNode) => {
+const processEnum = (
+  client: Client,
+  model: Model,
+  onNode: OnNode,
+  isExported: boolean = false,
+) => {
+  if (!isExported) {
+    return;
+  }
+
   const config = getConfig();
 
   const properties: Record<string | number, unknown> = {};
@@ -123,7 +132,7 @@ const processModel = (client: Client, model: Model, onNode: OnNode) => {
     case 'interface':
       return processComposition(client, model, onNode);
     case 'enum':
-      return processEnum(client, model, onNode);
+      return processEnum(client, model, onNode, true);
     default:
       return processType(client, model, onNode);
   }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/types.gen.ts.snap
@@ -244,16 +244,6 @@ export type ModelWithEnum = {
 };
 
 /**
- * This is a simple enum with strings
- */
-export type test = 'Success' | 'Warning' | 'Error' | 'ØÆÅ字符串';
-
-/**
- * These are the HTTP error code enums
- */
-export type statusCode = '100' | '200 FOO' | '300 FOO_BAR' | '400 foo-bar' | '500 foo.bar' | '600 foo&bar';
-
-/**
  * This is a model with one enum
  */
 export type ModelWithEnumFromDescription = {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/types.gen.ts.snap
@@ -280,11 +280,6 @@ export type ModelWithNullableString = {
 };
 
 /**
- * This is a simple enum with strings
- */
-export type foo_bar_enum_ = 'Success' | 'Warning' | 'Error' | 'ØÆÅ字符串';
-
-/**
  * This is a model with one enum
  */
 export type ModelWithEnum = {
@@ -303,18 +298,11 @@ export type ModelWithEnum = {
 };
 
 /**
- * These are the HTTP error code enums
- */
-export type statusCode = '100' | '200 FOO' | '300 FOO_BAR' | '400 foo-bar' | '500 foo.bar' | '600 foo&bar';
-
-/**
  * This is a model with one enum with escaped name
  */
 export type ModelWithEnumWithHyphen = {
     'foo-bar-baz-qux'?: '3.0';
 };
-
-export type foo_bar_baz_qux_ = '3.0';
 
 /**
  * This is a model with one enum
@@ -728,8 +716,6 @@ export type ModelWithOneOfEnum = {
     foo: 'Corge';
 };
 
-export type foo = 'Bar';
-
 export type ModelWithNestedArrayEnumsDataFoo = 'foo' | 'bar';
 
 export type ModelWithNestedArrayEnumsDataBar = 'baz' | 'qux';
@@ -787,11 +773,6 @@ export type ModelWithNumericEnumUnion = {
      */
     value?: -10 | -1 | 0 | 1 | 3 | 6 | 12;
 };
-
-/**
- * Период
- */
-export type value = -10 | -1 | 0 | 1 | 3 | 6 | 12;
 
 /**
  * Some description with `back ticks`

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/types.gen.ts.snap
@@ -280,11 +280,6 @@ export type ModelWithNullableString = {
 };
 
 /**
- * This is a simple enum with strings
- */
-export type foo_bar_enum_ = 'Success' | 'Warning' | 'Error' | 'ØÆÅ字符串';
-
-/**
  * This is a model with one enum
  */
 export type ModelWithEnum = {
@@ -303,18 +298,11 @@ export type ModelWithEnum = {
 };
 
 /**
- * These are the HTTP error code enums
- */
-export type statusCode = '100' | '200 FOO' | '300 FOO_BAR' | '400 foo-bar' | '500 foo.bar' | '600 foo&bar';
-
-/**
  * This is a model with one enum with escaped name
  */
 export type ModelWithEnumWithHyphen = {
     'foo-bar-baz-qux'?: '3.0';
 };
-
-export type foo_bar_baz_qux_ = '3.0';
 
 /**
  * This is a model with one enum
@@ -728,8 +716,6 @@ export type ModelWithOneOfEnum = {
     foo: 'Corge';
 };
 
-export type foo = 'Bar';
-
 export type ModelWithNestedArrayEnumsDataFoo = 'foo' | 'bar';
 
 export type ModelWithNestedArrayEnumsDataBar = 'baz' | 'qux';
@@ -787,11 +773,6 @@ export type ModelWithNumericEnumUnion = {
      */
     value?: -10 | -1 | 0 | 1 | 3 | 6 | 12;
 };
-
-/**
- * Период
- */
-export type value = -10 | -1 | 0 | 1 | 3 | 6 | 12;
 
 /**
  * Some description with `back ticks`

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/types.gen.ts.snap
@@ -280,11 +280,6 @@ export type ModelWithNullableString = {
 };
 
 /**
- * This is a simple enum with strings
- */
-export type foo_bar_enum_ = 'Success' | 'Warning' | 'Error' | 'ØÆÅ字符串';
-
-/**
  * This is a model with one enum
  */
 export type ModelWithEnum = {
@@ -303,18 +298,11 @@ export type ModelWithEnum = {
 };
 
 /**
- * These are the HTTP error code enums
- */
-export type statusCode = '100' | '200 FOO' | '300 FOO_BAR' | '400 foo-bar' | '500 foo.bar' | '600 foo&bar';
-
-/**
  * This is a model with one enum with escaped name
  */
 export type ModelWithEnumWithHyphen = {
     'foo-bar-baz-qux'?: '3.0';
 };
-
-export type foo_bar_baz_qux_ = '3.0';
 
 /**
  * This is a model with one enum
@@ -728,8 +716,6 @@ export type ModelWithOneOfEnum = {
     foo: 'Corge';
 };
 
-export type foo = 'Bar';
-
 export type ModelWithNestedArrayEnumsDataFoo = 'foo' | 'bar';
 
 export type ModelWithNestedArrayEnumsDataBar = 'baz' | 'qux';
@@ -787,11 +773,6 @@ export type ModelWithNumericEnumUnion = {
      */
     value?: -10 | -1 | 0 | 1 | 3 | 6 | 12;
 };
-
-/**
- * Период
- */
-export type value = -10 | -1 | 0 | 1 | 3 | 6 | 12;
 
 /**
  * Some description with `back ticks`

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/types.gen.ts.snap
@@ -280,11 +280,6 @@ export type ModelWithNullableString = {
 };
 
 /**
- * This is a simple enum with strings
- */
-export type foo_bar_enum_ = 'Success' | 'Warning' | 'Error' | 'ØÆÅ字符串';
-
-/**
  * This is a model with one enum
  */
 export type ModelWithEnum = {
@@ -303,18 +298,11 @@ export type ModelWithEnum = {
 };
 
 /**
- * These are the HTTP error code enums
- */
-export type statusCode = '100' | '200 FOO' | '300 FOO_BAR' | '400 foo-bar' | '500 foo.bar' | '600 foo&bar';
-
-/**
  * This is a model with one enum with escaped name
  */
 export type ModelWithEnumWithHyphen = {
     'foo-bar-baz-qux'?: '3.0';
 };
-
-export type foo_bar_baz_qux_ = '3.0';
 
 /**
  * This is a model with one enum
@@ -728,8 +716,6 @@ export type ModelWithOneOfEnum = {
     foo: 'Corge';
 };
 
-export type foo = 'Bar';
-
 export type ModelWithNestedArrayEnumsDataFoo = 'foo' | 'bar';
 
 export type ModelWithNestedArrayEnumsDataBar = 'baz' | 'qux';
@@ -787,11 +773,6 @@ export type ModelWithNumericEnumUnion = {
      */
     value?: -10 | -1 | 0 | 1 | 3 | 6 | 12;
 };
-
-/**
- * Период
- */
-export type value = -10 | -1 | 0 | 1 | 3 | 6 | 12;
 
 /**
  * Some description with `back ticks`

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_models/types.gen.ts.snap
@@ -280,11 +280,6 @@ export type ModelWithNullableString = {
 };
 
 /**
- * This is a simple enum with strings
- */
-export type foo_bar_enum_ = 'Success' | 'Warning' | 'Error' | 'ØÆÅ字符串';
-
-/**
  * This is a model with one enum
  */
 export type ModelWithEnum = {
@@ -303,18 +298,11 @@ export type ModelWithEnum = {
 };
 
 /**
- * These are the HTTP error code enums
- */
-export type statusCode = '100' | '200 FOO' | '300 FOO_BAR' | '400 foo-bar' | '500 foo.bar' | '600 foo&bar';
-
-/**
  * This is a model with one enum with escaped name
  */
 export type ModelWithEnumWithHyphen = {
     'foo-bar-baz-qux'?: '3.0';
 };
-
-export type foo_bar_baz_qux_ = '3.0';
 
 /**
  * This is a model with one enum
@@ -728,8 +716,6 @@ export type ModelWithOneOfEnum = {
     foo: 'Corge';
 };
 
-export type foo = 'Bar';
-
 export type ModelWithNestedArrayEnumsDataFoo = 'foo' | 'bar';
 
 export type ModelWithNestedArrayEnumsDataBar = 'baz' | 'qux';
@@ -787,11 +773,6 @@ export type ModelWithNumericEnumUnion = {
      */
     value?: -10 | -1 | 0 | 1 | 3 | 6 | 12;
 };
-
-/**
- * Период
- */
-export type value = -10 | -1 | 0 | 1 | 3 | 6 | 12;
 
 /**
  * Some description with `back ticks`


### PR DESCRIPTION
This is causing issues in builds. These types do not need to be exported as they are inlined in other types.