### PR TITLE
fix: transform service name when generating named client

### DIFF
--- a/.changeset/silent-bananas-study.md
+++ b/.changeset/silent-bananas-study.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: transform service name when generating named client

--- a/packages/openapi-ts/src/templates/client.hbs
+++ b/packages/openapi-ts/src/templates/client.hbs
@@ -57,7 +57,7 @@ type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
 export class {{{@root.$config.name}}} {
 
 	{{#each services}}
-	public readonly {{{camelCase name}}}: {{{transformServiceName name}}};
+	public readonly {{{camelCase (transformServiceName name)}}}: {{{transformServiceName name}}};
 	{{/each}}
 
 	public readonly request: BaseHttpRequest;
@@ -80,7 +80,7 @@ export class {{{@root.$config.name}}} {
 		});
 
 		{{#each services}}
-		this.{{{camelCase name}}} = new {{{transformServiceName name}}}(this.request);
+		this.{{{camelCase (transformServiceName name)}}} = new {{{transformServiceName name}}}(this.request);
 		{{/each}}
 	}
 }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/ApiClient.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/ApiClient.ts.snap
@@ -31,29 +31,29 @@ type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
 
 export class ApiClient {
 
-	public readonly collectionFormat: CollectionFormatService;
-	public readonly complex: ComplexService;
-	public readonly default: DefaultService;
-	public readonly defaults: DefaultsService;
-	public readonly deprecated: DeprecatedService;
-	public readonly descriptions: DescriptionsService;
-	public readonly duplicate: DuplicateService;
-	public readonly error: ErrorService;
-	public readonly fileResponse: FileResponseService;
-	public readonly formData: FormDataService;
-	public readonly header: HeaderService;
-	public readonly multipart: MultipartService;
-	public readonly multipleTags1: MultipleTags1Service;
-	public readonly multipleTags2: MultipleTags2Service;
-	public readonly multipleTags3: MultipleTags3Service;
-	public readonly noContent: NoContentService;
-	public readonly nonAsciiÆøåÆøÅöôêÊ: NonAsciiÆøåÆøÅöôêÊService;
-	public readonly parameters: ParametersService;
-	public readonly requestBody: RequestBodyService;
-	public readonly response: ResponseService;
-	public readonly simple: SimpleService;
-	public readonly types: TypesService;
-	public readonly upload: UploadService;
+	public readonly collectionFormatService: CollectionFormatService;
+	public readonly complexService: ComplexService;
+	public readonly defaultService: DefaultService;
+	public readonly defaultsService: DefaultsService;
+	public readonly deprecatedService: DeprecatedService;
+	public readonly descriptionsService: DescriptionsService;
+	public readonly duplicateService: DuplicateService;
+	public readonly errorService: ErrorService;
+	public readonly fileResponseService: FileResponseService;
+	public readonly formDataService: FormDataService;
+	public readonly headerService: HeaderService;
+	public readonly multipartService: MultipartService;
+	public readonly multipleTags1Service: MultipleTags1Service;
+	public readonly multipleTags2Service: MultipleTags2Service;
+	public readonly multipleTags3Service: MultipleTags3Service;
+	public readonly noContentService: NoContentService;
+	public readonly nonAsciiÆøåÆøÅöôêÊservice: NonAsciiÆøåÆøÅöôêÊService;
+	public readonly parametersService: ParametersService;
+	public readonly requestBodyService: RequestBodyService;
+	public readonly responseService: ResponseService;
+	public readonly simpleService: SimpleService;
+	public readonly typesService: TypesService;
+	public readonly uploadService: UploadService;
 
 	public readonly request: BaseHttpRequest;
 
@@ -74,28 +74,28 @@ export class ApiClient {
       },
 		});
 
-		this.collectionFormat = new CollectionFormatService(this.request);
-		this.complex = new ComplexService(this.request);
-		this.default = new DefaultService(this.request);
-		this.defaults = new DefaultsService(this.request);
-		this.deprecated = new DeprecatedService(this.request);
-		this.descriptions = new DescriptionsService(this.request);
-		this.duplicate = new DuplicateService(this.request);
-		this.error = new ErrorService(this.request);
-		this.fileResponse = new FileResponseService(this.request);
-		this.formData = new FormDataService(this.request);
-		this.header = new HeaderService(this.request);
-		this.multipart = new MultipartService(this.request);
-		this.multipleTags1 = new MultipleTags1Service(this.request);
-		this.multipleTags2 = new MultipleTags2Service(this.request);
-		this.multipleTags3 = new MultipleTags3Service(this.request);
-		this.noContent = new NoContentService(this.request);
-		this.nonAsciiÆøåÆøÅöôêÊ = new NonAsciiÆøåÆøÅöôêÊService(this.request);
-		this.parameters = new ParametersService(this.request);
-		this.requestBody = new RequestBodyService(this.request);
-		this.response = new ResponseService(this.request);
-		this.simple = new SimpleService(this.request);
-		this.types = new TypesService(this.request);
-		this.upload = new UploadService(this.request);
+		this.collectionFormatService = new CollectionFormatService(this.request);
+		this.complexService = new ComplexService(this.request);
+		this.defaultService = new DefaultService(this.request);
+		this.defaultsService = new DefaultsService(this.request);
+		this.deprecatedService = new DeprecatedService(this.request);
+		this.descriptionsService = new DescriptionsService(this.request);
+		this.duplicateService = new DuplicateService(this.request);
+		this.errorService = new ErrorService(this.request);
+		this.fileResponseService = new FileResponseService(this.request);
+		this.formDataService = new FormDataService(this.request);
+		this.headerService = new HeaderService(this.request);
+		this.multipartService = new MultipartService(this.request);
+		this.multipleTags1Service = new MultipleTags1Service(this.request);
+		this.multipleTags2Service = new MultipleTags2Service(this.request);
+		this.multipleTags3Service = new MultipleTags3Service(this.request);
+		this.noContentService = new NoContentService(this.request);
+		this.nonAsciiÆøåÆøÅöôêÊservice = new NonAsciiÆøåÆøÅöôêÊService(this.request);
+		this.parametersService = new ParametersService(this.request);
+		this.requestBodyService = new RequestBodyService(this.request);
+		this.responseService = new ResponseService(this.request);
+		this.simpleService = new SimpleService(this.request);
+		this.typesService = new TypesService(this.request);
+		this.uploadService = new UploadService(this.request);
 	}
 }

--- a/packages/openapi-ts/test/e2e/client.axios.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.axios.spec.ts
@@ -25,7 +25,7 @@ describe('client.axios', () => {
       TOKEN: tokenRequest,
       USERNAME: undefined
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
     // @ts-ignore
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
@@ -38,7 +38,7 @@ describe('client.axios', () => {
       TOKEN: undefined,
       USERNAME: 'username'
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     // @ts-ignore
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
@@ -47,7 +47,7 @@ describe('client.axios', () => {
     const { ApiClient } = await import('./generated/client/axios/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.complex.complexTypes({
+    const result = await client.complexService.complexTypes({
       first: {
         second: {
           third: 'Hello World!'
@@ -61,7 +61,7 @@ describe('client.axios', () => {
     const { ApiClient } = await import('./generated/client/axios/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.parameters.callWithParameters(
+    const result = await client.parametersService.callWithParameters(
       'valueHeader',
       'valueQuery',
       'valueForm',
@@ -79,7 +79,7 @@ describe('client.axios', () => {
     try {
       const { ApiClient } = await import('./generated/client/axios/index.js')
       const client = new ApiClient()
-      const promise = client.simple.getCallWithoutParametersAndResponse()
+      const promise = client.simpleService.getCallWithoutParametersAndResponse()
       setTimeout(() => {
         promise.cancel()
       }, 10)
@@ -95,7 +95,7 @@ describe('client.axios', () => {
     try {
       const { ApiClient } = await import('./generated/client/axios/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(500)
+      await client.errorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,
@@ -126,7 +126,7 @@ describe('client.axios', () => {
     try {
       const { ApiClient } = await import('./generated/client/axios/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(599)
+      await client.errorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,

--- a/packages/openapi-ts/test/e2e/client.fetch.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.fetch.spec.ts
@@ -25,7 +25,7 @@ describe('client.fetch', () => {
       TOKEN: tokenRequest,
       USERNAME: undefined
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     // @ts-ignore
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
@@ -37,7 +37,7 @@ describe('client.fetch', () => {
       TOKEN: undefined,
       USERNAME: 'username'
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     // @ts-ignore
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
@@ -46,7 +46,7 @@ describe('client.fetch', () => {
     const { ApiClient } = await import('./generated/client/fetch/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.complex.complexTypes({
+    const result = await client.complexService.complexTypes({
       first: {
         second: {
           third: 'Hello World!'
@@ -60,7 +60,7 @@ describe('client.fetch', () => {
     const { ApiClient } = await import('./generated/client/fetch/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.parameters.callWithParameters(
+    const result = await client.parametersService.callWithParameters(
       'valueHeader',
       'valueQuery',
       'valueForm',
@@ -76,7 +76,7 @@ describe('client.fetch', () => {
   it('support blob response data', async () => {
     const { ApiClient } = await import('./generated/client/fetch/index.js')
     const client = new ApiClient()
-    const result = await client.fileResponse.fileResponse('test')
+    const result = await client.fileResponseService.fileResponse('test')
     expect(result).toBeDefined()
   })
 
@@ -85,7 +85,7 @@ describe('client.fetch', () => {
     try {
       const { ApiClient } = await import('./generated/client/fetch/index.js')
       const client = new ApiClient()
-      const promise = client.simple.getCallWithoutParametersAndResponse()
+      const promise = client.simpleService.getCallWithoutParametersAndResponse()
       setTimeout(() => {
         promise.cancel()
       }, 10)
@@ -101,7 +101,7 @@ describe('client.fetch', () => {
     try {
       const { ApiClient } = await import('./generated/client/fetch/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(500)
+      await client.errorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,
@@ -132,7 +132,7 @@ describe('client.fetch', () => {
     try {
       const { ApiClient } = await import('./generated/client/fetch/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(599)
+      await client.errorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,
@@ -162,7 +162,7 @@ describe('client.fetch', () => {
   it('it should parse query params', async () => {
     const { ApiClient } = await import('./generated/client/fetch/index.js')
     const client = new ApiClient()
-    const result = await client.parameters.postCallWithOptionalParam({
+    const result = await client.parametersService.postCallWithOptionalParam({
       page: 0,
       size: 1,
       sort: ['location']

--- a/packages/openapi-ts/test/e2e/client.node.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.node.spec.ts
@@ -25,7 +25,7 @@ describe('client.node', () => {
       TOKEN: tokenRequest,
       USERNAME: undefined
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
     // @ts-ignore
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
@@ -38,7 +38,7 @@ describe('client.node', () => {
       TOKEN: undefined,
       USERNAME: 'username'
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     // @ts-ignore
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
@@ -47,7 +47,7 @@ describe('client.node', () => {
     const { ApiClient } = await import('./generated/client/node/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.complex.complexTypes({
+    const result = await client.complexService.complexTypes({
       first: {
         second: {
           third: 'Hello World!'
@@ -61,7 +61,7 @@ describe('client.node', () => {
     const { ApiClient } = await import('./generated/client/node/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.parameters.callWithParameters(
+    const result = await client.parametersService.callWithParameters(
       'valueHeader',
       'valueQuery',
       'valueForm',
@@ -79,7 +79,7 @@ describe('client.node', () => {
     try {
       const { ApiClient } = await import('./generated/client/node/index.js')
       const client = new ApiClient()
-      const promise = client.simple.getCallWithoutParametersAndResponse()
+      const promise = client.simpleService.getCallWithoutParametersAndResponse()
       setTimeout(() => {
         promise.cancel()
       }, 10)
@@ -95,7 +95,7 @@ describe('client.node', () => {
     try {
       const { ApiClient } = await import('./generated/client/node/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(500)
+      await client.errorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,
@@ -126,7 +126,7 @@ describe('client.node', () => {
     try {
       const { ApiClient } = await import('./generated/client/node/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(599)
+      await client.errorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,

--- a/packages/openapi-ts/test/e2e/client.xhr.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.xhr.spec.ts
@@ -25,7 +25,7 @@ describe.skip('client.xhr', () => {
       TOKEN: tokenRequest,
       USERNAME: undefined
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     // @ts-ignore
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
@@ -37,7 +37,7 @@ describe.skip('client.xhr', () => {
       TOKEN: undefined,
       USERNAME: 'username'
     })
-    const result = await client.simple.getCallWithoutParametersAndResponse()
+    const result = await client.simpleService.getCallWithoutParametersAndResponse()
     // @ts-ignore
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
@@ -46,7 +46,7 @@ describe.skip('client.xhr', () => {
     const { ApiClient } = await import('./generated/client/xhr/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.complex.complexTypes({
+    const result = await client.complexService.complexTypes({
       first: {
         second: {
           third: 'Hello World!'
@@ -60,7 +60,7 @@ describe.skip('client.xhr', () => {
     const { ApiClient } = await import('./generated/client/xhr/index.js')
     const client = new ApiClient()
     // @ts-ignore
-    const result = await client.parameters.callWithParameters(
+    const result = await client.parametersService.callWithParameters(
       'valueHeader',
       'valueQuery',
       'valueForm',
@@ -78,7 +78,7 @@ describe.skip('client.xhr', () => {
     try {
       const { ApiClient } = await import('./generated/client/xhr/index.js')
       const client = new ApiClient()
-      const promise = client.simple.getCallWithoutParametersAndResponse()
+      const promise = client.simpleService.getCallWithoutParametersAndResponse()
       setTimeout(() => {
         promise.cancel()
       }, 10)
@@ -94,7 +94,7 @@ describe.skip('client.xhr', () => {
     try {
       const { ApiClient } = await import('./generated/client/xhr/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(500)
+      await client.errorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,
@@ -125,7 +125,7 @@ describe.skip('client.xhr', () => {
     try {
       const { ApiClient } = await import('./generated/client/xhr/index.js')
       const client = new ApiClient()
-      await client.error.testErrorCode(599)
+      await client.errorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
         body: err.body,


### PR DESCRIPTION
closes: #517 and #479 