### PR TITLE
Allow typescript dependency in peerDependencies

### DIFF
--- a/.changeset/wet-keys-allow.md
+++ b/.changeset/wet-keys-allow.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": minor
+---
+
+fix: Support typescript in peerDependencies

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docs": "pnpm --filter @hey-api/docs --",
     "example": "sh ./scripts/example.sh",
     "format": "prettier --write .",
-    "lint:fix": "prettier --check . && eslint . --fix",
+    "lint:fix": "prettier --check --write . && eslint . --fix",
     "lint": "prettier --check . && eslint .",
     "openapi-ts": "pnpm --filter @hey-api/openapi-ts --",
     "prepare": "husky",

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -200,10 +200,14 @@ const getTypes = (userConfig: UserConfig): Config['types'] => {
 
 const getInstalledDependencies = (): Dependencies => {
   const toReducedDependencies = (p: PackageDependencies): Dependencies =>
-    [p.dependencies ?? {}, p.devDependencies ?? {}, p.peerDependencies ?? {}].reduce(
+    [
+      p.dependencies ?? {},
+      p.devDependencies ?? {},
+      p.peerDependencies ?? {},
+    ].reduce(
       (acc, deps) => ({
         ...acc,
-        ...deps
+        ...deps,
       }),
       {},
     );

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -17,6 +17,7 @@ type Dependencies = Record<string, unknown>;
 type PackageDependencies = {
   dependencies?: Dependencies;
   devDependencies?: Dependencies;
+  peerDependencies?: Dependencies;
 };
 
 // Dependencies used in each client. User must have installed these to use the generated client

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -199,10 +199,11 @@ const getTypes = (userConfig: UserConfig): Config['types'] => {
 
 const getInstalledDependencies = (): Dependencies => {
   const toReducedDependencies = (p: PackageDependencies): Dependencies =>
-    [p.dependencies ?? {}, p.devDependencies ?? {}].reduce(
-      (deps, devDeps) => ({
+    [p.dependencies ?? {}, p.devDependencies ?? {}, p.peerDependencies ?? {}].reduce(
+      (deps, devDeps, peerDeps) => ({
         ...deps,
         ...devDeps,
+        ...peerDeps
       }),
       {},
     );

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -200,10 +200,9 @@ const getTypes = (userConfig: UserConfig): Config['types'] => {
 const getInstalledDependencies = (): Dependencies => {
   const toReducedDependencies = (p: PackageDependencies): Dependencies =>
     [p.dependencies ?? {}, p.devDependencies ?? {}, p.peerDependencies ?? {}].reduce(
-      (deps, devDeps, peerDeps) => ({
-        ...deps,
-        ...devDeps,
-        ...peerDeps
+      (acc, deps) => ({
+        ...acc,
+        ...deps
       }),
       {},
     );


### PR DESCRIPTION
My package.json looks like this. The `api-client` package a local yarn workspace package in this case. Typescript is supplied via a root `package.json` file in a parent directory and is available this way.

This MR allows these kinds of setups without throwing an error:

```json
{
  "name": "api-client",
  "private": true,
  "scripts": {...},
  "devDependencies": {
    "@hey-api/openapi-ts": "0.43.2",
    "js-cookie": "3.0.5"
  },
  "peerDependencies": {
    "axios": ">=1.6.5",
    "typescript": ">=5.4.5"
  }
}
```