### PR TITLE
fix: generate the correct error types instead of unknown

### DIFF
--- a/packages/openapi-ts/src/utils/write/types.ts
+++ b/packages/openapi-ts/src/utils/write/types.ts
@@ -360,7 +360,7 @@ const processServiceTypes = (client: Client, onNode: OnNode) => {
         });
 
         if (isStandaloneClient(config)) {
-          const errorResults = getErrorResponses(operation.results);
+          const errorResults = getErrorResponses(operation.errors);
           // create type export for operation error
           generateType({
             client,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch/types.gen.ts.snap
@@ -1281,7 +1281,7 @@ export type CallWithResponseError = unknown;
 
 export type CallWithDuplicateResponsesResponse = ModelWithBoolean & ModelWithInteger | ModelWithString;
 
-export type CallWithDuplicateResponsesError = unknown;
+export type CallWithDuplicateResponsesError = ModelWithStringError & DictionaryWithArray;
 
 export type CallWithResponsesResponse = {
     readonly '@namespace.string'?: string;
@@ -1289,7 +1289,7 @@ export type CallWithResponsesResponse = {
     readonly value?: Array<ModelWithString>;
 } | ModelThatExtends | ModelThatExtendsExtends;
 
-export type CallWithResponsesError = unknown;
+export type CallWithResponsesError = ModelWithStringError;
 
 export type CollectionFormatData = {
     query: {


### PR DESCRIPTION
Hi, I'm not sure if it was just a typo but this pull request fixes #641 for me. 