### PR TITLE
Fix discovered issues with types+transform output

### DIFF
--- a/.changeset/old-waves-taste.md
+++ b/.changeset/old-waves-taste.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+Fix an issue where transforms for endpoints with array returns were not generated correctly

--- a/packages/openapi-ts/src/compiler/index.ts
+++ b/packages/openapi-ts/src/compiler/index.ts
@@ -141,6 +141,7 @@ export const compiler = {
     dateTransformMutation: transform.createDateTransformMutation,
     mapArray: transform.createArrayMapTransform,
     newDate: transform.createDateTransformerExpression,
+    responseArrayTransform: transform.createResponseArrayTransform,
     transformItem: transform.createFunctionTransformMutation,
     transformMutationFunction: transform.createTransformMutationFunction,
   },

--- a/packages/openapi-ts/src/compiler/transform.ts
+++ b/packages/openapi-ts/src/compiler/transform.ts
@@ -258,3 +258,77 @@ export const createAlias = ({
       ts.NodeFlags.Const,
     ),
   );
+
+export const createResponseArrayTransform = ({
+  transform,
+  name,
+}: {
+  transform: string;
+  name: string;
+}) => {
+  const transformFunction = ts.factory.createArrowFunction(
+    undefined,
+    undefined,
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        ts.factory.createIdentifier('data'),
+        undefined,
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+        undefined,
+      ),
+    ],
+    undefined,
+    ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+    ts.factory.createBlock(
+      [
+        ts.factory.createIfStatement(
+          ts.factory.createCallExpression(
+            ts.factory.createPropertyAccessExpression(
+              ts.factory.createIdentifier('Array'),
+              ts.factory.createIdentifier('isArray'),
+            ),
+            undefined,
+            [ts.factory.createIdentifier('data')],
+          ),
+          ts.factory.createBlock(
+            [
+              ts.factory.createExpressionStatement(
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createIdentifier('data'),
+                    ts.factory.createIdentifier('forEach'),
+                  ),
+                  undefined,
+                  [ts.factory.createIdentifier(transform)],
+                ),
+              ),
+            ],
+            true,
+          ),
+          undefined,
+        ),
+        ts.factory.createReturnStatement(ts.factory.createIdentifier('data')),
+      ],
+      true,
+    ),
+  );
+
+  const declaration = ts.factory.createVariableStatement(
+    [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          ts.factory.createIdentifier(name),
+          undefined,
+          undefined,
+          transformFunction,
+        ),
+      ],
+      ts.NodeFlags.Const,
+    ),
+  );
+
+  return declaration;
+};

--- a/packages/openapi-ts/src/utils/write/types.ts
+++ b/packages/openapi-ts/src/utils/write/types.ts
@@ -366,16 +366,28 @@ const processServiceTypes = (client: Client, onNode: OnNode) => {
 
         if (config.types.dates === 'types+transform') {
           if (responses.length === 1) {
-            if (client.types[responses[0].type]?.hasTransformer) {
+            const response = responses[0];
+
+            if (client.types[response.type]?.hasTransformer) {
               const name = operationResponseTypeName(operation.name);
-              const transformAlias = compiler.transform.alias({
-                existingName: responses[0].type,
-                name,
-              });
+
+              if (response.export === 'array') {
+                const arrayTransformer =
+                  compiler.transform.responseArrayTransform({
+                    name,
+                    transform: response.type,
+                  });
+                onNode(arrayTransformer);
+              } else {
+                const transformAlias = compiler.transform.alias({
+                  existingName: response.type,
+                  name,
+                });
+
+                onNode(transformAlias);
+              }
 
               client.types[name].hasTransformer = true;
-
-              onNode(transformAlias);
             }
           } else if (responses.length > 1) {
             console.log(

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular_transform/types.gen.ts.snap
@@ -66,7 +66,12 @@ export const ModelWithDatesResponse = ModelWithDates;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ArrayOfDatesResponse = Array<(Date)>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios_transform/types.gen.ts.snap
@@ -66,7 +66,12 @@ export const ModelWithDatesResponse = ModelWithDates;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ArrayOfDatesResponse = Array<(Date)>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client_transform/types.gen.ts.snap
@@ -66,7 +66,12 @@ export const ModelWithDatesResponse = ModelWithDates;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ArrayOfDatesResponse = Array<(Date)>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-axios_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-axios_transform/types.gen.ts.snap
@@ -68,7 +68,12 @@ export type ModelWithDatesError = unknown;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ModelWithDatesArrayError = unknown;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_transform/types.gen.ts.snap
@@ -68,7 +68,12 @@ export type ModelWithDatesError = unknown;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ModelWithDatesArrayError = unknown;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_node_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_node_transform/types.gen.ts.snap
@@ -66,7 +66,12 @@ export const ModelWithDatesResponse = ModelWithDates;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ArrayOfDatesResponse = Array<(Date)>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_transform/types.gen.ts.snap
@@ -66,7 +66,12 @@ export const ModelWithDatesResponse = ModelWithDates;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ArrayOfDatesResponse = Array<(Date)>;
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr_transform/types.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr_transform/types.gen.ts.snap
@@ -66,7 +66,12 @@ export const ModelWithDatesResponse = ModelWithDates;
 
 export type ModelWithDatesArrayResponse = Array<ModelWithDates>;
 
-export const ModelWithDatesArrayResponse = ModelWithDates;
+export const ModelWithDatesArrayResponse = (data: any) => {
+    if (Array.isArray(data)) {
+        data.forEach(ModelWithDates);
+    }
+    return data;
+};
 
 export type ArrayOfDatesResponse = Array<(Date)>;
 


### PR DESCRIPTION
Just fixing 1 issue. Models get transforms, but response model aliasing didn't account for responses being arrays of models. We now have a transform for arrays too