### PR TITLE
fix: make getHeaders() accept generic

### DIFF
--- a/.changeset/brave-eyes-suffer.md
+++ b/.changeset/brave-eyes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: make getHeaders() accept generic

--- a/packages/client-axios/src/index.ts
+++ b/packages/client-axios/src/index.ts
@@ -60,20 +60,23 @@ export const OpenAPI: OpenAPIConfig<AxiosRequestConfig, AxiosResponse> = {
   interceptors: { request: new Interceptors(), response: new Interceptors() },
 };
 
-export const getHeaders = async (
+export const getHeaders = async <T>(
   config: OpenAPIConfig,
-  options: ApiRequestOptions,
+  options: ApiRequestOptions<T>,
 ): Promise<Record<string, string>> => {
   const [token, username, password, additionalHeaders] = await Promise.all([
+    // @ts-ignore
     resolve(options, config.TOKEN),
+    // @ts-ignore
     resolve(options, config.USERNAME),
+    // @ts-ignore
     resolve(options, config.PASSWORD),
+    // @ts-ignore
     resolve(options, config.HEADERS),
   ]);
 
   const headers = Object.entries({
     Accept: 'application/json',
-    // @ts-ignore
     ...additionalHeaders,
     ...options.headers,
   })

--- a/packages/openapi-ts/src/templates/core/angular/getHeaders.hbs
+++ b/packages/openapi-ts/src/templates/core/angular/getHeaders.hbs
@@ -1,4 +1,4 @@
-export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
+export const getHeaders = <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Observable<HttpHeaders> => {
 	return forkJoin({
 		// @ts-ignore
 		token: resolve(options, config.TOKEN),

--- a/packages/openapi-ts/src/templates/core/axios/getHeaders.hbs
+++ b/packages/openapi-ts/src/templates/core/axios/getHeaders.hbs
@@ -1,4 +1,4 @@
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Record<string, string>> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Record<string, string>> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/src/templates/core/fetch/getHeaders.hbs
+++ b/packages/openapi-ts/src/templates/core/fetch/getHeaders.hbs
@@ -1,4 +1,4 @@
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/src/templates/core/xhr/getHeaders.hbs
+++ b/packages/openapi-ts/src/templates/core/xhr/getHeaders.hbs
@@ -1,4 +1,4 @@
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular/core/request.ts.snap
@@ -114,7 +114,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
+export const getHeaders = <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Observable<HttpHeaders> => {
 	return forkJoin({
 		// @ts-ignore
 		token: resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular_transform/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_angular_transform/core/request.ts.snap
@@ -114,7 +114,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
+export const getHeaders = <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Observable<HttpHeaders> => {
 	return forkJoin({
 		// @ts-ignore
 		token: resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios/core/request.ts.snap
@@ -117,7 +117,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Record<string, string>> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Record<string, string>> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios_transform/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_axios_transform/core/request.ts.snap
@@ -117,7 +117,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Record<string, string>> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Record<string, string>> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_client_transform/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_client_transform/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_enums_typescript/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_legacy_positional_args/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_node/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_node/core/request.ts.snap
@@ -113,7 +113,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_node_transform/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_node_transform/core/request.ts.snap
@@ -113,7 +113,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_options/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_transform/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_transform/core/request.ts.snap
@@ -110,7 +110,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr/core/request.ts.snap
@@ -114,7 +114,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr_transform/core/request.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_xhr_transform/core/request.ts.snap
@@ -114,7 +114,7 @@ export const resolve = async <T>(options: ApiRequestOptions<T>, resolver?: T | R
 	return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+export const getHeaders = async <T>(config: OpenAPIConfig, options: ApiRequestOptions<T>): Promise<Headers> => {
 	const [token, username, password, additionalHeaders] = await Promise.all([
 		// @ts-ignore
 		resolve(options, config.TOKEN),


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/706