### PR TITLE
fix: use methodNameBuilder when asClass is false

### DIFF
--- a/.changeset/great-cougars-relax.md
+++ b/.changeset/great-cougars-relax.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: use methodNameBuilder when asClass is false

--- a/packages/openapi-ts/src/generate/__tests__/services.spec.ts
+++ b/packages/openapi-ts/src/generate/__tests__/services.spec.ts
@@ -143,8 +143,8 @@ describe('methodNameBuilder', () => {
     );
   });
 
-  it('call methodNameBuilder', async () => {
-    const methodNameBuilderMock = vi.fn().mockReturnValue('customName');
+  it('use methodNameBuilder when asClass is true', async () => {
+    const methodNameBuilder = vi.fn().mockReturnValue('customName');
 
     setConfig({
       client: 'fetch',
@@ -160,7 +160,7 @@ describe('methodNameBuilder', () => {
       schemas: {},
       services: {
         asClass: true,
-        methodNameBuilder: methodNameBuilderMock,
+        methodNameBuilder,
       },
       types: {},
       useOptions: false,
@@ -183,6 +183,49 @@ describe('methodNameBuilder', () => {
       expect.stringContaining('public static customName()'),
     );
 
-    expect(methodNameBuilderMock).toHaveBeenCalledWith(operation);
+    expect(methodNameBuilder).toHaveBeenCalledWith(operation);
+  });
+
+  it('use methodNameBuilder when asClass is false', async () => {
+    const methodNameBuilder = vi.fn().mockReturnValue('customName');
+
+    setConfig({
+      client: 'fetch',
+      configFile: '',
+      debug: false,
+      dryRun: false,
+      exportCore: true,
+      input: '',
+      output: {
+        path: '',
+      },
+      plugins: [],
+      schemas: {},
+      services: {
+        asClass: false,
+        methodNameBuilder,
+      },
+      types: {},
+      useOptions: false,
+    });
+
+    const file = new TypeScriptFile({
+      dir: '/',
+      name: 'services.ts',
+    });
+    const files = {
+      services: file,
+    };
+
+    await generateServices({ client, files });
+
+    file.write();
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      path.resolve('/services.gen.ts'),
+      expect.stringContaining('public static customName()'),
+    );
+
+    expect(methodNameBuilder).toHaveBeenCalledWith(operation);
   });
 });

--- a/packages/openapi-ts/src/generate/services.ts
+++ b/packages/openapi-ts/src/generate/services.ts
@@ -381,6 +381,16 @@ const toRequestOptions = (
   });
 };
 
+const toOperationName = (operation: Operation) => {
+  const config = getConfig();
+
+  if (!config.services.methodNameBuilder) {
+    return operation.name;
+  }
+
+  return config.services.methodNameBuilder(operation);
+};
+
 const toOperationStatements = (
   client: Client,
   operation: Operation,
@@ -534,7 +544,7 @@ const processService = (
       const statement = compiler.export.const({
         comment: toOperationComment(operation),
         expression,
-        name: operation.name,
+        name: toOperationName(operation),
       });
       onNode(statement);
     });
@@ -546,9 +556,7 @@ const processService = (
       accessLevel: 'public',
       comment: toOperationComment(operation),
       isStatic: config.name === undefined && config.client !== 'angular',
-      name: config.services.methodNameBuilder
-        ? config.services.methodNameBuilder(operation)
-        : operation.name,
+      name: toOperationName(operation),
       parameters: toOperationParamType(client, operation),
       returnType: isStandalone
         ? undefined


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/762