### PR TITLE
Define the axios request body to be of type any:

### DIFF
--- a/.changeset/three-dryers-arrive.md
+++ b/.changeset/three-dryers-arrive.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/client-axios': patch
+---
+
+fix: declare axios body to be unknown so that it can be set to anything

--- a/packages/client-axios/src/types.ts
+++ b/packages/client-axios/src/types.ts
@@ -23,12 +23,7 @@ export interface Config extends Omit<CreateAxiosDefaults, 'headers'> {
    *
    * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
    */
-  body?:
-    | RequestInit['body']
-    | Record<string, unknown>
-    | Array<Record<string, unknown>>
-    | Array<unknown>
-    | number;
+  body?: unknown;
   /**
    * A function for serializing request body parameter. By default,
    * {@link JSON.stringify()} will be used.

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-axios_bundle/core/types.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-axios_bundle/core/types.ts.snap
@@ -23,12 +23,7 @@ export interface Config extends Omit<CreateAxiosDefaults, 'headers'> {
    *
    * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
    */
-  body?:
-    | RequestInit['body']
-    | Record<string, unknown>
-    | Array<Record<string, unknown>>
-    | Array<unknown>
-    | number;
+  body?: unknown;
   /**
    * A function for serializing request body parameter. By default,
    * {@link JSON.stringify()} will be used.

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-axios_bundle_transform/core/types.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-axios_bundle_transform/core/types.ts.snap
@@ -23,12 +23,7 @@ export interface Config extends Omit<CreateAxiosDefaults, 'headers'> {
    *
    * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
    */
-  body?:
-    | RequestInit['body']
-    | Record<string, unknown>
-    | Array<Record<string, unknown>>
-    | Array<unknown>
-    | number;
+  body?: unknown;
   /**
    * A function for serializing request body parameter. By default,
    * {@link JSON.stringify()} will be used.


### PR DESCRIPTION
Fixes errors caused when the API request body is just a json bool. 

For example:
```
Error: src/app/client/services.gen.ts(88,159): error TS2345: Argument of type '{ url: string; data?: any; path: Record<string, unknown> & { name: string; }; method?: "connect" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "trace"; timeout?: number; ... 42 more ...; headers: { "if-match": string; }; }' is not assignable to parameter of type 'RequestOptionsBase'.
  Types of property 'body' are incompatible.
    Type 'boolean' is not assignable to type 'number | unknown[] | Record<string, unknown> | BodyInit | Record<string, unknown>[] | null | undefined'.
```