### PR TITLE
Return error with Promise.reject in `client-axios`

### DIFF
--- a/packages/client-axios/src/index.ts
+++ b/packages/client-axios/src/index.ts
@@ -57,10 +57,10 @@ export const createClient = (config: Config): Client => {
       };
     } catch (error) {
       const e = error as AxiosError;
-      return {
+      return Promise.reject({
         ...error,
         error: e.response?.data ?? {},
-      };
+      });
     }
   };
 

--- a/packages/client-axios/src/index.ts
+++ b/packages/client-axios/src/index.ts
@@ -1,9 +1,18 @@
 import axios, { AxiosError } from 'axios';
 
-import type { Client, Config, RequestOptions } from './types';
+import { type Client, type Config, type RequestOptions } from './types';
 import { createDefaultConfig, getUrl, mergeHeaders } from './utils';
 
 let globalConfig = createDefaultConfig();
+
+export class OpenApiAxiosError extends AxiosError {
+  constructor(e: AxiosError) {
+    super(e.message, e.code, e.config, e.request, e.response);
+    this.error = e.response?.data ?? {};
+  }
+
+  error: any;
+}
 
 export const createClient = (config: Config): Client => {
   const defaultConfig = createDefaultConfig();
@@ -57,10 +66,7 @@ export const createClient = (config: Config): Client => {
       };
     } catch (error) {
       const e = error as AxiosError;
-      return Promise.reject({
-        ...error,
-        error: e.response?.data ?? {},
-      });
+      return Promise.reject(new OpenApiAxiosError(e));
     }
   };
 

--- a/packages/client-axios/src/index.ts
+++ b/packages/client-axios/src/index.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 
-import { type Client, type Config, type RequestOptions } from './types';
+import type { Client, Config, RequestOptions } from './types';
 import { createDefaultConfig, getUrl, mergeHeaders } from './utils';
 
 let globalConfig = createDefaultConfig();


### PR DESCRIPTION
> [Promise.reject in axios example](https://github.com/axios/axios/blob/0e4f9fa29077ebee4499facea6be1492b42e8a26/lib/core/Axios.js#L175)

In axios, when an error occurs in a request, it returns a Promise.reject. However, in the current client-axios, it simply returns an object. We need to align this behavior to match that of axios.

This way, you can handle errors in the .catch block of the Promise, just like the behavior of axios. (It is not currently working).

---
(added)

I added an extension of AxiosError for error returns. Previously, we returned a plain object, which did not inherit AxiosError's prototype. Consequently, Axios's **isAxiosError function always returned false**. Developers expect this function to return true when checking for errors, so this also needs to be corrected.

By doing this, the prototype of AxiosError is inherited, allowing isAxiosError to pass the check. This makes error handling clearer, as isAxiosError functions as developers expect.

```ts
import axios, { AxiosError } from 'axios';

class OpenApiAxiosError extends AxiosError {
  constructor(e: AxiosError) {
    super(e.message, e.code, e.config, e.request, e.response);
    this.error = e.response?.data ?? {};
  }

  error: any;
}

axios.get('/some-endpoint')
  .then(response => {
    // handle response
  })
  .catch(error => {
    if (axios.isAxiosError(error)) {
     // handle AxiosError
    } else {
      console.error('Non-Axios error:', error);
    }
  });
```  

In the above code, if the axios.get request fails, the catch block checks the error using isAxiosError, then throws a custom error. This custom error includes all the properties and methods of AxiosError, thus maintaining the existing Axios error handling logic while adding extended functionality.

By implementing in this way, you can combine Axios's error handling with custom logic.
