### PR TITLE
export Config for typescript augmentation for consumers

### DIFF
--- a/.changeset/forty-ears-divide.md
+++ b/.changeset/forty-ears-divide.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/client-fetch': patch
+---
+
+Expose Config interface to consumers for Typescript augmentation

--- a/packages/client-fetch/src/node/index.ts
+++ b/packages/client-fetch/src/node/index.ts
@@ -1,5 +1,5 @@
 export { client, createClient } from '../';
-export type { Client, Options, RequestResult } from '../types';
+export type { Client, Config, Options, RequestResult } from '../types';
 export {
   formDataBodySerializer,
   jsonBodySerializer,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle/client.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle/client.ts.snap
@@ -1,5 +1,5 @@
 export { client, createClient } from './core/';
-export type { Client, Options, RequestResult } from './core/types';
+export type { Client, Config, Options, RequestResult } from './core/types';
 export {
   formDataBodySerializer,
   jsonBodySerializer,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle_transform/client.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle_transform/client.ts.snap
@@ -1,5 +1,5 @@
 export { client, createClient } from './core/';
-export type { Client, Options, RequestResult } from './core/types';
+export type { Client, Config, Options, RequestResult } from './core/types';
 export {
   formDataBodySerializer,
   jsonBodySerializer,


### PR DESCRIPTION
Use case example for a nextjs app.

```ts
export const getExample = (options: Options<{ path: { myId: number } }>) => {
  return (options?.client ?? client).get<ExampleData, ApiError>({
    ...options,
    url: '/api/my/endpoints/{myId}}',
    errors: {
      401: () => redirect('/login'),
      404: 'Could not find the requested resource',
    },
  });
};
```

Then with the interceptors i could do something like this

```ts

client.interceptors.response.use(async (response, request, options) => {
  if (!response.ok) {
    const error = options.errors?.[response.status];

    if (error && typeof error === 'string') {
      throw new Error(error);
    }

    if (error && typeof error === 'function') {
      await error();
    }
  }

  return response;
});
```

then in a declaration file i can do this:

```ts
import '@hey-api/client-fetch'

declare module '@hey-api/client-fetch' {
  interface Config {
    errors?: {
      [key: string]: string | number | (() => void)
    }
  }
}
```

For this to work in typescript, i need to augment the Config interface for typing the `errors` property.