### PR TITLE
fix: cast query params dates into ISO strings

### DIFF
--- a/.changeset/twelve-chicken-heal.md
+++ b/.changeset/twelve-chicken-heal.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/client-fetch': patch
+---
+
+fix: cast query params dates into ISO strings

--- a/packages/client-fetch/src/utils.ts
+++ b/packages/client-fetch/src/utils.ts
@@ -150,8 +150,12 @@ const serializeObjectParam = ({
   style,
   value,
 }: SerializeOptions<ObjectSeparatorStyle> & {
-  value: Record<string, unknown>;
+  value: Record<string, unknown> | Date;
 }) => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
   if (style !== 'deepObject' && !explode) {
     let values: string[] = [];
     Object.entries(value).forEach(([key, v]) => {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle/core/utils.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle/core/utils.ts.snap
@@ -150,8 +150,12 @@ const serializeObjectParam = ({
   style,
   value,
 }: SerializeOptions<ObjectSeparatorStyle> & {
-  value: Record<string, unknown>;
+  value: Record<string, unknown> | Date;
 }) => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
   if (style !== 'deepObject' && !explode) {
     let values: string[] = [];
     Object.entries(value).forEach(([key, v]) => {

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle_transform/core/utils.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle_transform/core/utils.ts.snap
@@ -150,8 +150,12 @@ const serializeObjectParam = ({
   style,
   value,
 }: SerializeOptions<ObjectSeparatorStyle> & {
-  value: Record<string, unknown>;
+  value: Record<string, unknown> | Date;
 }) => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
   if (style !== 'deepObject' && !explode) {
     let values: string[] = [];
     Object.entries(value).forEach(([key, v]) => {


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/847