### PR TITLE
fix: Relax json content type check

### DIFF
--- a/.changeset/sweet-parrots-roll.md
+++ b/.changeset/sweet-parrots-roll.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/client-fetch': patch
+---
+
+Relax JSON content type check so that e.g. `application/json; charset=utf-8` is properly detected

--- a/packages/client-fetch/src/utils.ts
+++ b/packages/client-fetch/src/utils.ts
@@ -332,7 +332,7 @@ export const getParseAs = (
     return;
   }
 
-  if (content === 'application/json' || content.endsWith('+json')) {
+  if (content.startsWith('application/json') || content.endsWith('+json')) {
     return 'json';
   }
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle/core/utils.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle/core/utils.ts.snap
@@ -332,7 +332,7 @@ export const getParseAs = (
     return;
   }
 
-  if (content === 'application/json' || content.endsWith('+json')) {
+  if (content.startsWith('application/json') || content.endsWith('+json')) {
     return 'json';
   }
 

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle_transform/core/utils.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3_hey-api_client-fetch_bundle_transform/core/utils.ts.snap
@@ -332,7 +332,7 @@ export const getParseAs = (
     return;
   }
 
-  if (content === 'application/json' || content.endsWith('+json')) {
+  if (content.startsWith('application/json') || content.endsWith('+json')) {
     return 'json';
   }
 


### PR DESCRIPTION
Correctly handle values such as `application/json; charset=utf-8`

In the meantime, `parseAs: 'json'` in the client's config will help.