### PR TITLE
fix: make UserConfig interface instead of type

### DIFF
--- a/.changeset/little-bikes-dance.md
+++ b/.changeset/little-bikes-dance.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: make UserConfig interface instead of type

--- a/packages/openapi-ts/src/types/config.ts
+++ b/packages/openapi-ts/src/types/config.ts
@@ -233,8 +233,7 @@ export interface ClientConfig {
   useOptions?: boolean;
 }
 
-// export type UserConfig = ClientConfig | ReadonlyArray<ClientConfig>
-export type UserConfig = ClientConfig;
+export interface UserConfig extends ClientConfig {}
 
 export type Config = Omit<
   Required<ClientConfig>,


### PR DESCRIPTION
Fixes #661 

Similar problems with exporting a type alias:
- https://github.com/microsoft/TypeScript/issues/23280#issue-312643360
- https://github.com/microsoft/TypeScript/issues/9944#issue-167507078

Seems like this is intentional, explanation can be found here: https://github.com/privatenumber/cleye/pull/11#issue-1259615307

Should we want `createClient` and `defineConfig` to take an array we can just make the parameter `config` type `UserConfig | ReadonlyArray<UserConfig>`.