### PR TITLE
refactor: use `@ts-expect-error` to keep error suppression up to date

### DIFF
--- a/packages/client-axios/src/index.ts
+++ b/packages/client-axios/src/index.ts
@@ -15,18 +15,18 @@ export const createClient = (config: Config): Client => {
     instance.defaults = {
       ...instance.defaults,
       ..._config,
-      // @ts-ignore
+      // @ts-expect-error
       headers: mergeHeaders(instance.defaults.headers, _config.headers),
     };
     return getConfig();
   };
 
-  // @ts-ignore
+  // @ts-expect-error
   const request: Client['request'] = async (options) => {
     const opts: RequestOptions = {
       ..._config,
       ...options,
-      // @ts-ignore
+      // @ts-expect-error
       headers: mergeHeaders(_config.headers, options.headers),
     };
     if (opts.body && opts.bodySerializer) {
@@ -63,7 +63,7 @@ export const createClient = (config: Config): Client => {
       if (opts.throwOnError) {
         throw e;
       }
-      // @ts-ignore
+      // @ts-expect-error
       e.error = e.response?.data ?? {};
       return e;
     }

--- a/packages/client-axios/src/utils.ts
+++ b/packages/client-axios/src/utils.ts
@@ -289,17 +289,17 @@ export const mergeHeaders = (
 
     for (const [key, value] of iterator) {
       if (value === null) {
-        // @ts-ignore
+        // @ts-expect-error
         delete mergedHeaders[key];
       } else if (Array.isArray(value)) {
         for (const v of value) {
-          // @ts-ignore
+          // @ts-expect-error
           mergedHeaders[key] = [...(mergedHeaders[key] ?? []), v as string];
         }
       } else if (value !== undefined) {
         // assume object headers are meant to be JSON stringified, i.e. their
         // content value in OpenAPI specification is 'application/json'
-        // @ts-ignore
+        // @ts-expect-error
         mergedHeaders[key] =
           typeof value === 'object' ? JSON.stringify(value) : (value as string);
       }

--- a/packages/client-fetch/src/index.ts
+++ b/packages/client-fetch/src/index.ts
@@ -26,9 +26,9 @@ export const createClient = (config: Config = {}): Client => {
 
   const interceptors = createInterceptors<Request, Response, RequestOptions>();
 
-  // @ts-ignore
+  // @ts-expect-error
   const request: Client['request'] = async (options) => {
-    // @ts-ignore
+    // @ts-expect-error
     const opts: RequestOptions = {
       ..._config,
       ...options,

--- a/packages/openapi-ts/src/compiler/classes.ts
+++ b/packages/openapi-ts/src/compiler/classes.ts
@@ -157,7 +157,7 @@ export const createClassDeclaration = ({
   // Add newline between each class member.
   let m: ts.ClassElement[] = [];
   members.forEach((member) => {
-    // @ts-ignore
+    // @ts-expect-error
     m = [...m, member, createIdentifier({ text: '\n' })];
   });
 

--- a/packages/openapi-ts/src/compiler/transform.ts
+++ b/packages/openapi-ts/src/compiler/transform.ts
@@ -39,7 +39,7 @@ export const createPropertyAccessExpressions = ({
   const expression = expressions.reduce((expression, name) => {
     const node = createPropertyAccessExpression({
       expression,
-      // @ts-ignore
+      // @ts-expect-error
       name,
     });
     return node;

--- a/packages/openapi-ts/src/generate/schemas.ts
+++ b/packages/openapi-ts/src/generate/schemas.ts
@@ -33,7 +33,7 @@ const ensureValidSchemaOutput = (
         ].includes(key) &&
         parentKey !== 'properties'
       ) {
-        // @ts-ignore
+        // @ts-expect-error
         delete result[key];
         return;
       }
@@ -42,12 +42,12 @@ const ensureValidSchemaOutput = (
     // refs are encoded probably by json-schema-ref-parser, didn't investigate
     // further
     if (key === '$ref' && typeof value === 'string') {
-      // @ts-ignore
+      // @ts-expect-error
       result[key] = decodeURIComponent(value);
     }
 
     if (value && typeof value === 'object') {
-      // @ts-ignore
+      // @ts-expect-error
       result[key] = ensureValidSchemaOutput(value, key);
     }
   });

--- a/packages/openapi-ts/src/openApi/__tests__/index.spec.ts
+++ b/packages/openapi-ts/src/openApi/__tests__/index.spec.ts
@@ -84,7 +84,7 @@ describe('parse', () => {
   });
 
   it('throws on unknown version', () => {
-    // @ts-ignore
+    // @ts-expect-error
     expect(() => parse({ foo: 'bar' })).toThrow(
       `Unsupported Open API specification: ${JSON.stringify({ foo: 'bar' }, null, 2)}`,
     );

--- a/packages/openapi-ts/src/openApi/common/parser/getRef.ts
+++ b/packages/openapi-ts/src/openApi/common/parser/getRef.ts
@@ -22,7 +22,7 @@ export function getRef<T>(
         path.replace(ESCAPED_REF_SLASH, '/').replace(ESCAPED_REF_TILDE, '~'),
       );
       if (result.hasOwnProperty(decodedPath)) {
-        // @ts-ignore
+        // @ts-expect-error
         result = result[decodedPath];
       } else {
         throw new Error(`Could not find reference: "${item.$ref}"`);

--- a/packages/openapi-ts/src/utils/__tests__/sort.spec.ts
+++ b/packages/openapi-ts/src/utils/__tests__/sort.spec.ts
@@ -104,7 +104,7 @@ describe('sortByName', () => {
 
   it('should throw errors when trying to sort without a name entry', () => {
     const values = ['some', 'string', 'array'];
-    // @ts-ignore
+    // @ts-expect-error
     expect(() => sortByName(values)).toThrow(TypeError);
   });
 });

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle/core/index.ts.snap
@@ -15,18 +15,18 @@ export const createClient = (config: Config): Client => {
     instance.defaults = {
       ...instance.defaults,
       ..._config,
-      // @ts-ignore
+      // @ts-expect-error
       headers: mergeHeaders(instance.defaults.headers, _config.headers),
     };
     return getConfig();
   };
 
-  // @ts-ignore
+  // @ts-expect-error
   const request: Client['request'] = async (options) => {
     const opts: RequestOptions = {
       ..._config,
       ...options,
-      // @ts-ignore
+      // @ts-expect-error
       headers: mergeHeaders(_config.headers, options.headers),
     };
     if (opts.body && opts.bodySerializer) {
@@ -63,7 +63,7 @@ export const createClient = (config: Config): Client => {
       if (opts.throwOnError) {
         throw e;
       }
-      // @ts-ignore
+      // @ts-expect-error
       e.error = e.response?.data ?? {};
       return e;
     }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle/core/utils.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle/core/utils.ts.snap
@@ -289,17 +289,17 @@ export const mergeHeaders = (
 
     for (const [key, value] of iterator) {
       if (value === null) {
-        // @ts-ignore
+        // @ts-expect-error
         delete mergedHeaders[key];
       } else if (Array.isArray(value)) {
         for (const v of value) {
-          // @ts-ignore
+          // @ts-expect-error
           mergedHeaders[key] = [...(mergedHeaders[key] ?? []), v as string];
         }
       } else if (value !== undefined) {
         // assume object headers are meant to be JSON stringified, i.e. their
         // content value in OpenAPI specification is 'application/json'
-        // @ts-ignore
+        // @ts-expect-error
         mergedHeaders[key] =
           typeof value === 'object' ? JSON.stringify(value) : (value as string);
       }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle_transform/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle_transform/core/index.ts.snap
@@ -15,18 +15,18 @@ export const createClient = (config: Config): Client => {
     instance.defaults = {
       ...instance.defaults,
       ..._config,
-      // @ts-ignore
+      // @ts-expect-error
       headers: mergeHeaders(instance.defaults.headers, _config.headers),
     };
     return getConfig();
   };
 
-  // @ts-ignore
+  // @ts-expect-error
   const request: Client['request'] = async (options) => {
     const opts: RequestOptions = {
       ..._config,
       ...options,
-      // @ts-ignore
+      // @ts-expect-error
       headers: mergeHeaders(_config.headers, options.headers),
     };
     if (opts.body && opts.bodySerializer) {
@@ -63,7 +63,7 @@ export const createClient = (config: Config): Client => {
       if (opts.throwOnError) {
         throw e;
       }
-      // @ts-ignore
+      // @ts-expect-error
       e.error = e.response?.data ?? {};
       return e;
     }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle_transform/core/utils.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle_transform/core/utils.ts.snap
@@ -289,17 +289,17 @@ export const mergeHeaders = (
 
     for (const [key, value] of iterator) {
       if (value === null) {
-        // @ts-ignore
+        // @ts-expect-error
         delete mergedHeaders[key];
       } else if (Array.isArray(value)) {
         for (const v of value) {
-          // @ts-ignore
+          // @ts-expect-error
           mergedHeaders[key] = [...(mergedHeaders[key] ?? []), v as string];
         }
       } else if (value !== undefined) {
         // assume object headers are meant to be JSON stringified, i.e. their
         // content value in OpenAPI specification is 'application/json'
-        // @ts-ignore
+        // @ts-expect-error
         mergedHeaders[key] =
           typeof value === 'object' ? JSON.stringify(value) : (value as string);
       }

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle/core/index.ts.snap
@@ -26,9 +26,9 @@ export const createClient = (config: Config = {}): Client => {
 
   const interceptors = createInterceptors<Request, Response, RequestOptions>();
 
-  // @ts-ignore
+  // @ts-expect-error
   const request: Client['request'] = async (options) => {
-    // @ts-ignore
+    // @ts-expect-error
     const opts: RequestOptions = {
       ..._config,
       ...options,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle_transform/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle_transform/core/index.ts.snap
@@ -26,9 +26,9 @@ export const createClient = (config: Config = {}): Client => {
 
   const interceptors = createInterceptors<Request, Response, RequestOptions>();
 
-  // @ts-ignore
+  // @ts-expect-error
   const request: Client['request'] = async (options) => {
-    // @ts-ignore
+    // @ts-expect-error
     const opts: RequestOptions = {
       ..._config,
       ...options,

--- a/packages/openapi-ts/test/e2e/assets/main-angular-module.ts
+++ b/packages/openapi-ts/test/e2e/assets/main-angular-module.ts
@@ -45,7 +45,7 @@ export class AppComponent {
     private readonly simpleService: SimpleService,
     private readonly typesService: TypesService
   ) {
-    // @ts-ignore
+    // @ts-expect-error
     window.api = {
       ApiModule,
       CollectionFormatService: this.collectionFormatService,

--- a/packages/openapi-ts/test/e2e/assets/main-angular.ts
+++ b/packages/openapi-ts/test/e2e/assets/main-angular.ts
@@ -44,7 +44,7 @@ export class AppComponent {
     private readonly simpleService: SimpleService,
     private readonly typesService: TypesService
   ) {
-    // @ts-ignore
+    // @ts-expect-error
     window.api = {
       CollectionFormatService: this.collectionFormatService,
       ComplexService: this.complexService,

--- a/packages/openapi-ts/test/e2e/assets/main.ts
+++ b/packages/openapi-ts/test/e2e/assets/main.ts
@@ -1,4 +1,4 @@
 import * as api from './index'
 
-// @ts-ignore
+// @ts-expect-error
 window.api = api

--- a/packages/openapi-ts/test/e2e/client.angular.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.angular.spec.ts
@@ -37,16 +37,16 @@ describe('client.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { SimpleService } = window.api
-          // @ts-ignore
+          // @ts-expect-error
           SimpleService.httpRequest.config.TOKEN = window.tokenRequest
           SimpleService.httpRequest.config.USERNAME = undefined
           SimpleService.httpRequest.config.PASSWORD = undefined
           SimpleService.getCallWithoutParametersAndResponse().subscribe(resolve)
         })
     )
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -54,7 +54,7 @@ describe('client.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { SimpleService } = window.api
           SimpleService.httpRequest.config.TOKEN = undefined
           SimpleService.httpRequest.config.USERNAME = 'username'
@@ -62,7 +62,7 @@ describe('client.angular', () => {
           SimpleService.getCallWithoutParametersAndResponse().subscribe(resolve)
         })
     )
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
@@ -70,7 +70,7 @@ describe('client.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ComplexService } = window.api
           ComplexService.complexTypes({
             first: {
@@ -88,7 +88,7 @@ describe('client.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ParametersService } = window.api
           ParametersService.callWithParameters(
             'valueHeader',
@@ -109,28 +109,28 @@ describe('client.angular', () => {
     const error = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ErrorService } = window.api
           ErrorService.testErrorCode(500).subscribe({
             error: (e: unknown) => {
               resolve(
                 JSON.stringify({
-                  // @ts-ignore
+                  // @ts-expect-error
                   body: e.body,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   message: e.message,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   name: e.name,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   status: e.status,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   statusText: e.statusText,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   url: e.url
                 })
               )
@@ -157,28 +157,28 @@ describe('client.angular', () => {
     const error = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ErrorService } = window.api
           ErrorService.testErrorCode(599).subscribe({
             error: (e: unknown) => {
               resolve(
                 JSON.stringify({
-                  // @ts-ignore
+                  // @ts-expect-error
                   body: e.body,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   message: e.message,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   name: e.name,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   status: e.status,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   statusText: e.statusText,
 
-                  // @ts-ignore
+                  // @ts-expect-error
                   url: e.url
                 })
               )

--- a/packages/openapi-ts/test/e2e/client.axios.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.axios.spec.ts
@@ -27,7 +27,7 @@ describe('client.axios', () => {
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -39,14 +39,14 @@ describe('client.axios', () => {
       USERNAME: 'username'
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ApiClient } = await import('./generated/client/axios/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.complex.complexTypes({
       first: {
         second: {
@@ -60,7 +60,7 @@ describe('client.axios', () => {
   it('supports form data', async () => {
     const { ApiClient } = await import('./generated/client/axios/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.parameters.callWithParameters(
       'valueHeader',
       'valueQuery',

--- a/packages/openapi-ts/test/e2e/client.fetch.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.fetch.spec.ts
@@ -26,7 +26,7 @@ describe('client.fetch', () => {
       USERNAME: undefined
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -38,14 +38,14 @@ describe('client.fetch', () => {
       USERNAME: 'username'
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ApiClient } = await import('./generated/client/fetch/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.complex.complexTypes({
       first: {
         second: {
@@ -59,7 +59,7 @@ describe('client.fetch', () => {
   it('support form data', async () => {
     const { ApiClient } = await import('./generated/client/fetch/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.parameters.callWithParameters(
       'valueHeader',
       'valueQuery',
@@ -167,7 +167,7 @@ describe('client.fetch', () => {
       size: 1,
       sort: ['location']
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.query).toStrictEqual({
       parameter: { page: '0', size: '1', sort: 'location' }
     })

--- a/packages/openapi-ts/test/e2e/client.node.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.node.spec.ts
@@ -27,7 +27,7 @@ describe('client.node', () => {
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -39,14 +39,14 @@ describe('client.node', () => {
       USERNAME: 'username'
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ApiClient } = await import('./generated/client/node/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.complex.complexTypes({
       first: {
         second: {
@@ -60,7 +60,7 @@ describe('client.node', () => {
   it('support form data', async () => {
     const { ApiClient } = await import('./generated/client/node/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.parameters.callWithParameters(
       'valueHeader',
       'valueQuery',

--- a/packages/openapi-ts/test/e2e/client.xhr.spec.ts
+++ b/packages/openapi-ts/test/e2e/client.xhr.spec.ts
@@ -26,7 +26,7 @@ describe.skip('client.xhr', () => {
       USERNAME: undefined
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -38,14 +38,14 @@ describe.skip('client.xhr', () => {
       USERNAME: 'username'
     })
     const result = await client.simple.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ApiClient } = await import('./generated/client/xhr/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.complex.complexTypes({
       first: {
         second: {
@@ -59,7 +59,7 @@ describe.skip('client.xhr', () => {
   it('support form data', async () => {
     const { ApiClient } = await import('./generated/client/xhr/index.js')
     const client = new ApiClient()
-    // @ts-ignore
+    // @ts-expect-error
     const result = await client.parameters.callWithParameters(
       'valueHeader',
       'valueQuery',

--- a/packages/openapi-ts/test/e2e/v2.angular.spec.ts
+++ b/packages/openapi-ts/test/e2e/v2.angular.spec.ts
@@ -31,14 +31,14 @@ describe('v2.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { OpenAPI, SimpleService } = window.api
-          // @ts-ignore
+          // @ts-expect-error
           OpenAPI.TOKEN = window.tokenRequest
           SimpleService.getCallWithoutParametersAndResponse().subscribe(resolve)
         })
     )
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -46,7 +46,7 @@ describe('v2.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ComplexService } = window.api
           ComplexService.complexTypes({
             first: {

--- a/packages/openapi-ts/test/e2e/v2.axios.spec.ts
+++ b/packages/openapi-ts/test/e2e/v2.axios.spec.ts
@@ -25,14 +25,14 @@ describe('v2.axios', () => {
     OpenAPI.TOKEN = tokenRequest
     const result = await SimpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v2/axios/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -58,28 +58,28 @@ describe('v2.axios useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v2/axios/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v2/axios/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v2/axios/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v2.fetch.spec.ts
+++ b/packages/openapi-ts/test/e2e/v2.fetch.spec.ts
@@ -24,14 +24,14 @@ describe('v2.fetch', () => {
     const tokenRequest = vi.fn().mockResolvedValue('MY_TOKEN')
     OpenAPI.TOKEN = tokenRequest
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v2/fetch/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -57,28 +57,28 @@ describe('v2.fetch useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v2/fetch/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v2/fetch/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v2/fetch/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v2.node.spec.ts
+++ b/packages/openapi-ts/test/e2e/v2.node.spec.ts
@@ -25,14 +25,14 @@ describe('v2.node', () => {
     OpenAPI.TOKEN = tokenRequest
     const result = await SimpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v2/node/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -73,28 +73,28 @@ describe('v2.node useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v2/node/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v2/node/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v2/node/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v2.xhr.spec.ts
+++ b/packages/openapi-ts/test/e2e/v2.xhr.spec.ts
@@ -24,14 +24,14 @@ describe.skip('v2.xhr', () => {
     const tokenRequest = vi.fn().mockResolvedValue('MY_TOKEN')
     OpenAPI.TOKEN = tokenRequest
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v2/xhr/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -57,28 +57,28 @@ describe.skip('v2.xhr useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v2/xhr/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v2/xhr/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v2/xhr/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v3.angular.spec.ts
+++ b/packages/openapi-ts/test/e2e/v3.angular.spec.ts
@@ -31,16 +31,16 @@ describe('v3.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { OpenAPI, SimpleService } = window.api
-          // @ts-ignore
+          // @ts-expect-error
           OpenAPI.TOKEN = window.tokenRequest
           OpenAPI.USERNAME = undefined
           OpenAPI.PASSWORD = undefined
           SimpleService.getCallWithoutParametersAndResponse().subscribe(resolve)
         })
     )
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -48,7 +48,7 @@ describe('v3.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { OpenAPI, SimpleService } = window.api
           OpenAPI.TOKEN = undefined
           OpenAPI.USERNAME = 'username'
@@ -56,7 +56,7 @@ describe('v3.angular', () => {
           SimpleService.getCallWithoutParametersAndResponse().subscribe(resolve)
         })
     )
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
@@ -64,7 +64,7 @@ describe('v3.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ComplexService } = window.api
           ComplexService.complexTypes({
             first: {
@@ -82,7 +82,7 @@ describe('v3.angular', () => {
     const result = await browser.evaluate(
       async () =>
         await new Promise(resolve => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ParametersService } = window.api
           ParametersService.callWithParameters(
             'valueHeader',
@@ -103,7 +103,7 @@ describe('v3.angular', () => {
     const error = await browser.evaluate(async () => {
       try {
         await new Promise((resolve, reject) => {
-          // @ts-ignore
+          // @ts-expect-error
           const { ErrorService } = window.api
           ErrorService.testErrorCode(500).subscribe(resolve, reject)
         })
@@ -136,7 +136,7 @@ describe('v3.angular', () => {
 
   it('should throw unknown error (599)', async () => {
     const error = await browser.evaluate(async () => {
-      // @ts-ignore
+      // @ts-expect-error
       const { ErrorService } = window.api
       try {
         await new Promise((resolve, reject) => {

--- a/packages/openapi-ts/test/e2e/v3.axios.spec.ts
+++ b/packages/openapi-ts/test/e2e/v3.axios.spec.ts
@@ -27,7 +27,7 @@ describe('v3.axios', () => {
     OpenAPI.PASSWORD = undefined
     const result = await SimpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -39,14 +39,14 @@ describe('v3.axios', () => {
     OpenAPI.USERNAME = 'username'
     OpenAPI.PASSWORD = 'password'
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v3/axios/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -58,10 +58,10 @@ describe('v3.axios', () => {
 
   it('supports form data', async () => {
     const { ParametersService } = await import('./generated/v3/axios/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await ParametersService.callWithParameters(
       'valueHeader',
-      // @ts-ignore
+      // @ts-expect-error
       'valueQuery',
       'valueForm',
       'valueCookie',
@@ -92,7 +92,7 @@ describe('v3.axios', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/axios/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
@@ -123,7 +123,7 @@ describe('v3.axios', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/axios/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
@@ -154,12 +154,12 @@ describe('v3.axios', () => {
   it('it should parse query params', async () => {
     const { ParametersService } = await import('./generated/v3/axios/index.js')
     const result = await ParametersService.postCallWithOptionalParam({
-      // @ts-ignore
+      // @ts-expect-error
       page: 0,
       size: 1,
       sort: ['location']
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.query).toStrictEqual({
       parameter: { page: '0', size: '1', sort: 'location' }
     })
@@ -181,28 +181,28 @@ describe('v3.axios useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v3/axios/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v3/axios/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v3/axios/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v3.fetch.spec.ts
+++ b/packages/openapi-ts/test/e2e/v3.fetch.spec.ts
@@ -27,7 +27,7 @@ describe('v3.fetch', () => {
     OpenAPI.PASSWORD = undefined
     const result = await SimpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -39,14 +39,14 @@ describe('v3.fetch', () => {
     OpenAPI.USERNAME = 'username'
     OpenAPI.PASSWORD = 'password'
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v3/fetch/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -60,7 +60,7 @@ describe('v3.fetch', () => {
     const { ParametersService } = await import('./generated/v3/fetch/index.js')
     const result = await ParametersService.callWithParameters(
       'valueHeader',
-      // @ts-ignore
+      // @ts-expect-error
       'valueQuery',
       'valueForm',
       'valueCookie',
@@ -76,7 +76,7 @@ describe('v3.fetch', () => {
     const { FileResponseService } = await import(
       './generated/v3/fetch/index.js'
     )
-    // @ts-ignore
+    // @ts-expect-error
     const result = await FileResponseService.fileResponse('test')
     expect(result).toBeDefined()
   })
@@ -100,7 +100,7 @@ describe('v3.fetch', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/fetch/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
@@ -131,7 +131,7 @@ describe('v3.fetch', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/fetch/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
@@ -162,12 +162,12 @@ describe('v3.fetch', () => {
   it('it should parse query params', async () => {
     const { ParametersService } = await import('./generated/v3/fetch/index.js')
     const result = await ParametersService.postCallWithOptionalParam({
-      // @ts-ignore
+      // @ts-expect-error
       page: 0,
       size: 1,
       sort: ['location']
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.query).toStrictEqual({
       parameter: { page: '0', size: '1', sort: 'location' }
     })
@@ -189,28 +189,28 @@ describe('v3.fetch useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v3/fetch/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v3/fetch/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v3/fetch/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v3.node.spec.ts
+++ b/packages/openapi-ts/test/e2e/v3.node.spec.ts
@@ -27,7 +27,7 @@ describe('v3.node', () => {
     OpenAPI.PASSWORD = undefined
     const result = await SimpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -39,14 +39,14 @@ describe('v3.node', () => {
     OpenAPI.USERNAME = 'username'
     OpenAPI.PASSWORD = 'password'
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v3/node/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -60,7 +60,7 @@ describe('v3.node', () => {
     const { ParametersService } = await import('./generated/v3/node/index.js')
     const result = await ParametersService.callWithParameters(
       'valueHeader',
-      // @ts-ignore
+      // @ts-expect-error
       'valueQuery',
       'valueForm',
       'valueCookie',
@@ -74,7 +74,7 @@ describe('v3.node', () => {
 
   it('support blob response data', async () => {
     const { FileResponseService } = await import('./generated/v3/node/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await FileResponseService.fileResponse('test')
     expect(result).toBeDefined()
   })
@@ -98,7 +98,7 @@ describe('v3.node', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/node/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
@@ -129,7 +129,7 @@ describe('v3.node', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/node/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
@@ -160,12 +160,12 @@ describe('v3.node', () => {
   it('it should parse query params', async () => {
     const { ParametersService } = await import('./generated/v3/node/index.js')
     const result = await ParametersService.postCallWithOptionalParam({
-      // @ts-ignore
+      // @ts-expect-error
       page: 0,
       size: 1,
       sort: ['location']
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.query).toStrictEqual({
       parameter: { page: '0', size: '1', sort: 'location' }
     })
@@ -187,28 +187,28 @@ describe('v3.node useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v3/node/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v3/node/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v3/node/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })

--- a/packages/openapi-ts/test/e2e/v3.xhr.spec.ts
+++ b/packages/openapi-ts/test/e2e/v3.xhr.spec.ts
@@ -27,7 +27,7 @@ describe.skip('v3.xhr', () => {
     OpenAPI.PASSWORD = undefined
     const result = await SimpleService.getCallWithoutParametersAndResponse()
     expect(tokenRequest.mock.calls.length).toBe(1)
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Bearer MY_TOKEN')
   })
 
@@ -39,14 +39,14 @@ describe.skip('v3.xhr', () => {
     OpenAPI.USERNAME = 'username'
     OpenAPI.PASSWORD = 'password'
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.headers.authorization).toBe('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
   })
 
   it('supports complex params', async () => {
     const { ComplexService } = await import('./generated/v3/xhr/index.js')
     const result = await ComplexService.complexTypes({
-      // @ts-ignore
+      // @ts-expect-error
       first: {
         second: {
           third: 'Hello World!'
@@ -60,7 +60,7 @@ describe.skip('v3.xhr', () => {
     const { ParametersService } = await import('./generated/v3/xhr/index.js')
     const result = await ParametersService.callWithParameters(
       'valueHeader',
-      // @ts-ignore
+      // @ts-expect-error
       'valueQuery',
       'valueForm',
       'valueCookie',
@@ -91,7 +91,7 @@ describe.skip('v3.xhr', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/xhr/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(500)
     } catch (err) {
       error = JSON.stringify({
@@ -122,7 +122,7 @@ describe.skip('v3.xhr', () => {
     let error
     try {
       const { ErrorService } = await import('./generated/v3/xhr/index.js')
-      // @ts-ignore
+      // @ts-expect-error
       await ErrorService.testErrorCode(599)
     } catch (err) {
       error = JSON.stringify({
@@ -153,12 +153,12 @@ describe.skip('v3.xhr', () => {
   it('it should parse query params', async () => {
     const { ParametersService } = await import('./generated/v3/xhr/index.js')
     const result = await ParametersService.postCallWithOptionalParam({
-      // @ts-ignore
+      // @ts-expect-error
       page: 0,
       size: 1,
       sort: ['location']
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.query).toStrictEqual({
       parameter: { page: '0', size: '1', sort: 'location' }
     })
@@ -180,28 +180,28 @@ describe.skip('v3.xhr useOptions', () => {
   it('returns result body by default', async () => {
     const { SimpleService } = await import('./generated/v3/xhr/index.js')
     const result = await SimpleService.getCallWithoutParametersAndResponse()
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns result body', async () => {
     const { SimpleService } = await import('./generated/v3/xhr/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'body'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeUndefined()
   })
 
   it('returns raw result', async ({ skip }) => {
     skip()
     const { SimpleService } = await import('./generated/v3/xhr/index.js')
-    // @ts-ignore
+    // @ts-expect-error
     const result = await SimpleService.getCallWithoutParametersAndResponse({
       _result: 'raw'
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(result.body).toBeDefined()
   })
 })


### PR DESCRIPTION
Problem
=

Using `@ts-ignore` will suppress a type error, but if for some reason the type error no longer occurs in the future, it's difficult to notice this. Typically the `@ts-ignore` comment is left in the codebase, which can weaken the level of type checking in some cases.

Solution
=

Use `@ts-expect-error` instead. It does the same thing but also complains if it is being used to suppress an error that does not exist.

You can read more about it here

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments
- https://dev.to/maafaishal/ts-expect-error-over-ts-ignore-in-typescript-5140