### PR TITLE
Refactor some type related things

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/ban-ts-ignore': 'off',
+      '@typescript-eslint/consistent-type-imports': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
@@ -41,6 +42,12 @@ export default tseslint.config(
       'sort-keys-fix/sort-keys-fix': 'warn',
       'typescript-sort-keys/interface': 'warn',
       'typescript-sort-keys/string-enum': 'warn',
+    },
+  },
+  {
+    files: ['packages/openapi-ts/test/e2e/assets/main-angular-module.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'off',
     },
   },
   configPrettier,

--- a/packages/client-axios/src/index.ts
+++ b/packages/client-axios/src/index.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosError } from 'axios';
+import type { AxiosError } from 'axios';
+import axios from 'axios';
 
 import type { Client, Config, RequestOptions } from './types';
 import { createConfig, getUrl, mergeConfigs, mergeHeaders } from './utils';

--- a/packages/client-fetch/src/index.ts
+++ b/packages/client-fetch/src/index.ts
@@ -142,5 +142,5 @@ export const createClient = (config: Config = {}): Client => {
     request,
     setConfig,
     trace: (options) => request({ ...options, method: 'TRACE' }),
-  } as Client;
+  };
 };

--- a/packages/openapi-ts/src/compiler/classes.ts
+++ b/packages/openapi-ts/src/compiler/classes.ts
@@ -11,12 +11,8 @@ import {
   toParameterDeclarations,
   toTypeParameters,
 } from './types';
-import {
-  addLeadingComments,
-  Comments,
-  createIdentifier,
-  isType,
-} from './utils';
+import type { Comments } from './utils';
+import { addLeadingComments, createIdentifier, isType } from './utils';
 
 /**
  * Create a class constructor declaration.

--- a/packages/openapi-ts/src/compiler/index.ts
+++ b/packages/openapi-ts/src/compiler/index.ts
@@ -1,7 +1,7 @@
 import { type PathLike, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import ts from 'typescript';
+import type ts from 'typescript';
 
 import { ensureDirSync } from '../generate/utils';
 import * as classes from './classes';

--- a/packages/openapi-ts/src/generate/services.ts
+++ b/packages/openapi-ts/src/generate/services.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   ClassElement,
-  type Comments,
-  compiler,
+  Comments,
   FunctionParameter,
-  type Node,
-  TypeScriptFile,
+  Node,
 } from '../compiler';
+import { compiler, TypeScriptFile } from '../compiler';
 import type { FunctionTypeParameter, ObjectValue } from '../compiler/types';
 import { isOperationParameterRequired } from '../openApi';
 import type {

--- a/packages/openapi-ts/src/generate/types.ts
+++ b/packages/openapi-ts/src/generate/types.ts
@@ -1,4 +1,4 @@
-import { EnumDeclaration } from 'typescript';
+import type { EnumDeclaration } from 'typescript';
 
 import {
   type Comments,

--- a/packages/openapi-ts/src/openApi/common/parser/getRef.ts
+++ b/packages/openapi-ts/src/openApi/common/parser/getRef.ts
@@ -1,6 +1,6 @@
 import type { OpenApiReference as OpenApiReferenceV2 } from '../../v2/interfaces/OpenApiReference';
 import type { OpenApiReference as OpenApiReferenceV3 } from '../../v3/interfaces/OpenApiReference';
-import { OpenApi } from '../interfaces/OpenApi';
+import type { OpenApi } from '../interfaces/OpenApi';
 
 const ESCAPED_REF_SLASH = /~1/g;
 const ESCAPED_REF_TILDE = /~0/g;

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 
 import { compiler, type Property } from '../../../compiler';
 import type { ImportExportItem } from '../../../compiler/module';
-import { ImportExportItemObject } from '../../../compiler/utils';
+import type { ImportExportItemObject } from '../../../compiler/utils';
 import {
   clientModulePath,
   clientOptionsTypeName,

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle/core/index.ts.snap
@@ -1,4 +1,5 @@
-import axios, { AxiosError } from 'axios';
+import type { AxiosError } from 'axios';
+import axios from 'axios';
 
 import type { Client, Config, RequestOptions } from './types';
 import { createConfig, getUrl, mergeConfigs, mergeHeaders } from './utils';

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle_transform/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-axios-bundle_transform/core/index.ts.snap
@@ -1,4 +1,5 @@
-import axios, { AxiosError } from 'axios';
+import type { AxiosError } from 'axios';
+import axios from 'axios';
 
 import type { Client, Config, RequestOptions } from './types';
 import { createConfig, getUrl, mergeConfigs, mergeHeaders } from './utils';

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle/core/index.ts.snap
@@ -142,5 +142,5 @@ export const createClient = (config: Config = {}): Client => {
     request,
     setConfig,
     trace: (options) => request({ ...options, method: 'TRACE' }),
-  } as Client;
+  };
 };

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle_transform/core/index.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-hey-api-client-fetch-bundle_transform/core/index.ts.snap
@@ -142,5 +142,5 @@ export const createClient = (config: Config = {}): Client => {
     request,
     setConfig,
     trace: (options) => request({ ...options, method: 'TRACE' }),
-  } as Client;
+  };
 };

--- a/packages/openapi-ts/test/e2e/scripts/browser.ts
+++ b/packages/openapi-ts/test/e2e/scripts/browser.ts
@@ -1,4 +1,5 @@
-import puppeteer, { Browser, EvaluateFunc, Page } from 'puppeteer'
+import type { Browser, EvaluateFunc, Page } from 'puppeteer';
+import puppeteer from 'puppeteer'
 
 let _browser: Browser
 let _page: Page

--- a/packages/openapi-ts/test/e2e/scripts/server.ts
+++ b/packages/openapi-ts/test/e2e/scripts/server.ts
@@ -1,7 +1,8 @@
-import { Server } from 'node:http'
+import type { Server } from 'node:http'
 import path from 'node:path'
 
-import express, { Express } from 'express'
+import type { Express } from 'express';
+import express from 'express'
 
 let _app: Express
 let _server: Server


### PR DESCRIPTION
# refactor: eslint uses `import type` where possible

This commit adds an eslint rule
`@typescript-eslint/consistent-type-imports` that warns (and
automatically fixes) when `import` is used instead of `import type` for
importing types.

This has minor performance benefits at build time and maybe at runtime,
but can also communicate the intent of the import more clearly.

For a nice developer experience, it's recommended to enable autofixing
fixable eslint issues so that the developer never has to worry about
this - it's done completely automatically when the file is saved.
Autoformatting with prettier is also recommended.

- https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/
- https://typescript-eslint.io/rules/consistent-type-imports/

---

# refactor: remove unnecessary type assertion