### PR TITLE
fix: import handlebars instead of runtime

### DIFF
--- a/.changeset/big-seals-count.md
+++ b/.changeset/big-seals-count.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: import handlebars instead of runtime

--- a/packages/openapi-ts/src/utils/__tests__/handlebars.spec.ts
+++ b/packages/openapi-ts/src/utils/__tests__/handlebars.spec.ts
@@ -1,4 +1,4 @@
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars';
 import { describe, expect, it } from 'vitest';
 
 import { setConfig } from '../config';

--- a/packages/openapi-ts/src/utils/handlebars.ts
+++ b/packages/openapi-ts/src/utils/handlebars.ts
@@ -1,4 +1,4 @@
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars';
 
 // @ts-ignore
 import templateClient from '../legacy/handlebars/compiled/client.js';


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/1082
