### PR TITLE
feat: Add support for mutation-specific options

### DIFF
--- a/.changeset/real-kangaroos-enjoy.md
+++ b/.changeset/real-kangaroos-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'@hey-api/openapi-ts': minor
+'@hey-api/openapi-ts': patch
 ---
 
 Add support for passing mutation specific options to `<operation_id>Mutation(options)`

--- a/.changeset/real-kangaroos-enjoy.md
+++ b/.changeset/real-kangaroos-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': minor
+---
+
+Add support for passing mutation specific options to `<operation_id>Mutation(options)`

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
@@ -628,8 +628,8 @@ const createQueryKeyLiteral = ({
 }: {
   isInfinite?: boolean;
   operation: Operation;
-}) =>
-  compiler.arrayLiteralExpression({
+}) => {
+  const queryKeyLiteral = compiler.arrayLiteralExpression({
     elements: [
       compiler.callExpression({
         functionName: createQueryKeyFn,
@@ -642,6 +642,8 @@ const createQueryKeyLiteral = ({
     ],
     multiLine: false,
   });
+  return queryKeyLiteral;
+};
 
 export const handler: PluginHandler<
   | ReactQueryPluginConfig

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
@@ -1143,8 +1143,9 @@ export const handler: PluginHandler<
         const expression = compiler.arrowFunction({
           parameters: [
             {
+              isRequired: false,
               name: 'options',
-              type: typeData,
+              type: `Partial<${typeData}>`,
             },
           ],
           statements: [

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin.ts
@@ -18,8 +18,8 @@ import {
 import { relativeModulePath } from '../../../generate/utils';
 import { isOperationParameterRequired } from '../../../openApi';
 import { getOperationKey } from '../../../openApi/common/parser/operation';
-import type { Client } from '../../../types/client';
 import type {
+  Client,
   Method,
   Model,
   Operation,
@@ -628,8 +628,8 @@ const createQueryKeyLiteral = ({
 }: {
   isInfinite?: boolean;
   operation: Operation;
-}) => {
-  const queryKeyLiteral = compiler.arrayLiteralExpression({
+}) =>
+  compiler.arrayLiteralExpression({
     elements: [
       compiler.callExpression({
         functionName: createQueryKeyFn,
@@ -642,8 +642,6 @@ const createQueryKeyLiteral = ({
     ],
     multiLine: false,
   });
-  return queryKeyLiteral;
-};
 
 export const handler: PluginHandler<
   | ReactQueryPluginConfig
@@ -1143,6 +1141,12 @@ export const handler: PluginHandler<
         });
 
         const expression = compiler.arrowFunction({
+          parameters: [
+            {
+              name: 'options',
+              type: typeData,
+            },
+          ],
           statements: [
             compiler.constVariable({
               expression: compiler.objectExpression({
@@ -1154,7 +1158,7 @@ export const handler: PluginHandler<
                       multiLine: true,
                       parameters: [
                         {
-                          name: 'options',
+                          name: 'localOptions',
                         },
                       ],
                       statements: [
@@ -1169,6 +1173,9 @@ export const handler: PluginHandler<
                                   obj: [
                                     {
                                       spread: 'options',
+                                    },
+                                    {
+                                      spread: 'localOptions',
                                     },
                                     {
                                       key: 'throwOnError',

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
@@ -64,10 +64,11 @@ export const complexTypesOptions = (options: Options<ComplexTypesData>) => { ret
     queryKey: complexTypesQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ComplexService.complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -106,10 +107,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultService.import({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -164,20 +166,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -200,10 +204,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DeprecatedService.deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -226,10 +231,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DescriptionsService.callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -268,30 +274,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -314,10 +323,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ErrorService.testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -356,10 +366,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await FormDataService.postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -382,10 +393,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await HeaderService.callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -408,10 +420,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await MultipartService.multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -514,30 +527,33 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -614,10 +630,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -640,10 +657,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -732,10 +750,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -758,10 +777,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await RequestBodyService.postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -800,20 +820,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,30 +901,33 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -940,10 +966,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await UploadService.uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
@@ -65,10 +65,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: UseMutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: UseMutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -123,10 +124,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -149,40 +151,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -205,10 +211,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -231,10 +238,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -311,10 +319,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -337,10 +346,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -429,10 +439,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -455,10 +466,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -481,10 +493,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -523,20 +536,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -575,30 +590,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -701,20 +719,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -769,10 +789,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: UseMutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: UseMutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -827,10 +848,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -853,10 +875,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -879,10 +902,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -905,10 +929,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -931,20 +956,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
@@ -64,10 +64,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -122,10 +123,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -148,40 +150,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -204,10 +210,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -230,10 +237,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -310,10 +318,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -336,10 +345,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -428,10 +438,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -454,10 +465,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -480,10 +492,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -522,20 +535,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -574,30 +589,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -700,20 +718,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -768,10 +788,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -826,10 +847,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,10 +901,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -904,10 +928,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -930,20 +955,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
@@ -64,10 +64,11 @@ export const complexTypesOptions = (options: Options<ComplexTypesData>) => { ret
     queryKey: complexTypesQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ComplexService.complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -106,10 +107,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultService.import({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -164,20 +166,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -200,10 +204,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DeprecatedService.deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -226,10 +231,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DescriptionsService.callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -268,30 +274,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -314,10 +323,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ErrorService.testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -356,10 +366,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await FormDataService.postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -382,10 +393,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await HeaderService.callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -408,10 +420,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await MultipartService.multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -514,30 +527,33 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -614,10 +630,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -640,10 +657,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -732,10 +750,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -758,10 +777,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await RequestBodyService.postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -800,20 +820,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,30 +901,33 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -940,10 +966,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await UploadService.uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
@@ -65,10 +65,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: MutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: MutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -123,10 +124,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -149,40 +151,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -205,10 +211,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -231,10 +238,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -311,10 +319,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -337,10 +346,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -429,10 +439,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -455,10 +466,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -481,10 +493,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -523,20 +536,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -575,30 +590,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -701,20 +719,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -769,10 +789,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: MutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: MutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -827,10 +848,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -853,10 +875,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: MutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: MutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -879,10 +902,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -905,10 +929,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: MutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: MutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -931,20 +956,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
@@ -64,10 +64,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -122,10 +123,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -148,40 +150,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -204,10 +210,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -230,10 +237,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -310,10 +318,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -336,10 +345,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -428,10 +438,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -454,10 +465,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -480,10 +492,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -522,20 +535,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -574,30 +589,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -700,20 +718,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -768,10 +788,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -826,10 +847,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,10 +901,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -904,10 +928,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -930,20 +955,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
@@ -64,10 +64,11 @@ export const complexTypesOptions = (options: Options<ComplexTypesData>) => { ret
     queryKey: complexTypesQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ComplexService.complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -106,10 +107,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultService.import({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -164,20 +166,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -200,10 +204,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DeprecatedService.deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -226,10 +231,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DescriptionsService.callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -268,30 +274,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -314,10 +323,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ErrorService.testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -356,10 +366,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await FormDataService.postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -382,10 +393,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await HeaderService.callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -408,10 +420,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await MultipartService.multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -514,30 +527,33 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -614,10 +630,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -640,10 +657,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -732,10 +750,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -758,10 +777,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await RequestBodyService.postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -800,20 +820,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,30 +901,33 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -940,10 +966,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await UploadService.uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
@@ -65,10 +65,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: MutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: MutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -123,10 +124,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -149,40 +151,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -205,10 +211,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -231,10 +238,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -311,10 +319,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -337,10 +346,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -429,10 +439,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -455,10 +466,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -481,10 +493,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -523,20 +536,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -575,30 +590,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -701,20 +719,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -769,10 +789,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: MutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: MutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -827,10 +848,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -853,10 +875,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: MutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: MutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -879,10 +902,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -905,10 +929,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: MutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: MutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -931,20 +956,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: MutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
@@ -64,10 +64,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: MutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -122,10 +123,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -148,40 +150,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -204,10 +210,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -230,10 +237,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -310,10 +318,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -336,10 +345,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -428,10 +438,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: MutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -454,10 +465,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -480,10 +492,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -522,20 +535,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -574,30 +589,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -700,20 +718,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -768,10 +788,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: MutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -826,10 +847,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: MutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,10 +901,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: MutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -904,10 +928,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: MutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -930,20 +955,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: MutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: MutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
@@ -64,10 +64,11 @@ export const complexTypesOptions = (options: Options<ComplexTypesData>) => { ret
     queryKey: complexTypesQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ComplexService.complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -106,10 +107,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultService.import({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -164,20 +166,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DefaultsService.callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -200,10 +204,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DeprecatedService.deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -226,10 +231,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DescriptionsService.callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -268,30 +274,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await DuplicateService.duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -314,10 +323,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ErrorService.testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -356,10 +366,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await FormDataService.postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -382,10 +393,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await HeaderService.callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -408,10 +420,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await MultipartService.multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -514,30 +527,33 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await NonAsciiÆøåÆøÅöôêÊService.putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -614,10 +630,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -640,10 +657,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -732,10 +750,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ParametersService.postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -758,10 +777,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await RequestBodyService.postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -800,20 +820,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await ResponseService.callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,30 +901,33 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await SimpleService.patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -940,10 +966,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await UploadService.uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
@@ -65,10 +65,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: UseMutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: UseMutationOptions<ImportResponse, AxiosError<ImportError>, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -123,10 +124,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -149,40 +151,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -205,10 +211,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -231,10 +238,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -311,10 +319,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -337,10 +346,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -429,10 +439,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, AxiosError<PostCallWithOptionalParamError>, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -455,10 +466,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -481,10 +493,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -523,20 +536,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -575,30 +590,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -701,20 +719,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, AxiosError<CallWithDuplicateResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, AxiosError<CallWithResponsesError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -769,10 +789,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: UseMutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: UseMutationOptions<UploadFileResponse, AxiosError<UploadFileError>, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -827,10 +848,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -853,10 +875,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, AxiosError<ComplexParamsError>, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -879,10 +902,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, AxiosError<CallWithResultFromHeaderError>, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -905,10 +929,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, AxiosError<TestErrorCodeError>, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -931,20 +956,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, AxiosError<NonAsciiæøåÆøÅöôêÊ字符串Error>, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: UseMutationOptions<void, AxiosError<DefaultError>, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;

--- a/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
@@ -64,10 +64,11 @@ export const importOptions = (options: Options<ImportData>) => { return queryOpt
     queryKey: importQueryKey(options)
 }); };
 
-export const importMutation = () => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
-    mutationFn: async (options) => {
+export const importMutation = (options?: Partial<Options<ImportData>>) => { const mutationOptions: UseMutationOptions<ImportResponse, ImportError, Options<ImportData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await import_({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -122,10 +123,11 @@ export const getCallWithoutParametersAndResponseOptions = (options?: Options) =>
     queryKey: getCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const putCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const putCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -148,40 +150,44 @@ export const postCallWithoutParametersAndResponseOptions = (options?: Options) =
     queryKey: postCallWithoutParametersAndResponseQueryKey(options)
 }); };
 
-export const postCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const postCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const patchCallWithoutParametersAndResponseMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const patchCallWithoutParametersAndResponseMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await patchCallWithoutParametersAndResponse({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const deleteFooMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
-    mutationFn: async (options) => {
+export const deleteFooMutation = (options?: Partial<Options<DeleteFooData3>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeleteFooData3>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deleteFoo({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -204,10 +210,11 @@ export const callWithDescriptionsOptions = (options?: Options<CallWithDescriptio
     queryKey: callWithDescriptionsQueryKey(options)
 }); };
 
-export const callWithDescriptionsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
-    mutationFn: async (options) => {
+export const callWithDescriptionsMutation = (options?: Partial<Options<CallWithDescriptionsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDescriptionsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDescriptions({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -230,10 +237,11 @@ export const deprecatedCallOptions = (options: Options<DeprecatedCallData>) => {
     queryKey: deprecatedCallQueryKey(options)
 }); };
 
-export const deprecatedCallMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
-    mutationFn: async (options) => {
+export const deprecatedCallMutation = (options?: Partial<Options<DeprecatedCallData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<DeprecatedCallData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await deprecatedCall({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -310,10 +318,11 @@ export const callWithParametersInfiniteOptions = (options: Options<CallWithParam
     queryKey: callWithParametersInfiniteQueryKey(options)
 }); };
 
-export const callWithParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithParametersMutation = (options?: Partial<Options<CallWithParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -336,10 +345,11 @@ export const callWithWeirdParameterNamesOptions = (options: Options<CallWithWeir
     queryKey: callWithWeirdParameterNamesQueryKey(options)
 }); };
 
-export const callWithWeirdParameterNamesMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
-    mutationFn: async (options) => {
+export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<CallWithWeirdParameterNamesData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithWeirdParameterNamesData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithWeirdParameterNames({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -428,10 +438,11 @@ export const postCallWithOptionalParamInfiniteOptions = (options: Options<PostCa
     queryKey: postCallWithOptionalParamInfiniteQueryKey(options)
 }); };
 
-export const postCallWithOptionalParamMutation = () => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
-    mutationFn: async (options) => {
+export const postCallWithOptionalParamMutation = (options?: Partial<Options<PostCallWithOptionalParamData>>) => { const mutationOptions: UseMutationOptions<PostCallWithOptionalParamResponse, PostCallWithOptionalParamError, Options<PostCallWithOptionalParamData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postCallWithOptionalParam({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -454,10 +465,11 @@ export const postApiVbyApiVersionRequestBodyOptions = (options?: Options<PostApi
     queryKey: postApiVbyApiVersionRequestBodyQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionRequestBodyMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionRequestBodyMutation = (options?: Partial<Options<PostApiVbyApiVersionRequestBodyData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionRequestBodyData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionRequestBody({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -480,10 +492,11 @@ export const postApiVbyApiVersionFormDataOptions = (options?: Options<PostApiVby
     queryKey: postApiVbyApiVersionFormDataQueryKey(options)
 }); };
 
-export const postApiVbyApiVersionFormDataMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
-    mutationFn: async (options) => {
+export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<PostApiVbyApiVersionFormDataData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PostApiVbyApiVersionFormDataData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await postApiVbyApiVersionFormData({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -522,20 +535,22 @@ export const callWithDefaultOptionalParametersOptions = (options?: Options<CallW
     queryKey: callWithDefaultOptionalParametersQueryKey(options)
 }); };
 
-export const callWithDefaultOptionalParametersMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
-    mutationFn: async (options) => {
+export const callWithDefaultOptionalParametersMutation = (options?: Partial<Options<CallWithDefaultOptionalParametersData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallWithDefaultOptionalParametersData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDefaultOptionalParameters({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callToTestOrderOfParamsMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
-    mutationFn: async (options) => {
+export const callToTestOrderOfParamsMutation = (options?: Partial<Options<CallToTestOrderOfParamsData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<CallToTestOrderOfParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callToTestOrderOfParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -574,30 +589,33 @@ export const duplicateName1Options = (options?: Options) => { return queryOption
     queryKey: duplicateName1QueryKey(options)
 }); };
 
-export const duplicateName1Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName1Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName1({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName2Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName2Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName2({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const duplicateName3Mutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
-    mutationFn: async (options) => {
+export const duplicateName3Mutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await duplicateName3({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -700,20 +718,22 @@ export const callWithDuplicateResponsesOptions = (options?: Options) => { return
     queryKey: callWithDuplicateResponsesQueryKey(options)
 }); };
 
-export const callWithDuplicateResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithDuplicateResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithDuplicateResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const callWithResponsesMutation = () => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResponsesMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResponsesResponse, CallWithResponsesError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResponses({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -768,10 +788,11 @@ export const uploadFileOptions = (options: Options<UploadFileData>) => { return 
     queryKey: uploadFileQueryKey(options)
 }); };
 
-export const uploadFileMutation = () => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
-    mutationFn: async (options) => {
+export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>) => { const mutationOptions: UseMutationOptions<UploadFileResponse, UploadFileError, Options<UploadFileData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await uploadFile({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -826,10 +847,11 @@ export const multipartRequestOptions = (options?: Options<MultipartRequestData>)
     queryKey: multipartRequestQueryKey(options)
 }); };
 
-export const multipartRequestMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
-    mutationFn: async (options) => {
+export const multipartRequestMutation = (options?: Partial<Options<MultipartRequestData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<MultipartRequestData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await multipartRequest({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -852,10 +874,11 @@ export const multipartResponseOptions = (options?: Options) => { return queryOpt
     queryKey: multipartResponseQueryKey(options)
 }); };
 
-export const complexParamsMutation = () => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
-    mutationFn: async (options) => {
+export const complexParamsMutation = (options?: Partial<Options<ComplexParamsData>>) => { const mutationOptions: UseMutationOptions<ComplexParamsResponse, ComplexParamsError, Options<ComplexParamsData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await complexParams({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -878,10 +901,11 @@ export const callWithResultFromHeaderOptions = (options?: Options) => { return q
     queryKey: callWithResultFromHeaderQueryKey(options)
 }); };
 
-export const callWithResultFromHeaderMutation = () => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
-    mutationFn: async (options) => {
+export const callWithResultFromHeaderMutation = (options?: Partial<Options>) => { const mutationOptions: UseMutationOptions<CallWithResultFromHeaderResponse, CallWithResultFromHeaderError, Options> = {
+    mutationFn: async (localOptions) => {
         const { data } = await callWithResultFromHeader({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -904,10 +928,11 @@ export const testErrorCodeOptions = (options: Options<TestErrorCodeData>) => { r
     queryKey: testErrorCodeQueryKey(options)
 }); };
 
-export const testErrorCodeMutation = () => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
-    mutationFn: async (options) => {
+export const testErrorCodeMutation = (options?: Partial<Options<TestErrorCodeData>>) => { const mutationOptions: UseMutationOptions<TestErrorCodeResponse, TestErrorCodeError, Options<TestErrorCodeData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await testErrorCode({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
@@ -930,20 +955,22 @@ export const nonAsciiæøåÆøÅöôêÊ字符串Options = (options: Options<No
     queryKey: nonAsciiæøåÆøÅöôêÊ字符串QueryKey(options)
 }); };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = () => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
-    mutationFn: async (options) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串Mutation = (options?: Partial<Options<NonAsciiæøåÆøÅöôêÊ字符串Data>>) => { const mutationOptions: UseMutationOptions<NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Error, Options<NonAsciiæøåÆøÅöôêÊ字符串Data>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await nonAsciiæøåÆøÅöôêÊ字符串({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;
     }
 }; return mutationOptions; };
 
-export const putWithFormUrlEncodedMutation = () => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
-    mutationFn: async (options) => {
+export const putWithFormUrlEncodedMutation = (options?: Partial<Options<PutWithFormUrlEncodedData>>) => { const mutationOptions: UseMutationOptions<void, DefaultError, Options<PutWithFormUrlEncodedData>> = {
+    mutationFn: async (localOptions) => {
         const { data } = await putWithFormUrlEncoded({
             ...options,
+            ...localOptions,
             throwOnError: true
         });
         return data;


### PR DESCRIPTION
## Use case:
You have one class let's call it `ApiMutatations` that calls all the `createMutation`s once and stores it in a variable for later use. But you don't want to mess around with the default api, because when you use `solid-js` for example it's a lot more clean to use Contexts instead of global variables which might not have been configured (interceptors attached) already.

In our `ApiMutations` class we want to ensure that the correct `Client` is preconfigured, unfortunately until now, this was impossible. This small change covers this use case.