### PR TITLE
fix: ignore name option when not used with legacy clients to avoid producing broken output

### DIFF
--- a/.changeset/pink-garlics-fail.md
+++ b/.changeset/pink-garlics-fail.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: ignore name option when not used with legacy clients to avoid producing broken output

--- a/packages/openapi-ts/src/generate/class.ts
+++ b/packages/openapi-ts/src/generate/class.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import type { OpenApi } from '../openApi';
 import type { Client } from '../types/client';
-import { getConfig } from '../utils/config';
+import { getConfig, legacyNameFromConfig } from '../utils/config';
 import { getHttpRequestName } from '../utils/getHttpRequestName';
 import type { Templates } from '../utils/handlebars';
 import { sortByName } from '../utils/sort';
@@ -34,10 +34,10 @@ export const generateLegacyClientClass = async (
     services: sortByName(client.services),
   });
 
-  if (config.name) {
+  if (legacyNameFromConfig(config)) {
     ensureDirSync(outputPath);
     writeFileSync(
-      path.resolve(outputPath, `${config.name}.ts`),
+      path.resolve(outputPath, `${legacyNameFromConfig(config)}.ts`),
       templateResult,
     );
   }

--- a/packages/openapi-ts/src/generate/core.ts
+++ b/packages/openapi-ts/src/generate/core.ts
@@ -8,7 +8,7 @@ import {
 import path from 'node:path';
 
 import type { Client } from '../types/client';
-import { getConfig } from '../utils/config';
+import { getConfig, legacyNameFromConfig } from '../utils/config';
 import { getHttpRequestName } from '../utils/getHttpRequestName';
 import type { Templates } from '../utils/handlebars';
 
@@ -85,7 +85,7 @@ export const generateLegacyCore = async (
       }),
     );
 
-    if (config.name) {
+    if (legacyNameFromConfig(config)) {
       await writeFileSync(
         path.resolve(outputPath, 'BaseHttpRequest.ts'),
         templates.core.baseHttpRequest({

--- a/packages/openapi-ts/src/generate/indexFile.ts
+++ b/packages/openapi-ts/src/generate/indexFile.ts
@@ -1,6 +1,6 @@
 import { compiler } from '../compiler';
 import type { Files } from '../types/utils';
-import { getConfig } from '../utils/config';
+import { getConfig, legacyNameFromConfig } from '../utils/config';
 import { TypeScriptFile } from './files';
 
 export const generateIndexFile = ({ files }: { files: Files }): void => {
@@ -11,11 +11,11 @@ export const generateIndexFile = ({ files }: { files: Files }): void => {
     name: 'index.ts',
   });
 
-  if (config.name) {
+  if (legacyNameFromConfig(config)) {
     files.index.add(
       compiler.exportNamedDeclaration({
-        exports: config.name,
-        module: `./${config.name}`,
+        exports: legacyNameFromConfig(config)!,
+        module: `./${legacyNameFromConfig(config)}`,
       }),
     );
   }
@@ -35,7 +35,7 @@ export const generateIndexFile = ({ files }: { files: Files }): void => {
         }),
       );
     }
-    if (config.name) {
+    if (legacyNameFromConfig(config)) {
       files.index.add(
         compiler.exportNamedDeclaration({
           exports: 'BaseHttpRequest',

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -18,7 +18,11 @@ import type { PluginNames } from './plugins/types';
 import type { Client } from './types/client';
 import type { ClientConfig, Config, UserConfig } from './types/config';
 import { CLIENTS } from './types/config';
-import { isLegacyClient, setConfig } from './utils/config';
+import {
+  isLegacyClient,
+  legacyNameFromConfig,
+  setConfig,
+} from './utils/config';
 import { getOpenApiSpec } from './utils/getOpenApiSpec';
 import { registerHandlebarTemplates } from './utils/handlebars';
 import { Performance, PerformanceReport } from './utils/performance';
@@ -351,7 +355,11 @@ export async function createClient(
         operationParameter: operationParameterNameFn,
       },
     };
-    if (config.experimentalParser && !isLegacyClient(config) && !config.name) {
+    if (
+      config.experimentalParser &&
+      !isLegacyClient(config) &&
+      !legacyNameFromConfig(config)
+    ) {
       context = parseExperimental({
         config,
         parserConfig,

--- a/packages/openapi-ts/src/utils/config.ts
+++ b/packages/openapi-ts/src/utils/config.ts
@@ -13,3 +13,14 @@ export const isLegacyClient = (config: Config | Config['client']) => {
   const client = 'client' in config ? config.client.name : config.name;
   return client.startsWith('legacy/');
 };
+
+/**
+ * Wrap legacy `name` option so we don't use it when not using legacy clients.
+ */
+export const legacyNameFromConfig = (config: Config) => {
+  if (!isLegacyClient(config)) {
+    return;
+  }
+
+  return config.name;
+};

--- a/packages/openapi-ts/src/utils/postprocess.ts
+++ b/packages/openapi-ts/src/utils/postprocess.ts
@@ -2,7 +2,7 @@ import type { Client as ParserClient, Model } from '../openApi';
 import { sanitizeNamespaceIdentifier } from '../openApi';
 import type { Client, Operation, Service } from '../types/client';
 import { camelCase } from './camelCase';
-import { getConfig } from './config';
+import { getConfig, legacyNameFromConfig } from './config';
 import { sort } from './sort';
 import { unique } from './unique';
 
@@ -47,7 +47,8 @@ const postProcessOperations = (
   operations.forEach((parserOperation) => {
     const tags =
       parserOperation.tags?.length &&
-      (config.plugins['@hey-api/services']?.asClass || config.name)
+      (config.plugins['@hey-api/services']?.asClass ||
+        legacyNameFromConfig(config))
         ? parserOperation.tags.filter(unique)
         : ['Default'];
     tags.forEach((tag) => {


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/1208