### PR TITLE
fix: add before and after to pagination keywords

### DIFF
--- a/.changeset/mean-pigs-beg.md
+++ b/.changeset/mean-pigs-beg.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: add before and after to pagination keywords

--- a/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
+++ b/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { paginationKeywordsRegExp } from '../pagination';
+
+describe('paginationKeywordsRegExp', () => {
+  const scenarios: Array<{
+    result: boolean;
+    value: string;
+  }> = [
+    {
+      result: true,
+      value: 'after',
+    },
+    {
+      result: true,
+      value: 'before',
+    },
+    {
+      result: true,
+      value: 'cursor',
+    },
+    {
+      result: true,
+      value: 'offset',
+    },
+    {
+      result: true,
+      value: 'page',
+    },
+    {
+      result: true,
+      value: 'start',
+    },
+    {
+      result: false,
+      value: 'my_start',
+    },
+    {
+      result: false,
+      value: 'start_my',
+    },
+  ];
+
+  it.each(scenarios)(
+    'is $value pagination param? $output',
+    async ({ result, value }) => {
+      paginationKeywordsRegExp.lastIndex = 0;
+      expect(paginationKeywordsRegExp.test(value)).toEqual(result);
+    },
+  );
+});

--- a/packages/openapi-ts/src/ir/pagination.ts
+++ b/packages/openapi-ts/src/ir/pagination.ts
@@ -1,6 +1,7 @@
 import type { IRSchemaObject } from './ir';
 
-export const paginationKeywordsRegExp = /^(cursor|offset|page|start)$/;
+export const paginationKeywordsRegExp =
+  /^(after|before|cursor|offset|page|start)$/;
 
 export interface Pagination {
   in: string;


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/1355