### PR TITLE
feat: add log directory option

### DIFF
--- a/packages/openapi-ts/bin/index.cjs
+++ b/packages/openapi-ts/bin/index.cjs
@@ -29,6 +29,7 @@ const params = program
   )
   .option('-o, --output <value>', 'Output folder')
   .option('-p, --plugins [value...]', "List of plugins you'd like to use")
+  .option('--log-directory <value>', 'Path to write log file to')
   .option(
     '--base [value]',
     'DEPRECATED. Manually set base in OpenAPI config instead of inferring from server value',
@@ -87,8 +88,9 @@ async function start() {
     process.exit(0);
   } catch (error) {
     if (!userConfig?.dryRun) {
+      const logDirectory = userConfig?.logDirectory || process.cwd();
       const logName = `openapi-ts-error-${Date.now()}.log`;
-      const logPath = resolve(process.cwd(), logName);
+      const logPath = resolve(logDirectory, logName);
       writeFileSync(logPath, `${error.message}\n${error.stack}`);
       console.error(`🔥 Unexpected error occurred. Log saved to ${logPath}`);
     }


### PR DESCRIPTION
helpful if you have a tmp/ folder in your project and want all logs to go there
as opposed to cluttering up the root level of your workspace.

this makes it easier to clean out logs in one fell swoop (rm tmp/*)
