### PR TITLE
fix: add null safety for content type parsing

### DIFF
--- a/packages/client-fetch/src/utils.ts
+++ b/packages/client-fetch/src/utils.ts
@@ -332,11 +332,11 @@ export const getParseAs = (
     return;
   }
 
-  const cleanContent = contentType.split(';')[0].trim();
+	const cleanContent = contentType?.split(';')[0]?.trim();
 
   if (
-    cleanContent.startsWith('application/json') ||
-    cleanContent.endsWith('+json')
+    cleanContent?.startsWith('application/json') ||
+		cleanContent?.endsWith('+json')
   ) {
     return 'json';
   }
@@ -347,13 +347,13 @@ export const getParseAs = (
 
   if (
     ['application/', 'audio/', 'image/', 'video/'].some((type) =>
-      cleanContent.startsWith(type),
+      cleanContent?.startsWith(type),
     )
   ) {
     return 'blob';
   }
 
-  if (cleanContent.startsWith('text/')) {
+	if (cleanContent?.startsWith('text/')) {
     return 'text';
   }
 };

--- a/packages/client-fetch/src/utils.ts
+++ b/packages/client-fetch/src/utils.ts
@@ -332,7 +332,7 @@ export const getParseAs = (
     return;
   }
 
-	const cleanContent = contentType?.split(';')[0]?.trim();
+	const cleanContent = contentType.split(';')[0]?.trim();
 
   if (
     cleanContent?.startsWith('application/json') ||


### PR DESCRIPTION
Added null safety checks for content type parsing in the generated API client to handle undefined content types correctly. This fixes the TypeScript error in getParseAs utility function I got using the configuration bellow.

`client: {
		name: "@hey-api/client-fetch",
		bundle: true,
	}`

Fixes this build error:
![CleanShot 2024-12-04 at 10 52 50](https://github.com/user-attachments/assets/bddced67-2116-4203-a353-a8b7bcd8db82)