### PR TITLE
Fix #1450 - export Security type

### DIFF
--- a/packages/client-fetch/src/index.ts
+++ b/packages/client-fetch/src/index.ts
@@ -173,6 +173,7 @@ export type {
   OptionsLegacyParser,
   RequestOptions,
   RequestResult,
+  Security,
 } from './types';
 export {
   createConfig,


### PR DESCRIPTION
Export Security type to fix react-query codegen issue from https://github.com/hey-api/openapi-ts/issues/1450