### PR TITLE
Adds option to disable client auto creation in SDK

### DIFF
--- a/.changeset/pink-seahorses-cheer.md
+++ b/.changeset/pink-seahorses-cheer.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': minor
+---
+
+Add SDK option to disable the auto-creation of the client

--- a/packages/openapi-ts/src/compiler/index.ts
+++ b/packages/openapi-ts/src/compiler/index.ts
@@ -50,6 +50,7 @@ export const compiler = {
   propertyAccessExpression: types.createPropertyAccessExpression,
   propertyAccessExpressions: transform.createPropertyAccessExpressions,
   propertyAssignment: types.createPropertyAssignment,
+  propertyDeclaration: types.createPropertyDeclaration,
   regularExpressionLiteral: types.createRegularExpressionLiteral,
   returnFunctionCall: _return.createReturnFunctionCall,
   returnStatement: _return.createReturnStatement,

--- a/packages/openapi-ts/src/compiler/types.ts
+++ b/packages/openapi-ts/src/compiler/types.ts
@@ -898,6 +898,42 @@ export const createPropertyAssignment = ({
   name: string | ts.PropertyName;
 }) => ts.factory.createPropertyAssignment(name, initializer);
 
+export const createPropertyDeclaration = ({
+  accessLevel,
+  comment,
+  initializer,
+  isReadonly,
+  name,
+  type,
+}: {
+  accessLevel?: AccessLevel;
+  comment?: Comments;
+  initializer?: ts.Expression;
+  isReadonly?: boolean;
+  name: string;
+  type: ts.TypeNode;
+}) => {
+  const modifiers = toAccessLevelModifiers(accessLevel);
+  if (isReadonly) {
+    modifiers.push(ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword));
+  }
+
+  const node = ts.factory.createPropertyDeclaration(
+    modifiers,
+    createIdentifier({ text: name }),
+    undefined,
+    type,
+    initializer,
+  );
+
+  addLeadingComments({
+    comments: comment,
+    node,
+  });
+
+  return node;
+};
+
 export const createRegularExpressionLiteral = ({
   flags = [],
   text,

--- a/packages/openapi-ts/src/generate/client.ts
+++ b/packages/openapi-ts/src/generate/client.ts
@@ -28,6 +28,10 @@ export const clientModulePath = ({
 };
 
 export const clientApi = {
+  Client: {
+    asType: true,
+    name: 'Client',
+  },
   Options: {
     asType: true,
     name: 'Options',

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/config.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/config.ts
@@ -30,6 +30,7 @@ export const defaultConfig: Plugin.Config<Config> = {
   },
   asClass: false,
   auth: true,
+  autoCreateClient: true,
   exportFromIndex: true,
   name: '@hey-api/sdk',
   operationId: true,

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/types.d.ts
@@ -26,6 +26,18 @@ export interface Config extends Plugin.Name<'@hey-api/sdk'> {
    */
   auth?: boolean;
   /**
+   * **This feature works only with the [experimental parser](https://heyapi.dev/openapi-ts/configuration#parser)**
+   *
+   * Should the generated SDK do a createClient call automatically? If this is
+   * set to false, the generated SDK will expect a client to be passed in during:
+   *
+   * - instantiation if asClass is set to true (and the client will be passed to the constructor. All methods will not be static either)
+   * - each method call if asClass is set to false
+   *
+   * @default true
+   */
+  autoCreateClient?: boolean;
+  /**
    * **This feature works only with the legacy parser**
    *
    * Filter endpoints to be included in the generated SDK. The provided


### PR DESCRIPTION
This PR adds an option to the SDK which allows the user to disable the auto-creation of the client in the SDK output. (i.e **not** doing a `const client = createClient(createConfig());` at the top)

Reasoning behind this is we are generating an API client for a microservices based endpoint, so there are multiple SDKs that need to be generated. We want to sit these behind another class where the client is instantiated once, rather than multiple times.

Based on this, when you set `autoCreateClient: false`, the following happens:
- If `asClass` is true:
  - The SDK Class output now requires instantiation
  - The constructor must be passed a client argument
  - Each method is no longer static, as the client from the class is used for each call
- If flat:
  - Each method now has a required options argument
  - The `client` property is now also required in the options

I'm not sure I like the `autoCreateClient` variable name, so input would be appreciated!