### PR TITLE
Response type void when no content in schema.

### DIFF
--- a/packages/openapi-ts/src/openApi/3.0.x/parser/operation.ts
+++ b/packages/openapi-ts/src/openApi/3.0.x/parser/operation.ts
@@ -169,9 +169,7 @@ const operationToIrOperation = ({
       irOperation.responses[name] = {
         schema: {
           description: responseObject.description,
-          // TODO: parser - cover all statues with empty response bodies
-          // 1xx, 204, 205, 304
-          type: name === '204' ? 'void' : 'unknown',
+          type: 'void',
         },
       };
     }


### PR DESCRIPTION
After this change response type is set to void when no content schema is provided, regardless of status code of response.

Before this change, it was only set to void for status code 204.

The spec (https://swagger.io/docs/specification/v3_0/describing-responses/) does not say that an empty response body is only valid for 204 responses, it is just used as an example.