### PR TITLE
bug: Fix fetch clients serialises body to JSON for text/plain

### DIFF
--- a/packages/client-fetch/src/index.ts
+++ b/packages/client-fetch/src/index.ts
@@ -39,6 +39,7 @@ export const createClient = (config: Config = {}): Client => {
       fetch: options.fetch ?? _config.fetch ?? globalThis.fetch,
       headers: mergeHeaders(_config.headers, options.headers),
     };
+    const contentType: string | null = opts.headers.get('Content-Type')
 
     if (opts.security) {
       await setAuthParams({
@@ -47,7 +48,7 @@ export const createClient = (config: Config = {}): Client => {
       });
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body && opts.bodySerializer && contentType !== 'text/plain') {
       opts.body = opts.bodySerializer(opts.body);
     }
 


### PR DESCRIPTION
When posting a `text/plain` body, the fetch client puts the text inside hyphens because it wrongly serialises the request body using `JSON.stringify`.

This fixes this bug by not serialising the request body at all when the content type header is set to `text/plain`.