### PR TITLE
fix: avoid double escaping in zod patterns

### DIFF
--- a/.changeset/twenty-dryers-fly.md
+++ b/.changeset/twenty-dryers-fly.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: correctly generate zod regex expressions when using patterns

--- a/packages/openapi-ts/src/plugins/zod/plugin.ts
+++ b/packages/openapi-ts/src/plugins/zod/plugin.ts
@@ -527,21 +527,12 @@ const stringTypeToZodSchema = ({
   }
 
   if (schema.pattern) {
-    const text = schema.pattern
-      .replace(/\\/g, '\\\\') // backslashes
-      .replace(/\n/g, '\\n') // newlines
-      .replace(/\r/g, '\\r') // carriage returns
-      .replace(/\t/g, '\\t') // tabs
-      .replace(/\f/g, '\\f') // form feeds
-      .replace(/\v/g, '\\v') // vertical tabs
-      .replace(/'/g, "\\'") // single quotes
-      .replace(/"/g, '\\"'); // double quotes
     stringExpression = compiler.callExpression({
       functionName: compiler.propertyAccessExpression({
         expression: stringExpression,
         name: regexIdentifier,
       }),
-      parameters: [compiler.regularExpressionLiteral({ text })],
+      parameters: [compiler.regularExpressionLiteral({ text: schema.pattern })],
     });
   }
 

--- a/packages/openapi-ts/test/__snapshots__/2.0.x/plugins/@hey-api/schemas/default/schemas.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/2.0.x/plugins/@hey-api/schemas/default/schemas.gen.ts
@@ -604,8 +604,7 @@ export const ModelWithPatternSchema = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/__snapshots__/2.0.x/plugins/zod/default/zod.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/2.0.x/plugins/zod/default/zod.gen.ts
@@ -227,9 +227,9 @@ export const zModelWithPattern = z.object({
     name: z.string().max(255),
     enabled: z.boolean().readonly().optional(),
     modified: z.string().datetime().readonly().optional(),
-    id: z.string().regex(/^\\d{2}-\\d{3}-\\d{4}$/).optional(),
-    text: z.string().regex(/^\\w+$/).optional(),
-    patternWithSingleQuotes: z.string().regex(/^[a-zA-Z0-9\']*$/).optional(),
+    id: z.string().regex(/^\d{2}-\d{3}-\d{4}$/).optional(),
+    text: z.string().regex(/^\w+$/).optional(),
+    patternWithSingleQuotes: z.string().regex(/^[a-zA-Z0-9']*$/).optional(),
     patternWithNewline: z.string().regex(/aaa\nbbb/).optional(),
     patternWithBacktick: z.string().regex(/aaa`bbb/).optional()
 });

--- a/packages/openapi-ts/test/__snapshots__/3.0.x/plugins/@hey-api/schemas/default/schemas.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.0.x/plugins/@hey-api/schemas/default/schemas.gen.ts
@@ -1204,8 +1204,7 @@ export const ModelWithPatternSchema = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/__snapshots__/3.0.x/plugins/zod/default/zod.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.0.x/plugins/zod/default/zod.gen.ts
@@ -462,9 +462,9 @@ export const zModelWithPattern = z.object({
     name: z.string().max(255),
     enabled: z.boolean().readonly().optional(),
     modified: z.string().datetime().readonly().optional(),
-    id: z.string().regex(/^\\d{2}-\\d{3}-\\d{4}$/).optional(),
-    text: z.string().regex(/^\\w+$/).optional(),
-    patternWithSingleQuotes: z.string().regex(/^[a-zA-Z0-9\']*$/).optional(),
+    id: z.string().regex(/^\d{2}-\d{3}-\d{4}$/).optional(),
+    text: z.string().regex(/^\w+$/).optional(),
+    patternWithSingleQuotes: z.string().regex(/^[a-zA-Z0-9']*$/).optional(),
     patternWithNewline: z.string().regex(/aaa\nbbb/).optional(),
     patternWithBacktick: z.string().regex(/aaa`bbb/).optional()
 });

--- a/packages/openapi-ts/test/__snapshots__/3.0.x/validators/zod.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.0.x/validators/zod.gen.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 export const zFoo: z.ZodTypeAny = z.union([
     z.object({
-        foo: z.string().regex(/^\\d{3}-\\d{2}-\\d{4}$/).optional(),
+        foo: z.string().regex(/^\d{3}-\d{2}-\d{4}$/).optional(),
         bar: z.object({
             foo: z.lazy(() => {
                 return zFoo;

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/plugins/@hey-api/schemas/default/schemas.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/plugins/@hey-api/schemas/default/schemas.gen.ts
@@ -1194,8 +1194,7 @@ export const ModelWithPatternSchema = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/plugins/zod/default/zod.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/plugins/zod/default/zod.gen.ts
@@ -457,9 +457,9 @@ export const zModelWithPattern = z.object({
     name: z.string().max(255),
     enabled: z.boolean().readonly().optional(),
     modified: z.string().datetime().readonly().optional(),
-    id: z.string().regex(/^\\d{2}-\\d{3}-\\d{4}$/).optional(),
-    text: z.string().regex(/^\\w+$/).optional(),
-    patternWithSingleQuotes: z.string().regex(/^[a-zA-Z0-9\']*$/).optional(),
+    id: z.string().regex(/^\d{2}-\d{3}-\d{4}$/).optional(),
+    text: z.string().regex(/^\w+$/).optional(),
+    patternWithSingleQuotes: z.string().regex(/^[a-zA-Z0-9']*$/).optional(),
     patternWithNewline: z.string().regex(/aaa\nbbb/).optional(),
     patternWithBacktick: z.string().regex(/aaa`bbb/).optional()
 });

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/validators/zod.gen.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/validators/zod.gen.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 export const zFoo: z.ZodTypeAny = z.union([
     z.object({
-        foo: z.string().regex(/^\\d{3}-\\d{2}-\\d{4}$/).optional(),
+        foo: z.string().regex(/^\d{3}-\d{2}-\d{4}$/).optional(),
         bar: z.object({
             foo: z.lazy(() => {
                 return zFoo;

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v2/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v2/schemas.gen.ts.snap
@@ -602,8 +602,7 @@ export const ModelWithPatternSchema = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-schemas-form/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-schemas-form/schemas.gen.ts.snap
@@ -1093,8 +1093,7 @@ export const ModelWithPatternSchema = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-schemas-json/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-schemas-json/schemas.gen.ts.snap
@@ -1201,8 +1201,7 @@ export const ModelWithPatternSchema = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/__snapshots__/test/generated/v3-schemas-name/schemas.gen.ts.snap
+++ b/packages/openapi-ts/test/__snapshots__/test/generated/v3-schemas-name/schemas.gen.ts.snap
@@ -1201,8 +1201,7 @@ export const $ModelWithPattern = {
         },
         patternWithNewline: {
             type: 'string',
-            pattern: `aaa
-bbb`
+            pattern: 'aaa\\nbbb'
         },
         patternWithBacktick: {
             type: 'string',

--- a/packages/openapi-ts/test/spec/2.0.x/full.json
+++ b/packages/openapi-ts/test/spec/2.0.x/full.json
@@ -1481,7 +1481,7 @@
         },
         "patternWithNewline": {
           "type": "string",
-          "pattern": "aaa\nbbb"
+          "pattern": "aaa\\nbbb"
         },
         "patternWithBacktick": {
           "type": "string",

--- a/packages/openapi-ts/test/spec/3.0.x/full.json
+++ b/packages/openapi-ts/test/spec/3.0.x/full.json
@@ -2932,7 +2932,7 @@
           },
           "patternWithNewline": {
             "type": "string",
-            "pattern": "aaa\nbbb"
+            "pattern": "aaa\\nbbb"
           },
           "patternWithBacktick": {
             "type": "string",

--- a/packages/openapi-ts/test/spec/3.0.x/validators.json
+++ b/packages/openapi-ts/test/spec/3.0.x/validators.json
@@ -40,7 +40,7 @@
       },
       "Baz": {
         "default": "baz",
-        "pattern": "foo\nbar",
+        "pattern": "foo\\nbar",
         "readOnly": true,
         "type": "string"
       }

--- a/packages/openapi-ts/test/spec/3.1.x/full.json
+++ b/packages/openapi-ts/test/spec/3.1.x/full.json
@@ -2914,7 +2914,7 @@
           },
           "patternWithNewline": {
             "type": "string",
-            "pattern": "aaa\nbbb"
+            "pattern": "aaa\\nbbb"
           },
           "patternWithBacktick": {
             "type": "string",

--- a/packages/openapi-ts/test/spec/3.1.x/validators.json
+++ b/packages/openapi-ts/test/spec/3.1.x/validators.json
@@ -39,7 +39,7 @@
       },
       "Baz": {
         "default": "baz",
-        "pattern": "foo\nbar",
+        "pattern": "foo\\nbar",
         "readOnly": true,
         "type": "string"
       }

--- a/packages/openapi-ts/test/spec/v2.json
+++ b/packages/openapi-ts/test/spec/v2.json
@@ -1509,7 +1509,7 @@
         },
         "patternWithNewline": {
           "type": "string",
-          "pattern": "aaa\nbbb"
+          "pattern": "aaa\\nbbb"
         },
         "patternWithBacktick": {
           "type": "string",

--- a/packages/openapi-ts/test/spec/v3.json
+++ b/packages/openapi-ts/test/spec/v3.json
@@ -2908,7 +2908,7 @@
           },
           "patternWithNewline": {
             "type": "string",
-            "pattern": "aaa\nbbb"
+            "pattern": "aaa\\nbbb"
           },
           "patternWithBacktick": {
             "type": "string",


### PR DESCRIPTION
Fixes #1727

The `pattern` field requires an [ECMA 262](https://262.ecma-international.org/5.1/#sec-15.10.1) compliant regex expression so no transformation should be required when generating the Zod schemas.