### PR TITLE
fix: Wrap HEAD request in a try-catch to prevent watch mode crashes on server reloads

### DIFF
--- a/.changeset/shy-mugs-rescue.md
+++ b/.changeset/shy-mugs-rescue.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: Wrap HEAD request in a try-catch to prevent watch mode crashes on server reloads

--- a/packages/openapi-ts/src/getSpec.ts
+++ b/packages/openapi-ts/src/getSpec.ts
@@ -40,14 +40,22 @@ export const getSpec = async ({
   if (resolvedInput.type === 'url') {
     // do NOT send HEAD request on first run or if unsupported
     if (watch.lastValue && watch.isHeadMethodSupported !== false) {
-      const request = await sendRequest({
-        init: {
-          headers: watch.headers,
-          method: 'HEAD',
-        },
-        timeout,
-        url: resolvedInput.path,
-      });
+      let request;
+      try {
+        request = await sendRequest({
+          init: {
+            headers: watch.headers,
+            method: 'HEAD',
+          },
+          timeout,
+          url: resolvedInput.path,
+        });
+      } catch (ex) {
+        return {
+          error: 'not-ok',
+          response: new Response(ex.message),
+        };
+      }
       response = request.response;
 
       if (!response.ok && watch.isHeadMethodSupported) {


### PR DESCRIPTION
A quick fix on the problem discussed at https://github.com/hey-api/openapi-ts/issues/1542#issuecomment-2676153754

I'm not sure if this is the best approach, but I didn't want to go fiddling around with the json-schema-ref-parser library, which is causing the actual error to pop up so I wrote this and tested it out and it seemed to run without a hitch.

I also decided to pass the exception message to the response body but idk if that's what we want to do here.

Tested locally against the repro I posted here and another project and couldn't get it to crash.