### PR TITLE
fix: request body type being too specific in some clients

### DIFF
--- a/packages/client-fetch/src/types.ts
+++ b/packages/client-fetch/src/types.ts
@@ -48,12 +48,7 @@ export interface RequestOptions<
    *
    * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
    */
-  body?:
-    | RequestInit['body']
-    | Record<string, unknown>
-    | Array<Record<string, unknown>>
-    | Array<unknown>
-    | number;
+  body?: unknown;
   path?: Record<string, unknown>;
   query?: Record<string, unknown>;
   /**

--- a/packages/client-next/src/types.ts
+++ b/packages/client-next/src/types.ts
@@ -48,12 +48,7 @@ export interface RequestOptions<
    *
    * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
    */
-  body?:
-    | RequestInit['body']
-    | Record<string, unknown>
-    | Array<Record<string, unknown>>
-    | Array<unknown>
-    | number;
+  body?: unknown;
   path?: Record<string, unknown>;
   query?: Record<string, unknown>;
   /**

--- a/packages/client-nuxt/src/types.ts
+++ b/packages/client-nuxt/src/types.ts
@@ -68,7 +68,7 @@ export interface RequestOptions<
        *
        * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
        */
-      body?: BodyInit | Record<string, any> | null;
+      body?: unknown;
       path?: FetchOptions<unknown>['query'];
       query?: FetchOptions<unknown>['query'];
     }> {

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/bundle/client/index.d.cts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/bundle/client/index.d.cts
@@ -162,7 +162,7 @@ interface RequestOptions<ThrowOnError extends boolean = boolean, Url extends str
      *
      * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
      */
-    body?: RequestInit['body'] | Record<string, unknown> | Array<Record<string, unknown>> | Array<unknown> | number;
+    body?: unknown;
     path?: Record<string, unknown>;
     query?: Record<string, unknown>;
     /**

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/bundle/client/index.d.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/bundle/client/index.d.ts
@@ -162,7 +162,7 @@ interface RequestOptions<ThrowOnError extends boolean = boolean, Url extends str
      *
      * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
      */
-    body?: RequestInit['body'] | Record<string, unknown> | Array<Record<string, unknown>> | Array<unknown> | number;
+    body?: unknown;
     path?: Record<string, unknown>;
     query?: Record<string, unknown>;
     /**

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-next/bundle/client/index.d.cts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-next/bundle/client/index.d.cts
@@ -162,7 +162,7 @@ interface RequestOptions<ThrowOnError extends boolean = boolean, Url extends str
      *
      * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
      */
-    body?: RequestInit['body'] | Record<string, unknown> | Array<Record<string, unknown>> | Array<unknown> | number;
+    body?: unknown;
     path?: Record<string, unknown>;
     query?: Record<string, unknown>;
     /**

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-next/bundle/client/index.d.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-next/bundle/client/index.d.ts
@@ -162,7 +162,7 @@ interface RequestOptions<ThrowOnError extends boolean = boolean, Url extends str
      *
      * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
      */
-    body?: RequestInit['body'] | Record<string, unknown> | Array<Record<string, unknown>> | Array<unknown> | number;
+    body?: unknown;
     path?: Record<string, unknown>;
     query?: Record<string, unknown>;
     /**

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/bundle/client/index.d.cts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/bundle/client/index.d.cts
@@ -136,7 +136,7 @@ interface RequestOptions<TComposable extends Composable = Composable, ResT = unk
      *
      * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
      */
-    body?: BodyInit | Record<string, any> | null;
+    body?: unknown;
     path?: FetchOptions<unknown>['query'];
     query?: FetchOptions<unknown>['query'];
 }> {

--- a/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/bundle/client/index.d.ts
+++ b/packages/openapi-ts/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/bundle/client/index.d.ts
@@ -136,7 +136,7 @@ interface RequestOptions<TComposable extends Composable = Composable, ResT = unk
      *
      * {@link https://developer.mozilla.org/docs/Web/API/fetch#body}
      */
-    body?: BodyInit | Record<string, any> | null;
+    body?: unknown;
     path?: FetchOptions<unknown>['query'];
     query?: FetchOptions<unknown>['query'];
 }> {


### PR DESCRIPTION
Fixes #1659 .

This is a simple fix changing the type of the request body in all clients to `unknown`.
I don't know whether the original differences in types are meaningful, though, so would be good to get another good look at it.