### PR TITLE
fix: Wrap the GET request in watch mode with try-catch to prevent crashes on no-head watch targets

### DIFF
--- a/.changeset/selfish-nails-fail.md
+++ b/.changeset/selfish-nails-fail.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: Wrap the GET request in watch mode with try-catch to prevent crashes on no-head watch targets

--- a/packages/openapi-ts/src/getSpec.ts
+++ b/packages/openapi-ts/src/getSpec.ts
@@ -109,14 +109,21 @@ export const getSpec = async ({
       }
     }
 
-    const fileRequest = await sendRequest({
-      init: {
-        method: 'GET',
-      },
-      timeout,
-      url: resolvedInput.path,
-    });
-    response = fileRequest.response;
+    try {
+      const fileRequest = await sendRequest({
+        init: {
+          method: 'GET',
+        },
+        timeout,
+        url: resolvedInput.path,
+      });
+      response = fileRequest.response;
+    } catch (ex) {
+      return {
+        error: 'not-ok',
+        response: new Response(ex.message),
+      };
+    }
 
     if (!response.ok) {
       // assume the server is no longer running


### PR DESCRIPTION
Hey it's me again!  (sorry!)

Thanks for handling the previous PR in such a switft fashion. I got to my workstation this morning and tried it out against my repro, (https://github.com/Matsuuu/openapi-ts-watch-repro) and a fresh Quarkus project and it worked flawlessly!

However, my client has a .Net project, which doesn't always seem to provide HEAD which causes `watch.isHeadMethodSupported` to resolve to false, causing it to skip the guard-rail we implemented in the [PR](https://github.com/hey-api/openapi-ts/pull/1748).

This PR implements the same solution but on the second (GET) call on the watch mode handler.

Hope you have time to take a look at this and thanks for the great tool!