### PR TITLE
docs(zod): Import the emdbedProject file to launch the demo for zod

### DIFF
--- a/docs/openapi-ts/plugins/zod.md
+++ b/docs/openapi-ts/plugins/zod.md
@@ -3,10 +3,6 @@ title: Zod
 description: Zod plugin for Hey API. Compatible with all our features.
 ---
 
-<script setup>
-import { embedProject } from '../../embed'
-</script>
-
 # Zod
 
 ::: warning
@@ -17,11 +13,11 @@ This feature is in development! :tada: Try it out and provide feedback on [GitHu
 
 [Zod](https://zod.dev/) is a TypeScript-first schema validation library with static type inference.
 
-### Demo
+<!-- ### Demo
 
 <button class="buttonLink" @click="(event) => embedProject('hey-api-client-fetch-plugin-zod-example')(event)">
 Launch demo
-</button>
+</button> -->
 
 ## Features
 

--- a/docs/openapi-ts/plugins/zod.md
+++ b/docs/openapi-ts/plugins/zod.md
@@ -3,6 +3,10 @@ title: Zod
 description: Zod plugin for Hey API. Compatible with all our features.
 ---
 
+<script setup>
+import { embedProject } from '../../embed'
+</script>
+
 # Zod
 
 ::: warning


### PR DESCRIPTION
## Problem

The embedProject method was not imported correctly within the documentation page for Zod.

<img width="1728" alt="Screenshot 2025-02-27 at 13 36 43" src="https://github.com/user-attachments/assets/1615a95a-494d-47a6-baf0-c44a0f485a04" />


## Solution

Added the import emdedProject to the `zod.md`.