### PR TITLE
feat: Add opeanapi-info plugin

### DIFF
--- a/packages/openapi-ts/src/plugins/index.ts
+++ b/packages/openapi-ts/src/plugins/index.ts
@@ -73,6 +73,7 @@ import {
 import { type Config as Fastify, defaultConfig as fastify } from './fastify';
 import type { DefaultPluginConfigs, Plugin } from './types';
 import { type Config as Zod, defaultConfig as zod } from './zod';
+import {type Config as OpenApiInfo, defaultConfig as openApiInfo} from './metadata'
 
 /**
  * User-facing plugin types.
@@ -97,7 +98,8 @@ export type UserPlugins =
   | Plugin.UserConfig<TanStackSvelteQuery>
   | Plugin.UserConfig<TanStackVueQuery>
   | Plugin.UserConfig<Fastify>
-  | Plugin.UserConfig<Zod>;
+  | Plugin.UserConfig<Zod>
+  | Plugin.UserConfig<OpenApiInfo>;
 
 /**
  * Internal plugin types.
@@ -122,7 +124,8 @@ export type ClientPlugins =
   | Plugin.Config<TanStackSvelteQuery>
   | Plugin.Config<TanStackVueQuery>
   | Plugin.Config<Fastify>
-  | Plugin.Config<Zod>;
+  | Plugin.Config<Zod>
+  | Plugin.Config<OpenApiInfo>;
 
 export const defaultPluginConfigs: DefaultPluginConfigs<ClientPlugins> = {
   '@hey-api/client-axios': heyApiClientAxios,
@@ -145,4 +148,5 @@ export const defaultPluginConfigs: DefaultPluginConfigs<ClientPlugins> = {
   'legacy/node': heyApiLegacyNode,
   'legacy/xhr': heyApiLegacyXhr,
   zod,
+  'openapi-info': openApiInfo,
 };

--- a/packages/openapi-ts/src/plugins/metadata/config.ts
+++ b/packages/openapi-ts/src/plugins/metadata/config.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from '../types';
+import { handler } from './plugin'
+import type { Config } from './types';
+
+export const defaultConfig: Plugin.Config<Config> = {
+  _handler: handler,
+  _handlerLegacy: () => {},
+  name: 'openapi-info',
+  output: 'opeapi-info',
+};
+
+/**
+ * Type helper for `metadata` plugin, returns {@link Plugin.Config} object
+ */
+export const defineConfig: Plugin.DefineConfig<Config> = (config) => ({
+  ...defaultConfig,
+  ...config,
+});

--- a/packages/openapi-ts/src/plugins/metadata/index.ts
+++ b/packages/openapi-ts/src/plugins/metadata/index.ts
@@ -1,0 +1,2 @@
+export { defaultConfig, defineConfig } from './config';
+export type { Config } from './types';

--- a/packages/openapi-ts/src/plugins/metadata/plugin.ts
+++ b/packages/openapi-ts/src/plugins/metadata/plugin.ts
@@ -1,0 +1,24 @@
+import ts from 'typescript';
+
+import type { Plugin } from '../types';
+import type { Config } from './types';
+
+export const handler: Plugin.Handler<Config> = ({ context, plugin }) => {
+  const file = context.createFile({
+    id: plugin.name,
+    path: plugin.output,
+  });
+
+  // Create const for every set info value
+  const { info } = context.spec;
+  Object.entries(info).forEach(([key, value]) => {
+    const stringLiteral = ts.factory.createStringLiteral(value);
+    const variableDeclaration = ts.factory.createVariableDeclaration(key, undefined, undefined, stringLiteral);
+    const node = ts.factory.createVariableStatement(
+      [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+      ts.factory.createVariableDeclarationList([variableDeclaration], ts.NodeFlags.Const),
+    );
+    // add node to file
+    file.add(node);
+  });
+};

--- a/packages/openapi-ts/src/plugins/metadata/types.d.ts
+++ b/packages/openapi-ts/src/plugins/metadata/types.d.ts
@@ -1,0 +1,10 @@
+import type { Plugin } from '../types';
+
+export interface Config extends Plugin.Name<'openapi-info'> {
+  /**
+   * Name of the generated file.
+   *
+   * @default 'openapi-info'
+   */
+  output?: string;
+}

--- a/packages/openapi-ts/src/plugins/types.d.ts
+++ b/packages/openapi-ts/src/plugins/types.d.ts
@@ -33,6 +33,7 @@ export type PluginNames =
   | '@tanstack/svelte-query'
   | '@tanstack/vue-query'
   | 'fastify'
+  | 'openapi-info'
   | PluginValidatorNames;
 
 export type AnyPluginName = PluginNames | (string & {});

--- a/packages/openapi-ts/test/plugins.test.ts
+++ b/packages/openapi-ts/test/plugins.test.ts
@@ -245,6 +245,12 @@ for (const version of versions) {
       },
       {
         config: createConfig({
+          output: 'default',
+          plugins: ['openapi-info']
+        })
+      },
+      {
+        config: createConfig({
           input: 'type-format.yaml',
           output: 'type-format',
           plugins: [


### PR DESCRIPTION
This adds a simple plugin that makes the data from the info object of the openapi.json available as output. 

See: https://swagger.io/specification/#InfoObject