### PR TITLE
Allow scheme Property to Be Case-Insensitive in securitySchemeObjectToAuthObject Function

### DIFF
--- a/.changeset/chilled-rules-matter.md
+++ b/.changeset/chilled-rules-matter.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+Allow `scheme` property to be case-insensitive

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
@@ -188,12 +188,10 @@ const securitySchemeObjectToAuthObject = ({
   }
 
   if (securitySchemeObject.type === 'http') {
-    if (
-      securitySchemeObject.scheme === 'bearer' ||
-      securitySchemeObject.scheme === 'basic'
-    ) {
+    const scheme = securitySchemeObject.scheme.toLowerCase();
+    if (scheme === 'bearer' || scheme === 'basic') {
       return {
-        scheme: securitySchemeObject.scheme,
+        scheme: scheme as 'bearer' | 'basic',
         type: 'http',
       };
     }


### PR DESCRIPTION
This pull request introduces a change to the **securitySchemeObjectToAuthObject** function to allow the **scheme** property to be case-insensitive by converting it to lowercase. This ensures that the function can handle schemes provided in any case format (e.g., "Bearer", "bearer", "BEARER").