### PR TITLE
docs: Update tanstack query docs on Infinite params

### DIFF
--- a/docs/openapi-ts/plugins/tanstack-query.md
+++ b/docs/openapi-ts/plugins/tanstack-query.md
@@ -142,6 +142,15 @@ const { data, error } = useInfiniteQuery({
 });
 ```
 
+Infinite queries are recognized by having one of these keywords in the endpoint's parameters:
+
+- after
+- before
+- cursor
+- offset
+- page
+- start
+
 ## Mutations
 
 Mutations are generated from DELETE, PATCH, POST, and PUT endpoints. The generated functions follow the naming convention of SDK functions and append `Mutation`, e.g. `addPetMutation()`.


### PR DESCRIPTION
Update the docs to list out the regex params we use for matching infinite queries. This will make it easier for people debugging infinite queries to find the proper keywords.

I only did a quite quick scan of the docs but these were the keywords I found at https://github.com/hey-api/openapi-ts/blob/main/packages/openapi-ts/src/ir/pagination.ts#L3

If there is some other way we map these, I'd be happy to update the doc.