### PR TITLE
fix(pagination-parsing): code generation when optional pagination field is missing

### DIFF
--- a/.changeset/giant-jeans-study.md
+++ b/.changeset/giant-jeans-study.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: prevent crash when optional pagination field is missing

--- a/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
+++ b/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { Config } from '../../types/config';
+import { operationPagination } from '../operation';
 import { getPaginationKeywordsRegExp } from '../pagination';
+import type { IR } from '../types';
 
 describe('paginationKeywordsRegExp', () => {
   const defaultScenarios: Array<{
@@ -66,9 +68,192 @@ describe('paginationKeywordsRegExp', () => {
       const pagination: Config['input']['pagination'] = {
         keywords: ['customPagination', 'pageSize', 'perPage'],
       };
-
       const paginationRegExp = getPaginationKeywordsRegExp(pagination);
       expect(paginationRegExp.test(value)).toEqual(result);
     },
   );
+});
+
+describe('operationPagination', () => {
+  const queryScenarios: Array<{
+    hasPagination: boolean;
+    operation: IR.OperationObject;
+  }> = [
+    {
+      hasPagination: true,
+      operation: {
+        id: 'op1',
+        method: 'get',
+        parameters: {
+          query: {
+            page: {
+              explode: true,
+              location: 'query',
+              name: 'page',
+              schema: { type: 'integer' },
+              style: 'form',
+            },
+            perPage: {
+              explode: true,
+              location: 'query',
+              name: 'perPage',
+              schema: { type: 'integer' },
+              style: 'form',
+            },
+          },
+        },
+        path: '/test',
+      },
+    },
+    {
+      hasPagination: false,
+      operation: {
+        id: 'op2',
+        method: 'get',
+        parameters: {
+          query: {
+            sort: {
+              explode: true,
+              location: 'query',
+              name: 'sort',
+              schema: { type: 'string' },
+              style: 'form',
+            },
+          },
+        },
+        path: '/test',
+      },
+    },
+  ];
+
+  it.each(queryScenarios)(
+    'query params for $operation.id → $hasPagination',
+    ({ hasPagination, operation }) => {
+      const result = operationPagination({ context: {} as any, operation });
+      expect(Boolean(result)).toEqual(hasPagination);
+    },
+  );
+
+  it('body.pagination === true returns entire body', () => {
+    const operation: IR.OperationObject = {
+      body: {
+        mediaType: 'application/json',
+        pagination: true,
+        schema: {
+          properties: {
+            page: { type: 'integer' },
+          },
+          type: 'object',
+        },
+      },
+      id: 'bodyTrue',
+      method: 'post',
+      path: '/test',
+    };
+
+    const result = operationPagination({ context: {} as any, operation });
+
+    expect(result?.in).toEqual('body');
+    expect(result?.name).toEqual('body');
+    expect(result?.schema?.type).toEqual('object');
+  });
+
+  it('body.pagination = "pagination" returns the matching property', () => {
+    const operation: IR.OperationObject = {
+      body: {
+        mediaType: 'application/json',
+        pagination: 'pagination',
+        schema: {
+          properties: {
+            pagination: {
+              properties: {
+                page: { type: 'integer' },
+              },
+              type: 'object',
+            },
+          },
+          type: 'object',
+        },
+      },
+      id: 'bodyField',
+      method: 'post',
+      path: '/test',
+    };
+
+    const result = operationPagination({ context: {} as any, operation });
+
+    expect(result?.in).toEqual('body');
+    expect(result?.name).toEqual('pagination');
+    expect(result?.schema?.type).toEqual('object');
+  });
+
+  it('resolves $ref and uses the resolved pagination property', () => {
+    const context: IR.Context = {
+      resolveIrRef: vi.fn().mockReturnValue({
+        properties: {
+          pagination: {
+            properties: {
+              page: { type: 'integer' },
+            },
+            type: 'object',
+          },
+        },
+        type: 'object',
+      }),
+    } as unknown as IR.Context;
+
+    const operation: IR.OperationObject = {
+      body: {
+        mediaType: 'application/json',
+        pagination: 'pagination',
+        schema: { $ref: '#/components/schemas/PaginationBody' },
+      },
+      id: 'refPagination',
+      method: 'post',
+      path: '/test',
+    };
+
+    const result = operationPagination({ context, operation });
+
+    expect(context.resolveIrRef).toHaveBeenCalledWith(
+      '#/components/schemas/PaginationBody',
+    );
+    expect(result?.in).toEqual('body');
+    expect(result?.name).toEqual('pagination');
+    expect(result?.schema?.type).toEqual('object');
+  });
+
+  it('falls back to query when pagination key not found in body', () => {
+    const operation: IR.OperationObject = {
+      body: {
+        mediaType: 'application/json',
+        pagination: 'pagination',
+        schema: {
+          properties: {
+            notPagination: { type: 'string' },
+          },
+          type: 'object',
+        },
+      },
+      id: 'fallback',
+      method: 'post',
+      parameters: {
+        query: {
+          cursor: {
+            explode: true,
+            location: 'query',
+            name: 'cursor',
+            schema: { type: 'string' },
+            style: 'form',
+          },
+        },
+      },
+      path: '/test',
+    };
+
+    const result = operationPagination({ context: {} as any, operation });
+
+    expect(result?.in).toEqual('query');
+    expect(result?.schema?.properties?.cursor).toBeDefined();
+  });
 });

--- a/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
+++ b/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
@@ -80,11 +80,11 @@ describe('operationPagination', () => {
     type: IR.SchemaObject['type'] = 'string',
     pagination = false,
   ): IR.ParameterObject => ({
-    name,
+    explode: true,
     location: 'query',
+    name,
     schema: { type },
     style: 'form',
-    explode: true,
     ...(pagination ? { pagination: true } : {}),
   });
 
@@ -129,7 +129,13 @@ describe('operationPagination', () => {
 
   it.each(queryScenarios)(
     'query params for $operation.id → $hasPagination',
-    ({ hasPagination, operation }: { hasPagination: boolean; operation: IR.OperationObject }) => {
+    ({
+      hasPagination,
+      operation,
+    }: {
+      hasPagination: boolean;
+      operation: IR.OperationObject;
+    }) => {
       const result = operationPagination({ context: emptyContext, operation });
       expect(Boolean(result)).toEqual(hasPagination);
     },
@@ -138,17 +144,17 @@ describe('operationPagination', () => {
   it('body.pagination === true returns entire body', () => {
     const operation: IR.OperationObject = {
       ...baseOperationMeta,
-      id: 'bodyTrue',
       body: {
         mediaType: 'application/json',
         pagination: true,
         schema: {
-          type: 'object',
           properties: {
             page: { type: 'integer' },
           },
+          type: 'object',
         },
       },
+      id: 'bodyTrue',
     };
 
     const result = operationPagination({ context: emptyContext, operation });
@@ -161,22 +167,22 @@ describe('operationPagination', () => {
   it('body.pagination = "pagination" returns the matching property', () => {
     const operation: IR.OperationObject = {
       ...baseOperationMeta,
-      id: 'bodyField',
       body: {
         mediaType: 'application/json',
         pagination: 'pagination',
         schema: {
-          type: 'object',
           properties: {
             pagination: {
-              type: 'object',
               properties: {
                 page: { type: 'integer' },
               },
+              type: 'object',
             },
           },
+          type: 'object',
         },
       },
+      id: 'bodyField',
     };
 
     const result = operationPagination({ context: emptyContext, operation });
@@ -189,26 +195,26 @@ describe('operationPagination', () => {
   it('resolves $ref and uses the resolved pagination property', () => {
     const context: IR.Context = {
       resolveIrRef: vi.fn().mockReturnValue({
-        type: 'object',
         properties: {
           pagination: {
-            type: 'object',
             properties: {
               page: { type: 'integer' },
             },
+            type: 'object',
           },
         },
+        type: 'object',
       }),
     } as unknown as IR.Context;
 
     const operation: IR.OperationObject = {
       ...baseOperationMeta,
-      id: 'refPagination',
       body: {
         mediaType: 'application/json',
         pagination: 'pagination',
         schema: { $ref: '#/components/schemas/PaginationBody' },
       },
+      id: 'refPagination',
     };
 
     const result = operationPagination({ context, operation });
@@ -224,20 +230,20 @@ describe('operationPagination', () => {
   it('falls back to query when pagination key not found in body', () => {
     const operation: IR.OperationObject = {
       ...baseOperationMeta,
-      id: 'fallback',
-      parameters: {
-        query: {
-          cursor: queryParam('cursor', 'string', true),
-        },
-      },
       body: {
         mediaType: 'application/json',
         pagination: 'pagination',
         schema: {
-          type: 'object',
           properties: {
             notPagination: { type: 'string' },
           },
+          type: 'object',
+        },
+      },
+      id: 'fallback',
+      parameters: {
+        query: {
+          cursor: queryParam('cursor', 'string', true),
         },
       },
     };
@@ -249,3 +255,4 @@ describe('operationPagination', () => {
     expect(result?.schema?.type).toEqual('string');
   });
 });
+test(pagination): fix new tests in CI (2)

--- a/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
+++ b/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
@@ -255,4 +255,3 @@ describe('operationPagination', () => {
     expect(result?.schema?.type).toEqual('string');
   });
 });
-test(pagination): fix new tests in CI (2)


### PR DESCRIPTION
These tests ensure the pagination logic works correctly when defined in different parts of the request (body or query), including edge cases. This supports the fix where pagination fields might be missing or optional.

Adds tests for operationPagination to cover:
	•	Pagination from query parameters
	•	Pagination from the request body (pagination: true and "pagination")
	•	Resolving schemas from $ref
	•	Fallback to query params when the body field is missing

Closes https://github.com/hey-api/openapi-ts/issues/1908