### PR TITLE
Fixing widespread edge case of nullable dates in  required  fields in transformers

### DIFF
--- a/.changeset/red-days-camp.md
+++ b/.changeset/red-days-camp.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: handle nullable dates in transformers

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/transformers-any-of-null/transformers.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/transformers-any-of-null/transformers.gen.ts
@@ -9,6 +9,9 @@ const fooSchemaResponseTransformer = (data: any) => {
     if (data.bar) {
         data.bar = new Date(data.bar);
     }
+    if (data.requiredBaz) {
+        data.requiredBaz = new Date(data.requiredBaz);
+    }
     return data;
 };
 

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/transformers-any-of-null/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/transformers-any-of-null/types.gen.ts
@@ -3,6 +3,7 @@
 export type Foo = {
     foo?: Date;
     bar?: Date | null;
+    requiredBaz: Date | null;
 };
 
 export type GetFooData = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/transformers-any-of-null/transformers.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/transformers-any-of-null/transformers.gen.ts
@@ -12,6 +12,9 @@ const fooSchemaResponseTransformer = (data: any) => {
     if (data.baz) {
         data.baz = new Date(data.baz);
     }
+    if (data.requiredQux) {
+        data.requiredQux = new Date(data.requiredQux);
+    }
     return data;
 };
 

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/transformers-any-of-null/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/transformers-any-of-null/types.gen.ts
@@ -13,6 +13,7 @@ export type Foo = {
     foo?: Date;
     bar?: Date | null;
     baz?: Date | null;
+    requiredQux: Date | null;
 };
 
 export type GetFooData = {

--- a/packages/openapi-ts-tests/test/spec/3.0.x/transformers-any-of-null.json
+++ b/packages/openapi-ts-tests/test/spec/3.0.x/transformers-any-of-null.json
@@ -42,8 +42,18 @@
                 "format": "date-time"
               }
             ]
+          },
+          "requiredBaz": {
+            "anyOf": [
+              {
+                "type": "string",
+                "nullable": true,
+                "format": "date-time"
+              }
+            ]
           }
-        }
+        },
+        "required": ["requiredBaz"]
       }
     }
   }

--- a/packages/openapi-ts-tests/test/spec/3.1.x/transformers-any-of-null.json
+++ b/packages/openapi-ts-tests/test/spec/3.1.x/transformers-any-of-null.json
@@ -84,8 +84,17 @@
                 "format": "date-time"
               }
             ]
+          },
+          "requiredQux": {
+            "anyOf": [
+              {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            ]
           }
-        }
+        },
+        "required": ["requiredQux"]
       }
     }
   }


### PR DESCRIPTION
Right now date transformer doesn't take into account nullable dates, which is quite a widespread case. It produces this code:

```
obj.nullableDate =  new Date(obj.nullableDate);
```

I suppose everybody is experienced enough to see it's gonna give your consumers a data corruption in no time.

The PR doesn't account for all possible cases, only for Date | null. 


I'm not sure if the author of the repo is reading through PRs, but if you do, I tell you what: 

The plugin system right now is in absolutely disastrous state. You won't get much help by outright lying in your docs. 

**We are not in the same boat!** Your built-in plugins do communicate with each other somehow and they have access to modules that are not exported from the project. 

The only reason I'm sending this PR is that I don't want to have your project hanging in my repo with source files. Under different circumstances I would never sent a PR after spending 6 hours on a 3 minute fix because I believed you that we are in the same boat. We clearly are not.

I can't imagine how many others tried to write their own plugins only to find out you can't do anything with them. To replicate the behavior of transformers you need to resort to copying and pasting files from original code and in the end SDK plugin simply ignores yours, because yours is not "@hey-api/transformers".

Decouple your plugins and the project is going to bloom. For now, you can at least allow to set the same names as built-in plugins for your own plugins to create an override, so we could copy / paste the code and fix problems there or tweak the behaviours.


EDIT AFTER FINALIZING FIX: 

**Turned out that the original transformers for nullables were fine in what schemas they supposed to pick up. The problem was in discriminating against required fields in object schemas. Required means that value is present, but doesn't guarantee that the value is not nulish.**