### PR TITLE
Not to merge: add test case for int64 min/max

### DIFF
--- a/examples/openapi-ts-tanstack-angular-query-experimental/angular.json
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/angular.json
@@ -71,5 +71,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/schemas/default/schemas.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/schemas/default/schemas.gen.ts
@@ -337,6 +337,58 @@ export const ModelWithIntegerSchema = {
     }
 } as const;
 
+export const ModelWithInt64Schema = {
+    description: 'This is a model with one int64 property',
+    type: 'object',
+    properties: {
+        prop: {
+            description: 'This is a simple int64 property',
+            type: 'integer',
+            format: 'int64'
+        }
+    }
+} as const;
+
+export const ModelWithInt32Schema = {
+    description: 'This is a model with one int32 property',
+    type: 'object',
+    properties: {
+        prop: {
+            description: 'This is a simple int32 property',
+            type: 'integer',
+            format: 'int64'
+        }
+    }
+} as const;
+
+export const ModelWithInt64AndMinMaxSchema = {
+    description: 'This is a model with one int64 property',
+    type: 'object',
+    properties: {
+        prop: {
+            description: 'This is a simple int64 property',
+            type: 'integer',
+            format: 'int64',
+            minimum: 0,
+            maximum: 100
+        }
+    }
+} as const;
+
+export const ModelWithInt32AndMinMaxSchema = {
+    description: 'This is a model with one int32 property',
+    type: 'object',
+    properties: {
+        prop: {
+            description: 'This is a simple int32 property',
+            type: 'integer',
+            format: 'int32',
+            minimum: 0,
+            maximum: 100
+        }
+    }
+} as const;
+
 export const ModelWithBooleanSchema = {
     description: 'This is a model with one boolean property',
     type: 'object',

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/fastify/default/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/fastify/default/types.gen.ts
@@ -224,6 +224,46 @@ export type ModelWithInteger = {
 };
 
 /**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64 = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32 = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int64 property
+ */
+export type ModelWithInt64AndMinMax = {
+    /**
+     * This is a simple int64 property
+     */
+    prop?: number;
+};
+
+/**
+ * This is a model with one int32 property
+ */
+export type ModelWithInt32AndMinMax = {
+    /**
+     * This is a simple int32 property
+     */
+    prop?: number;
+};
+
+/**
  * This is a model with one boolean property
  */
 export type ModelWithBoolean = {

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/zod/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/zod/default/zod.gen.ts
@@ -111,6 +111,22 @@ export const zModelWithInteger = z.object({
     prop: z.number().int().optional()
 });
 
+export const zModelWithInt64 = z.object({
+    prop: z.coerce.bigint().optional()
+});
+
+export const zModelWithInt32 = z.object({
+    prop: z.coerce.bigint().optional()
+});
+
+export const zModelWithInt64AndMinMax = z.object({
+    prop: z.coerce.bigint().gte(0).lte(100).optional()
+});
+
+export const zModelWithInt32AndMinMax = z.object({
+    prop: z.number().int().gte(0).lte(100).optional()
+});
+
 export const zModelWithBoolean = z.object({
     prop: z.boolean().optional()
 });

--- a/packages/openapi-ts-tests/test/spec/3.0.x/full.json
+++ b/packages/openapi-ts-tests/test/spec/3.0.x/full.json
@@ -2099,6 +2099,54 @@
           }
         }
       },
+      "ModelWithInt64": {
+        "description": "This is a model with one int64 property",
+        "type": "object",
+        "properties": {
+          "prop": {
+            "description": "This is a simple int64 property",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ModelWithInt32": {
+        "description": "This is a model with one int32 property",
+        "type": "object",
+        "properties": {
+          "prop": {
+            "description": "This is a simple int32 property",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ModelWithInt64AndMinMax": {
+        "description": "This is a model with one int64 property",
+        "type": "object",
+        "properties": {
+          "prop": {
+            "description": "This is a simple int64 property",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "maximum": 100
+          }
+        }
+      },
+      "ModelWithInt32AndMinMax": {
+        "description": "This is a model with one int32 property",
+        "type": "object",
+        "properties": {
+          "prop": {
+            "description": "This is a simple int32 property",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 100
+          }
+        }
+      },
       "ModelWithBoolean": {
         "description": "This is a model with one boolean property",
         "type": "object",


### PR DESCRIPTION
Demonstrates invalid Zod schema getting generated when using `format: 'int64'` with min and max values.

```json
"ModelWithInt64AndMinMax": {
  "description": "This is a model with one int64 property",
  "type": "object",
  "properties": {
    "prop": {
      "description": "This is a simple int64 property",
      "type": "integer",
      "format": "int64",
      "minimum": 0,
      "maximum": 100
    }
  }
},
```

Generates the following Zod schema:

```typescript
export const zModelWithInt64AndMinMax = z.object({
    prop: z.coerce.bigint().gte(0).lte(100).optional()
});
```

Which does not compile! It should instead generate:

```typescript
export const zModelWithInt64AndMinMax = z.object({
    prop: z.coerce.bigint().gte(BigInt(0)).lte(BigInt(100)).optional()
});
```