### PR TITLE
Allow generating class sdks that are instantiable

### DIFF
--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/config.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/config.ts
@@ -40,6 +40,7 @@ export const defaultConfig: Plugin.Config<Config> = {
     }
   },
   asClass: false,
+  asInstance: false,
   auth: true,
   client: true,
   exportFromIndex: true,

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/typeOptions.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/typeOptions.ts
@@ -63,7 +63,7 @@ export const createTypeOptions = ({
                 'individual options. This might be also useful if you want to implement a',
                 'custom client.',
               ],
-              isRequired: !plugin.client,
+              isRequired: !plugin.client && !plugin.asInstance,
               name: 'client',
               type: compiler.typeReferenceNode({ typeName: clientType.name }),
             },

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/types.d.ts
@@ -20,6 +20,13 @@ export interface Config extends Plugin.Name<'@hey-api/sdk'> {
    */
   asClass?: boolean;
   /**
+   * SDK functions are non-static methods and the class must be instantiated
+   * with a client.
+   *
+   * @default false
+   */
+  asInstance?: boolean;
+  /**
    * Should the generated functions contain auth mechanisms? You may want to
    * disable this option if you're handling auth yourself or defining it
    * globally on the client and want to reduce the size of generated code.


### PR DESCRIPTION
This adds an option asInstance that makes the sdk class instantiable. Specifically:

1. Methods are instance methods instead of static
2. The sdk takes a client as a parameter in the constructor, and sdk methods use the instance of the client.

This allows creating multiple instances of the sdk that work independently. My use case is using a client during server side rendering where each sdk instance is authenticated with the end-user's auth token which has limited permissions (as opposed to using a single client with admin permissions).

Contributes https://github.com/hey-api/openapi-ts/issues/671

I could use some guidance on how to add a snapshot test for this.