### PR TITLE
feat(openapi-ts): export additional functions from openapi-ts

### DIFF
--- a/.changeset/three-rats-count.md
+++ b/.changeset/three-rats-count.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: export some internal functions

--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -52,6 +52,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./internal": {
+      "import": {
+        "types": "./dist/internal.d.ts",
+        "default": "./dist/internal.js"
+      },
+      "require": {
+        "types": "./dist/internal.d.cts",
+        "default": "./dist/internal.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "bin": {
@@ -64,7 +74,7 @@
   ],
   "scripts": {
     "build": "tsup && pnpm check-exports",
-    "check-exports": "attw --pack .",
+    "check-exports": "attw --pack . --profile node16",
     "dev": "tsup --watch",
     "handlebars": "node src/legacy/handlebars/handlebars.cjs",
     "prepublishOnly": "pnpm build",

--- a/packages/openapi-ts/src/__tests__/index.test.ts
+++ b/packages/openapi-ts/src/__tests__/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+describe('main entry index', () => {
+  describe('createClient', () => {
+    it('should be exported', async () => {
+      const { createClient } = await import('../index');
+      expect(createClient).toBeDefined();
+    });
+  });
+});

--- a/packages/openapi-ts/src/__tests__/internal.test.ts
+++ b/packages/openapi-ts/src/__tests__/internal.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+describe('internal entry index', () => {
+  it('getSpec should be exported', async () => {
+    const { getSpec } = await import('../internal');
+    expect(getSpec).toBeDefined();
+  });
+
+  it('initConfigs should be exported', async () => {
+    const { initConfigs } = await import('../internal');
+    expect(initConfigs).toBeDefined();
+  });
+
+  it('parseOpenApiSpec should be exported', async () => {
+    const { parseOpenApiSpec } = await import('../internal');
+    expect(parseOpenApiSpec).toBeDefined();
+  });
+});

--- a/packages/openapi-ts/src/getSpec.ts
+++ b/packages/openapi-ts/src/getSpec.ts
@@ -21,6 +21,9 @@ interface SpecError {
   response: Response;
 }
 
+/**
+ * @internal
+ */
 export const getSpec = async ({
   fetchOptions,
   inputPath,

--- a/packages/openapi-ts/src/initConfigs.ts
+++ b/packages/openapi-ts/src/initConfigs.ts
@@ -253,6 +253,9 @@ const getWatch = (
   return watch;
 };
 
+/**
+ * @internal
+ */
 export const initConfigs = async (
   userConfig: UserConfig | undefined,
 ): Promise<Config[]> => {

--- a/packages/openapi-ts/src/internal.ts
+++ b/packages/openapi-ts/src/internal.ts
@@ -1,0 +1,3 @@
+export { getSpec } from './getSpec';
+export { initConfigs } from './initConfigs';
+export { parseOpenApiSpec } from './openApi';

--- a/packages/openapi-ts/src/openApi/index.ts
+++ b/packages/openapi-ts/src/openApi/index.ts
@@ -57,6 +57,7 @@ export function parseLegacy({
 }
 
 /**
+ * @internal
  * Parse the resolved OpenAPI specification. This will populate and return
  * `context` with intermediate representation obtained from the parsed spec.
  */

--- a/packages/openapi-ts/tsup.config.ts
+++ b/packages/openapi-ts/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig((options) => ({
   },
   clean: true,
   dts: true,
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/internal.ts'],
   format: ['cjs', 'esm'],
   minify: !options.watch,
   shims: false,


### PR DESCRIPTION
Added exports for getSpec, initConfigs, and parseOpenApiSpec to the new exported internal file for improved accessibility of these functions across internal packages

These functions are helpful for custom clients and plugins.

Marked the exported functions as @internal, and I put them in a new export path