### PR TITLE
fix: watch at prepare & sdk missing

### DIFF
--- a/.changeset/spotty-cows-cry.md
+++ b/.changeset/spotty-cows-cry.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/nuxt": patch
+---
+
+fix: avoid duplicate definition of `@hey-api/client-nuxt` plugin

--- a/.changeset/two-fans-train.md
+++ b/.changeset/two-fans-train.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/nuxt": patch
+---
+
+fix: skip watch mode in prepare step

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -67,6 +67,10 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias[options.alias!] = folder;
 
+    nuxt.hooks.hookOnce('app:templates', async () => {
+      await createClient(config);
+    });
+
     // auto-import enabled
     if (options.autoImport) {
       await createClient(config);
@@ -107,10 +111,6 @@ export default defineNuxtModule<ModuleOptions>({
           imports,
         });
       }
-    } else {
-      nuxt.hooks.hookOnce('app:templates', async () => {
-        await createClient(config);
-      });
     }
   },
 });

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -48,8 +48,17 @@ export default defineNuxtModule<ModuleOptions>({
       output: {
         path: path.join(nuxt.options.buildDir, 'client'),
       },
-      plugins: ['@hey-api/client-nuxt'],
+      plugins: options.config.plugins.some((plugin: any) => {
+        const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
+        return pluginName === '@hey-api/plugin-nuxt';
+      })
+        ? []
+        : ['@hey-api/client-nuxt'],
     } satisfies Partial<UserConfig>) as UserConfig;
+
+    if (nuxt.options._prepare) {
+      config.watch = false;
+    }
 
     const folder = path.resolve(
       nuxt.options.rootDir,
@@ -57,10 +66,6 @@ export default defineNuxtModule<ModuleOptions>({
     );
 
     nuxt.options.alias[options.alias!] = folder;
-
-    nuxt.hooks.hookOnce('app:templates', async () => {
-      await createClient(config);
-    });
 
     // auto-import enabled
     if (options.autoImport) {
@@ -102,6 +107,10 @@ export default defineNuxtModule<ModuleOptions>({
           imports,
         });
       }
+    } else {
+      nuxt.hooks.hookOnce('app:templates', async () => {
+        await createClient(config);
+      });
     }
   },
 });

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -48,7 +48,7 @@ export default defineNuxtModule<ModuleOptions>({
       output: {
         path: path.join(nuxt.options.buildDir, 'client'),
       },
-      plugins: options.config.plugins.some((plugin: any) => {
+      plugins: (options.config.plugins || []).some((plugin: any) => {
         const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
         return pluginName === '@hey-api/plugin-nuxt';
       })


### PR DESCRIPTION
This PR addresses 2 problems:

1. After `pnpm i`, `postinstall` script will run, i.e. `nuxt prepare`, in this scenario, we should disable watch mode.
2. When user pass in `@hey-api/client-nuxt` plugin, we shouldn't specify it again, which will cause sdk missing in the generated client folder.