### PR TITLE
Fix missing body serializer when media type octet-stream

### DIFF
--- a/.changeset/friendly-bobcats-allow.md
+++ b/.changeset/friendly-bobcats-allow.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+Issue when using Content-Type': 'application/octet-stream', it using default json serializer. The fix is adding new media type octet-stream and body serializer to null when using Content-Type': 'application/octet-stream'

--- a/packages/openapi-ts/src/ir/__tests__/mediaType.test.ts
+++ b/packages/openapi-ts/src/ir/__tests__/mediaType.test.ts
@@ -92,6 +92,10 @@ describe('mediaTypeToIrMediaType', () => {
       response: 'url-search-params',
     },
     {
+      mediaType: 'application/octet-stream',
+      response: 'octet-stream',
+    },
+    {
       mediaType: 'application/foo',
       response: undefined,
     },

--- a/packages/openapi-ts/src/ir/mediaType.ts
+++ b/packages/openapi-ts/src/ir/mediaType.ts
@@ -5,8 +5,14 @@ const multipartFormDataMimeRegExp = /^multipart\/form-data(;.*)?$/i;
 const textMimeRegExp = /^text\/[a-z0-9.+-]+(;.*)?$/i;
 const xWwwFormUrlEncodedMimeRegExp =
   /^application\/x-www-form-urlencoded(;.*)?$/i;
+const octetStreamMimeRegExp = /^application\/octet-stream(;.*)?$/i;
 
-export type IRMediaType = 'form-data' | 'json' | 'text' | 'url-search-params';
+export type IRMediaType =
+  | 'form-data'
+  | 'json'
+  | 'text'
+  | 'url-search-params'
+  | 'octet-stream';
 
 export const isMediaTypeFileLike = ({
   mediaType,
@@ -40,5 +46,10 @@ export const mediaTypeToIrMediaType = ({
   xWwwFormUrlEncodedMimeRegExp.lastIndex = 0;
   if (xWwwFormUrlEncodedMimeRegExp.test(mediaType)) {
     return 'url-search-params';
+  }
+
+  octetStreamMimeRegExp.lastIndex = 0;
+  if (octetStreamMimeRegExp.test(mediaType)) {
+    return 'octet-stream';
   }
 };

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
@@ -287,6 +287,7 @@ const operationStatements = ({
         // jsonBodySerializer is the default, no need to specify
         break;
       case 'text':
+      case 'octet-stream':
         // ensure we don't use any serializer by default
         requestOptions.push({
           key: 'bodySerializer',


### PR DESCRIPTION
Related to issue #1855 

Issue when using Content-Type': 'application/octet-stream', it using default json serializer. The fix is adding new media type and body serializer to null when using Content-Type': 'application/octet-stream'