### PR TITLE
Typeid support

### DIFF
--- a/.changeset/clean-kiwis-worry.md
+++ b/.changeset/clean-kiwis-worry.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(typescript): add support for TypeID types

--- a/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/types.gen.ts
@@ -3,7 +3,7 @@
 export type Foo = {
     bar?: number;
     foo: bigint;
-    id: string;
+    id: UserId;
 };
 
 export type Bar = {
@@ -26,6 +26,10 @@ export type PostFooResponses = {
 };
 
 export type PostFooResponse = PostFooResponses[keyof PostFooResponses];
+
+export type TypeID<T extends string> = `${T}_${string}`;
+
+export type UserId = TypeID<'user'>;
 
 export type ClientOptions = {
     baseUrl: string;

--- a/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/types.gen.ts
@@ -3,7 +3,7 @@
 export type Foo = {
     bar?: number;
     foo: bigint;
-    id: string;
+    id: UserId;
 };
 
 export type Bar = {
@@ -26,6 +26,10 @@ export type PostFooResponses = {
 };
 
 export type PostFooResponse = PostFooResponses[keyof PostFooResponses];
+
+export type TypeID<T extends string> = `${T}_${string}`;
+
+export type UserId = TypeID<'user'>;
 
 export type ClientOptions = {
     baseUrl: string;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/types.gen.ts
@@ -3,7 +3,7 @@
 export type Foo = {
     bar?: number;
     foo: bigint;
-    id: string;
+    id: UserId;
 };
 
 export type Bar = {
@@ -26,6 +26,10 @@ export type PostFooResponses = {
 };
 
 export type PostFooResponse = PostFooResponses[keyof PostFooResponses];
+
+export type TypeID<T extends string> = `${T}_${string}`;
+
+export type UserId = TypeID<'user'>;
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/types.gen.ts
@@ -3,7 +3,7 @@
 export type Foo = {
     bar?: number;
     foo: bigint;
-    id: string;
+    id: UserId;
 };
 
 export type Bar = {
@@ -26,6 +26,10 @@ export type PostFooResponses = {
 };
 
 export type PostFooResponse = PostFooResponses[keyof PostFooResponses];
+
+export type TypeID<T extends string> = `${T}_${string}`;
+
+export type UserId = TypeID<'user'>;
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/types.gen.ts
@@ -3,7 +3,7 @@
 export type Foo = {
     bar?: number;
     foo: bigint;
-    id: string;
+    id: UserId;
 };
 
 export type Bar = {
@@ -26,6 +26,10 @@ export type PostFooResponses = {
 };
 
 export type PostFooResponse = PostFooResponses[keyof PostFooResponses];
+
+export type TypeID<T extends string> = `${T}_${string}`;
+
+export type UserId = TypeID<'user'>;
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/types.gen.ts
@@ -3,7 +3,7 @@
 export type Foo = {
     bar?: number;
     foo: bigint;
-    id: string;
+    id: UserId;
 };
 
 export type Bar = {
@@ -26,6 +26,10 @@ export type PostFooResponses = {
 };
 
 export type PostFooResponse = PostFooResponses[keyof PostFooResponses];
+
+export type TypeID<T extends string> = `${T}_${string}`;
+
+export type UserId = TypeID<'user'>;
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/test/spec/2.0.x/type-format.yaml
+++ b/packages/openapi-ts-tests/test/spec/2.0.x/type-format.yaml
@@ -24,6 +24,8 @@ definitions:
         type: integer
       id:
         type: string
+        format: typeid
+        example: 'user_123'
     required:
       - id
       - foo

--- a/packages/openapi-ts-tests/test/spec/3.0.x/type-format.yaml
+++ b/packages/openapi-ts-tests/test/spec/3.0.x/type-format.yaml
@@ -25,6 +25,8 @@ components:
           type: integer
         id:
           type: string
+          format: typeid
+          example: 'user_123'
       required:
         - id
         - foo

--- a/packages/openapi-ts-tests/test/spec/3.1.x/type-format.yaml
+++ b/packages/openapi-ts-tests/test/spec/3.1.x/type-format.yaml
@@ -25,6 +25,8 @@ components:
           type: integer
         id:
           type: string
+          format: typeid
+          example: 'user_123'
       required:
         - id
         - foo

--- a/packages/openapi-ts/src/ir/types.d.ts
+++ b/packages/openapi-ts/src/ir/types.d.ts
@@ -139,6 +139,7 @@ interface IRSchemaObject
     | 'pattern'
     | 'required'
     | 'title'
+    | 'example'
   > {
   /**
    * If the schema is intended to be used as an object property, it can be

--- a/packages/openapi-ts/src/openApi/2.0.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/2.0.x/parser/schema.ts
@@ -34,6 +34,10 @@ const parseSchemaJsDoc = ({
   irSchema: IR.SchemaObject;
   schema: SchemaObject;
 }) => {
+  if (schema.example) {
+    irSchema.example = schema.example;
+  }
+
   if (schema.description) {
     irSchema.description = schema.description;
   }

--- a/packages/openapi-ts/src/openApi/3.0.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/3.0.x/parser/schema.ts
@@ -38,6 +38,10 @@ const parseSchemaJsDoc = ({
     irSchema.deprecated = schema.deprecated;
   }
 
+  if (schema.example) {
+    irSchema.example = schema.example;
+  }
+
   if (schema.description) {
     irSchema.description = schema.description;
   }

--- a/packages/openapi-ts/src/openApi/3.1.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/3.1.x/parser/schema.ts
@@ -41,6 +41,10 @@ const parseSchemaJsDoc = ({
     irSchema.deprecated = schema.deprecated;
   }
 
+  if (schema.example) {
+    irSchema.example = schema.example;
+  }
+
   if (schema.description) {
     irSchema.description = schema.description;
   }

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/operation.ts
@@ -18,6 +18,7 @@ import {
   transformersId,
 } from '../transformers/plugin';
 import { typesId } from '../typescript/ref';
+import type { PluginState } from '../typescript/types';
 import { operationAuth } from './auth';
 import { nuxtTypeComposable, nuxtTypeDefault, sdkId } from './constants';
 import type { HeyApiSdkPlugin } from './types';
@@ -211,6 +212,9 @@ export const operationParameters = ({
   };
 
   const pluginTypeScript = plugin.getPlugin('@hey-api/typescript')!;
+  const typescriptState: PluginState = {
+    usedTypeIDs: new Set<string>(),
+  };
   const client = getClientPlugin(plugin.context.config);
   const isNuxtClient = client.name === '@hey-api/client-nuxt';
 
@@ -243,6 +247,7 @@ export const operationParameters = ({
             },
             plugin: pluginTypeScript,
             schema: parameter.schema,
+            state: typescriptState,
           }),
         });
       }
@@ -274,6 +279,7 @@ export const operationParameters = ({
             },
             plugin: pluginTypeScript,
             schema: parameter.schema,
+            state: typescriptState,
           }),
         });
       }
@@ -300,6 +306,7 @@ export const operationParameters = ({
           },
           plugin: pluginTypeScript,
           schema: operation.body.schema,
+          state: typescriptState,
         }),
       });
     }

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/operation.ts
@@ -7,7 +7,7 @@ import type { IR } from '../../../ir/types';
 import { buildName } from '../../../openApi/shared/utils/name';
 import { schemaToType } from './plugin';
 import { typesId } from './ref';
-import type { HeyApiTypeScriptPlugin } from './types';
+import type { HeyApiTypeScriptPlugin, PluginState } from './types';
 
 const irParametersToIrSchema = ({
   parameters,
@@ -48,9 +48,11 @@ const irParametersToIrSchema = ({
 const operationToDataType = ({
   operation,
   plugin,
+  state,
 }: {
   operation: IR.OperationObject;
   plugin: HeyApiTypeScriptPlugin['Instance'];
+  state: PluginState;
 }) => {
   const file = plugin.context.file({ id: typesId })!;
   const data: IR.SchemaObject = {
@@ -138,6 +140,7 @@ const operationToDataType = ({
     onRef: undefined,
     plugin,
     schema: data,
+    state,
   });
   const node = compiler.typeAliasDeclaration({
     exportType: nodeInfo.exported,
@@ -150,11 +153,13 @@ const operationToDataType = ({
 export const operationToType = ({
   operation,
   plugin,
+  state,
 }: {
   operation: IR.OperationObject;
   plugin: HeyApiTypeScriptPlugin['Instance'];
+  state: PluginState;
 }) => {
-  operationToDataType({ operation, plugin });
+  operationToDataType({ operation, plugin, state });
 
   const file = plugin.context.file({ id: typesId })!;
 
@@ -177,6 +182,7 @@ export const operationToType = ({
       onRef: undefined,
       plugin,
       schema: errors,
+      state,
     });
     const node = compiler.typeAliasDeclaration({
       exportType: nodeInfo.exported,
@@ -232,6 +238,7 @@ export const operationToType = ({
       onRef: undefined,
       plugin,
       schema: responses,
+      state,
     });
     const node = compiler.typeAliasDeclaration({
       exportType: nodeInfo.exported,

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/types.d.ts
@@ -425,4 +425,8 @@ export type Config = Plugin.Name<'@hey-api/typescript'> & {
   tree: boolean;
 };
 
+export interface PluginState {
+  usedTypeIDs: Set<string>;
+}
+
 export type HeyApiTypeScriptPlugin = DefinePlugin<UserConfig, Config, Api>;

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/infiniteQueryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/infiniteQueryOptions.ts
@@ -295,9 +295,13 @@ export const createInfiniteQueryOptions = ({
   const pluginTypeScript = plugin.getPlugin('@hey-api/typescript')!;
   // TODO: parser - this is a bit clunky, need to compile type to string because
   // `compiler.returnFunctionCall()` accepts only strings, should be cleaned up
+  const typescriptState = {
+    usedTypeIDs: new Set<string>(),
+  };
   const type = pluginTypeScript.api.schemaToType({
     plugin: pluginTypeScript,
     schema: pagination.schema,
+    state: typescriptState,
   });
   const typePageParam = `${tsNodeToString({
     node: type,


### PR DESCRIPTION
See #2033 

This is a very rough draft. I originally tried to use the `x-typeid-type` property I proposed in https://github.com/jetify-com/typeid/issues/45. Then I noticed there's an IR involved and decided to temporarily extract the type name from the `example` field instead (which I also had to add to the parsers/IR).

I've tested this by modifying the `openapi-ts-fetch` example. I downloaded the openapi.yml file and modified the `id` property of `Order` to be a typeid like this:
```yml
        id:
          type: string
          format: typeid
          example: order_1111
```
And added `typeids: true,` to the `openapi-ts.config.ts` file.

This produced this output:
```ts
export type TypeID<T extends string> = `${T}_${string}`;

export type OrderId = TypeId<'order'>;

export type Order = {
  complete?: boolean;
  id?: OrderId;
  /* ... */
}
```

Nice 🎉

~~Currently the TypeID<T> declaration is always added. Which means if you enable the config option but don't use typeids, you'll get an unused type warning.~~

## Questions

- I want to use `x-typeid-type` instead of parsing the `example` value, but I'm unsure given the current IR infrastructure. I don't believe adding arbitrary extensions to the parser is maintainable. One I had was: what if the IR had an extra field which simply contained the original object or just `x-*` properties? This feels more future-proof to me.
- ~~Should `TypeID<T>` be exported or should consumers do `User["id"]` instead of `TypeID<"user">` if they want to access the type themselves?~~
- ~~Should there be a concrete type per ID (eg `type UserID = "user_${string}"`) instead of the `TypeID` "overlord" (or maybe both)? This would require extending the "State" interface to keep track of already generated ID types~~