### PR TITLE
fix(typescript): exclude  in readable/writable schemas when referenced schemas don't contain any readable/writable fields

### DIFF
--- a/.changeset/empty-trains-repair.md
+++ b/.changeset/empty-trains-repair.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix(typescript): exclude $refs in readable/writable schemas when referenced schemas don't contain any readable/writable fields

--- a/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/read-write-only-custom-name/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/read-write-only-custom-name/types.gen.ts
@@ -16,6 +16,19 @@ export type Baz = {
     baz?: string;
 };
 
+export type QuxAllRead = {
+    readonly baz?: string;
+};
+
+export type ReadableQuux = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
+export type WritableQuux = {
+    baz?: Array<Baz>;
+};
+
 export type PostFooReadData = {
     body: WritableFooRead;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/read-write-only-ignore/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/read-write-only-ignore/types.gen.ts
@@ -12,6 +12,15 @@ export type Baz = {
     baz?: string;
 };
 
+export type QuxAllRead = {
+    readonly baz?: string;
+};
+
+export type Quux = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
 export type PostFooReadData = {
     body: FooRead;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/2.0.x/read-write-only/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/2.0.x/read-write-only/types.gen.ts
@@ -16,6 +16,19 @@ export type Baz = {
     baz?: string;
 };
 
+export type QuxAllRead = {
+    readonly baz?: string;
+};
+
+export type QuuxReadable = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
+export type QuuxWritable = {
+    baz?: Array<Baz>;
+};
+
 export type PostFooReadData = {
     body: FooReadWritable;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/read-write-only-custom-name/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/read-write-only-custom-name/types.gen.ts
@@ -34,6 +34,19 @@ export type Baz = {
     baz?: string;
 };
 
+export type QuxAllRead = {
+    readonly baz?: string;
+};
+
+export type ReadableQuux = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
+export type WritableQuux = {
+    baz?: Array<Baz>;
+};
+
 export type PostFooReadWriteData = {
     body: WritableFooReadWrite;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/read-write-only-ignore/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/read-write-only-ignore/types.gen.ts
@@ -24,6 +24,15 @@ export type Baz = {
     baz?: string;
 };
 
+export type QuxAllRead = {
+    readonly baz?: string;
+};
+
+export type Quux = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
 export type PostFooReadWriteData = {
     body: FooReadWrite;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/read-write-only/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/read-write-only/types.gen.ts
@@ -34,6 +34,19 @@ export type Baz = {
     baz?: string;
 };
 
+export type QuxAllRead = {
+    readonly baz?: string;
+};
+
+export type QuuxReadable = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
+export type QuuxWritable = {
+    baz?: Array<Baz>;
+};
+
 export type PostFooReadWriteData = {
     body: FooReadWriteWritable;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/read-write-only-custom-name/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/read-write-only-custom-name/types.gen.ts
@@ -42,6 +42,15 @@ export type QuxAllRead = {
     readonly baz?: string;
 };
 
+export type ReadableQuux = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
+export type WritableQuux = {
+    baz?: Array<Baz>;
+};
+
 export type PostFooReadWriteData = {
     body: WritableFooReadWrite;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/read-write-only-ignore/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/read-write-only-ignore/types.gen.ts
@@ -32,6 +32,11 @@ export type QuxAllRead = {
     readonly baz?: string;
 };
 
+export type Quux = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
 export type PostFooReadWriteData = {
     body: FooReadWrite;
     path?: never;

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/read-write-only/types.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/read-write-only/types.gen.ts
@@ -42,6 +42,15 @@ export type QuxAllRead = {
     readonly baz?: string;
 };
 
+export type QuuxReadable = {
+    baz?: Array<Baz>;
+    qux?: QuxAllRead;
+};
+
+export type QuuxWritable = {
+    baz?: Array<Baz>;
+};
+
 export type PostFooReadWriteData = {
     body: FooReadWriteWritable;
     path?: never;

--- a/packages/openapi-ts-tests/test/spec/2.0.x/read-write-only.yaml
+++ b/packages/openapi-ts-tests/test/spec/2.0.x/read-write-only.yaml
@@ -42,3 +42,18 @@ definitions:
     properties:
       baz:
         type: string
+  QuxAllRead:
+    type: object
+    properties:
+      baz:
+        readOnly: true
+        type: string
+  Quux:
+    type: object
+    properties:
+      baz:
+        type: array
+        items:
+          $ref: '#/definitions/Baz'
+      qux:
+        $ref: '#/definitions/QuxAllRead'

--- a/packages/openapi-ts-tests/test/spec/3.0.x/read-write-only.yaml
+++ b/packages/openapi-ts-tests/test/spec/3.0.x/read-write-only.yaml
@@ -95,3 +95,18 @@ components:
       properties:
         baz:
           type: string
+    QuxAllRead:
+      type: object
+      properties:
+        baz:
+          readOnly: true
+          type: string
+    Quux:
+      type: object
+      properties:
+        baz:
+          type: array
+          items:
+            $ref: '#/components/schemas/Baz'
+        qux:
+          $ref: '#/components/schemas/QuxAllRead'

--- a/packages/openapi-ts-tests/test/spec/3.1.x/read-write-only.yaml
+++ b/packages/openapi-ts-tests/test/spec/3.1.x/read-write-only.yaml
@@ -111,3 +111,12 @@ components:
         baz:
           readOnly: true
           type: string
+    Quux:
+      type: object
+      properties:
+        baz:
+          type: array
+          items:
+            $ref: '#/components/schemas/Baz'
+        qux:
+          $ref: '#/components/schemas/QuxAllRead'

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/plugin.ts
@@ -89,8 +89,11 @@ const shouldSkipSchema = ({
 }) =>
   Boolean(
     state?.accessScope &&
-      schema.accessScope &&
-      state.accessScope !== schema.accessScope,
+      ((schema.accessScope && state.accessScope !== schema.accessScope) ||
+        (schema.$ref &&
+          schema.accessScopes &&
+          !schema.accessScopes.includes(state.accessScope) &&
+          !schema.accessScopes.includes('both'))),
   );
 
 const addJavaScriptEnum = ({


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/2021