### PR TITLE
use baseurl from options first, otherwise from the given clients

### DIFF
--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/queryKey.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/queryKey.ts
@@ -75,7 +75,7 @@ export const createQueryKeyFunction = ({
                 {
                   key: getClientBaseUrlKey(context.config),
                   value: compiler.identifier({
-                    text: `(options?.client ?? _heyApiClient).getConfig().${getClientBaseUrlKey(context.config)}`,
+                    text: `options.baseUrl || (options?.client ?? _heyApiClient).getConfig().${getClientBaseUrlKey(context.config)}`,
                   }),
                 },
               ],


### PR DESCRIPTION
I cannot overwrite the baseurl via the options as it is always used from the passed in or global client .