### PR TITLE
fix(client-nuxt): fixed an issue where key was stripped from options

### DIFF
--- a/.changeset/famous-ducks-fry.md
+++ b/.changeset/famous-ducks-fry.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/client-nuxt": patch
+---
+
+fix(client-nuxt): fixed an issue where key was stripped from options

--- a/packages/client-nuxt/src/client.ts
+++ b/packages/client-nuxt/src/client.ts
@@ -31,9 +31,9 @@ export const createClient = (config: Config = {}): Client => {
   const request: Client['request'] = ({
     asyncDataOptions,
     composable,
-    key,
     ...options
   }) => {
+    const key = options.key;
     const opts = {
       ..._config,
       ...options,


### PR DESCRIPTION
`key` was stripped from the the options object during restructuring, causing it not to be passed to `useFetch` or `useLazyFetch`.