### PR TITLE
fix(tanstack-query): create a shallow copy of queryKey in createInfiniteParams function

### DIFF
--- a/.changeset/perfect-garlics-return.md
+++ b/.changeset/perfect-garlics-return.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix(tanstack-query): create a shallow copy of queryKey in createInfiniteParams function

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/pagination-ref/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/pagination-ref/@tanstack/react-query.gen.ts
@@ -54,7 +54,9 @@ export const getFooOptions = (options: Options<GetFooData>) => {
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
@@ -337,7 +337,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
@@ -336,7 +336,9 @@ export const callWithParametersOptions = (options: Options<CallWithParametersDat
 };
 
 const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-    const params = queryKey[0];
+    const params = {
+        ...queryKey[0]
+    };
     if (page.body) {
         params.body = {
             ...queryKey[0].body as any,

--- a/packages/openapi-ts-tests/test/openapi-ts.config.ts
+++ b/packages/openapi-ts-tests/test/openapi-ts.config.ts
@@ -44,14 +44,14 @@ export default defineConfig(() => {
       //   openapi: '3.1.0',
       //   paths: {},
       // },
-      path: path.resolve(
-        __dirname,
-        'spec',
-        '3.1.x',
-        'invalid',
-        'servers-entry.yaml',
-      ),
-      // path: path.resolve(__dirname, 'spec', '3.1.x', 'servers.yaml'),
+      // path: path.resolve(
+      //   __dirname,
+      //   'spec',
+      //   '3.1.x',
+      //   'invalid',
+      //   'servers-entry.yaml',
+      // ),
+      path: path.resolve(__dirname, 'spec', '3.1.x', 'full.json'),
       // path: 'http://localhost:4000/',
       // path: 'https://get.heyapi.dev/',
       // path: 'https://get.heyapi.dev/hey-api/backend?branch=main&version=1.0.0',
@@ -136,7 +136,7 @@ export default defineConfig(() => {
       },
       {
         exportFromIndex: true,
-        // name: '@tanstack/vue-query',
+        name: '@tanstack/vue-query',
       },
       {
         // comments: false,

--- a/packages/openapi-ts/src/compiler/types.ts
+++ b/packages/openapi-ts/src/compiler/types.ts
@@ -72,7 +72,7 @@ export const createPropertyAccessExpression = ({
 }: {
   expression: string | ts.Expression;
   isOptional?: boolean;
-  name: string | ts.MemberName;
+  name: string | number | ts.MemberName;
 }):
   | ts.PropertyAccessChain
   | ts.PropertyAccessExpression
@@ -82,7 +82,7 @@ export const createPropertyAccessExpression = ({
       ? createIdentifier({ text: expression })
       : expression;
 
-  if (isOptional) {
+  if (isOptional && typeof name !== 'number') {
     return createPropertyAccessChain({
       expression: nodeExpression,
       name,
@@ -100,12 +100,17 @@ export const createPropertyAccessExpression = ({
       const nodeName = createIdentifier({ text: name });
       return ts.factory.createElementAccessExpression(nodeExpression, nodeName);
     }
+
+    const nodeName = createIdentifier({ text: name });
+    return ts.factory.createPropertyAccessExpression(nodeExpression, nodeName);
   }
 
-  const nodeName =
-    typeof name === 'string' ? createIdentifier({ text: name }) : name;
+  if (typeof name === 'number') {
+    const nodeName = ts.factory.createNumericLiteral(name);
+    return ts.factory.createElementAccessExpression(nodeExpression, nodeName);
+  }
 
-  return ts.factory.createPropertyAccessExpression(nodeExpression, nodeName);
+  return ts.factory.createPropertyAccessExpression(nodeExpression, name);
 };
 
 export const createNull = (): ts.NullLiteral => ts.factory.createNull();

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/infiniteQueryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/infiniteQueryOptions.ts
@@ -50,8 +50,15 @@ const createInfiniteParamsFunction = ({
       ],
       statements: [
         compiler.constVariable({
-          expression: compiler.identifier({
-            text: 'queryKey[0]',
+          expression: compiler.objectExpression({
+            obj: [
+              {
+                spread: compiler.propertyAccessExpression({
+                  expression: 'queryKey',
+                  name: 0,
+                }),
+              },
+            ],
           }),
           name: 'params',
         }),


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/2050