### PR TITLE
Add `throwOnError` configuration option to tanstack-query plugin

### DIFF
--- a/docs/openapi-ts/plugins/tanstack-query.md
+++ b/docs/openapi-ts/plugins/tanstack-query.md
@@ -108,6 +108,29 @@ export default {
 
 :::
 
+## Configs
+
+### throwOnError
+
+default: `true`
+
+When set to `true`, generated queries will have `throwOnError` set to `true`.
+
+```js
+export default {
+  input: 'https://get.heyapi.dev/hey-api/backend',
+  output: 'src/client',
+  plugins: [
+    ...defaultPlugins,
+    '@hey-api/client-fetch',
+    {
+      name: '@tanstack/solid-query',
+      throwOnError: false, // [!code ++]
+    },
+  ],
+};
+```
+
 ## Output
 
 The TanStack Query plugin will generate the following artifacts, depending on the input specification.

--- a/packages/openapi-ts/src/plugins/@tanstack/angular-query-experimental/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/angular-query-experimental/types.d.ts
@@ -29,4 +29,10 @@ export interface Config
    * @default true
    */
   queryOptions?: boolean;
+  /**
+   * Generate queries with `throwOnError` option when `true`, queries will throw errors instead of returning them in the error state, allowing for easier error handling with error boundaries.
+   *
+   * @default true
+   */
+  throwOnError?: boolean;
 }

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/infiniteQueryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/infiniteQueryOptions.ts
@@ -352,11 +352,13 @@ export const createInfiniteQueryOptions = ({
                 text: 'signal',
               }),
             },
-            {
-              key: 'throwOnError',
-              value: true,
-            },
-          ],
+            plugin.throwOnError === false
+              ? null
+              : {
+                  key: 'throwOnError',
+                  value: true,
+                },
+          ].filter((o) => o),
         }),
       ],
     }),

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/mutationOptions.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/mutationOptions.ts
@@ -84,11 +84,13 @@ export const createMutationOptions = ({
             {
               spread: 'localOptions',
             },
-            {
-              key: 'throwOnError',
-              value: true,
-            },
-          ],
+            plugin.throwOnError === false
+              ? null
+              : {
+                  key: 'throwOnError',
+                  value: true,
+                },
+          ].filter((o) => o),
         }),
       ],
     }),

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin-legacy.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/plugin-legacy.ts
@@ -845,11 +845,13 @@ export const handlerLegacy: Plugin.LegacyHandler<
                                             text: 'signal',
                                           }),
                                         },
-                                        {
-                                          key: 'throwOnError',
-                                          value: true,
-                                        },
-                                      ],
+                                        plugin.throwOnError === false
+                                          ? null
+                                          : {
+                                              key: 'throwOnError',
+                                              value: true,
+                                            },
+                                      ].filter((o) => o),
                                     }),
                                   ],
                                 }),

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/queryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/queryOptions.ts
@@ -111,11 +111,13 @@ export const createQueryOptions = ({
                 text: 'signal',
               }),
             },
-            {
-              key: 'throwOnError',
-              value: true,
-            },
-          ],
+            plugin.throwOnError === false
+              ? null
+              : {
+                  key: 'throwOnError',
+                  value: true,
+                },
+          ].filter((o) => o),
         }),
       ],
     }),

--- a/packages/openapi-ts/src/plugins/@tanstack/react-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/react-query/types.d.ts
@@ -29,4 +29,10 @@ export interface Config
    * @default true
    */
   queryOptions?: boolean;
+  /**
+   * Generate queries with {@link https://tanstack.com/query/v5/docs/framework/react/guides/query-options#throwonerror `throwOnError`} option when `true`, queries will throw errors instead of returning them in the error state, allowing for easier error handling with error boundaries.
+   *
+   * @default true
+   */
+  throwOnError?: boolean;
 }

--- a/packages/openapi-ts/src/plugins/@tanstack/solid-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/solid-query/types.d.ts
@@ -29,4 +29,10 @@ export interface Config
    * @default true
    */
   queryOptions?: boolean;
+  /**
+   * Generate queries with `throwOnError` option enabled? When enabled, queries will throw errors instead of returning them in the error state, allowing for easier error handling with error boundaries.
+   *
+   * @default true
+   */
+  throwOnError?: boolean;
 }

--- a/packages/openapi-ts/src/plugins/@tanstack/svelte-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/svelte-query/types.d.ts
@@ -29,4 +29,10 @@ export interface Config
    * @default true
    */
   queryOptions?: boolean;
+  /**
+   * Generate queries with `throwOnError` option when `true`, queries will throw errors instead of returning them in the error state, allowing for easier error handling with error boundaries.
+   *
+   * @default true
+   */
+  throwOnError?: boolean;
 }

--- a/packages/openapi-ts/src/plugins/@tanstack/vue-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/vue-query/types.d.ts
@@ -29,4 +29,10 @@ export interface Config
    * @default true
    */
   queryOptions?: boolean;
+  /**
+   * Generate queries with {@link https://tanstack.com/query/v5/docs/framework/vue/guides/query-options#throwonerror `throwOnError`} option when `true`, queries will throw errors instead of returning them in the error state, allowing for easier error handling with error boundaries.
+   *
+   * @default true
+   */
+  throwOnError?: boolean;
 }


### PR DESCRIPTION
Currently, all generated queries have the `throwOnError` option set to `true` by default. This works well for new projects or when all components using these queries properly implement error boundaries.

However, in cases where error boundaries are not appropriately set up, developers may need to manually remove this option from each generated query, which can be cumbersome.

This PR introduces a configuration option that allows users to control whether the `throwOnError` option should be included in generated queries, providing more flexibility for different project setups.