### PR TITLE
fix(parser): skip schema if it's an array or tuple and its items don't have any matching readable or writable scopes

### DIFF
--- a/.changeset/nice-badgers-stare.md
+++ b/.changeset/nice-badgers-stare.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix(parser): skip schema if it's an array or tuple and its items don't have any matching readable or writable scopes

--- a/packages/openapi-ts-tests/test/openapi-ts.config.ts
+++ b/packages/openapi-ts-tests/test/openapi-ts.config.ts
@@ -93,13 +93,13 @@ export default defineConfig(() => {
         // bundle: true,
         // bundleSource_EXPERIMENTAL: true,
         // exportFromIndex: true,
-        // name: '@hey-api/client-fetch',
-        name: 'legacy/fetch',
+        name: '@hey-api/client-fetch',
+        // name: 'legacy/fetch',
         // strictBaseUrl: true,
       },
       {
         exportFromIndex: true,
-        name: '@hey-api/schemas',
+        // name: '@hey-api/schemas',
         // type: 'json',
       },
       {

--- a/packages/openapi-ts/src/ir/utils.ts
+++ b/packages/openapi-ts/src/ir/utils.ts
@@ -1,4 +1,21 @@
+import { mergeSchemaAccessScopes } from '../openApi/shared/utils/schema';
 import type { IR } from './types';
+
+const assignItems = ({
+  items,
+  schema,
+}: {
+  items: Array<IR.SchemaObject>;
+  schema: IR.SchemaObject;
+}) => {
+  for (const item of items) {
+    schema.accessScopes = mergeSchemaAccessScopes(
+      schema.accessScopes,
+      item.accessScopes,
+    );
+  }
+  schema.items = items;
+};
 
 /**
  * Simply adds `items` to the schema. Also handles setting the logical operator
@@ -20,12 +37,12 @@ export const addItemsToSchema = ({
   }
 
   if (schema.type === 'tuple') {
-    schema.items = items;
+    assignItems({ items, schema });
     return schema;
   }
 
   if (items.length !== 1) {
-    schema.items = items;
+    assignItems({ items, schema });
     schema.logicalOperator = logicalOperator;
     return schema;
   }
@@ -39,6 +56,6 @@ export const addItemsToSchema = ({
     return schema;
   }
 
-  schema.items = items;
+  assignItems({ items, schema });
   return schema;
 };


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/2136