### PR TITLE
custom transformers

### DIFF
--- a/.changeset/giant-carrots-change.md
+++ b/.changeset/giant-carrots-change.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(transformers): add `transformers` option allowing passing custom transform functions

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -105,6 +105,7 @@ export const createClient = async (
 export const defineConfig = async (config: Configs): Promise<UserConfig> =>
   typeof config === 'function' ? await config() : config;
 
+export { compiler } from './compiler';
 export { defaultPaginationKeywords } from './config/parser';
 export { defaultPlugins } from './config/plugins';
 export type { IR } from './ir/types';
@@ -123,6 +124,7 @@ export {
 } from './plugins/@hey-api/client-core/config';
 export { clientPluginHandler } from './plugins/@hey-api/client-core/plugin';
 export type { Client } from './plugins/@hey-api/client-core/types';
+export type { expressionTransformer } from './plugins/@hey-api/transformers';
 export { definePluginConfig } from './plugins/shared/utils/config';
 export type { DefinePlugin, Plugin } from './plugins/types';
 export type { UserConfig } from './types/config';

--- a/packages/openapi-ts/src/plugins/@hey-api/transformers/expressions-transformers.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/transformers/expressions-transformers.ts
@@ -1,0 +1,96 @@
+import type ts from 'typescript';
+
+import { compiler } from '../../../compiler';
+import type { TypeScriptFile } from '../../../generate/files';
+import type { IR } from '../../../ir/types';
+import type { Config } from './types';
+
+export type expressionTransformer = ({
+  config,
+  dataExpression,
+  file,
+  schema,
+}: {
+  config: Config;
+  dataExpression?: ts.Expression | string;
+  file: TypeScriptFile;
+  schema: IR.SchemaObject;
+}) => Array<ts.Expression> | undefined;
+
+export const bigIntExpressions: expressionTransformer = ({
+  dataExpression,
+  schema,
+}) => {
+  if (schema.type !== 'integer' || schema.format !== 'int64') {
+    return undefined;
+  }
+
+  const bigIntCallExpression =
+    dataExpression !== undefined
+      ? compiler.callExpression({
+          functionName: 'BigInt',
+          parameters: [
+            compiler.callExpression({
+              functionName: compiler.propertyAccessExpression({
+                expression: dataExpression,
+                name: 'toString',
+              }),
+            }),
+          ],
+        })
+      : undefined;
+
+  if (bigIntCallExpression) {
+    if (typeof dataExpression === 'string') {
+      return [bigIntCallExpression];
+    }
+
+    if (dataExpression) {
+      return [
+        compiler.assignment({
+          left: dataExpression,
+          right: bigIntCallExpression,
+        }),
+      ];
+    }
+  }
+
+  return [];
+};
+
+export const dateExpressions: expressionTransformer = ({
+  dataExpression,
+  schema,
+}) => {
+  if (
+    schema.type !== 'string' ||
+    !(schema.format === 'date' || schema.format === 'date-time')
+  ) {
+    return undefined;
+  }
+
+  const identifierDate = compiler.identifier({ text: 'Date' });
+
+  if (typeof dataExpression === 'string') {
+    return [
+      compiler.newExpression({
+        argumentsArray: [compiler.identifier({ text: dataExpression })],
+        expression: identifierDate,
+      }),
+    ];
+  }
+
+  if (dataExpression) {
+    return [
+      compiler.assignment({
+        left: dataExpression,
+        right: compiler.newExpression({
+          argumentsArray: [dataExpression],
+          expression: identifierDate,
+        }),
+      }),
+    ];
+  }
+
+  return [];
+};

--- a/packages/openapi-ts/src/plugins/@hey-api/transformers/index.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/transformers/index.ts
@@ -1,2 +1,4 @@
+export { compiler } from '../../../compiler';
 export { defaultConfig, defineConfig } from './config';
+export { type expressionTransformer } from './expressions-transformers';
 export type { HeyApiTransformersPlugin } from './types';

--- a/packages/openapi-ts/src/plugins/@hey-api/transformers/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/transformers/plugin.ts
@@ -10,6 +10,7 @@ import { irRef } from '../../../utils/ref';
 import { stringCase } from '../../../utils/stringCase';
 import { operationIrRef } from '../../shared/utils/ref';
 import { typesId } from '../typescript/ref';
+import { bigIntExpressions, dateExpressions } from './expressions-transformers';
 import type { HeyApiTransformersPlugin } from './types';
 
 interface OperationIRRef {
@@ -18,75 +19,6 @@ interface OperationIRRef {
    */
   id: string;
 }
-
-const bigIntExpressions = ({
-  dataExpression,
-}: {
-  dataExpression?: ts.Expression | string;
-}): Array<ts.Expression> => {
-  const bigIntCallExpression =
-    dataExpression !== undefined
-      ? compiler.callExpression({
-          functionName: 'BigInt',
-          parameters: [
-            compiler.callExpression({
-              functionName: compiler.propertyAccessExpression({
-                expression: dataExpression,
-                name: 'toString',
-              }),
-            }),
-          ],
-        })
-      : undefined;
-
-  if (bigIntCallExpression) {
-    if (typeof dataExpression === 'string') {
-      return [bigIntCallExpression];
-    }
-
-    if (dataExpression) {
-      return [
-        compiler.assignment({
-          left: dataExpression,
-          right: bigIntCallExpression,
-        }),
-      ];
-    }
-  }
-
-  return [];
-};
-
-const dateExpressions = ({
-  dataExpression,
-}: {
-  dataExpression?: ts.Expression | string;
-}): Array<ts.Expression> => {
-  const identifierDate = compiler.identifier({ text: 'Date' });
-
-  if (typeof dataExpression === 'string') {
-    return [
-      compiler.newExpression({
-        argumentsArray: [compiler.identifier({ text: dataExpression })],
-        expression: identifierDate,
-      }),
-    ];
-  }
-
-  if (dataExpression) {
-    return [
-      compiler.assignment({
-        left: dataExpression,
-        right: compiler.newExpression({
-          argumentsArray: [dataExpression],
-          expression: identifierDate,
-        }),
-      }),
-    ];
-  }
-
-  return [];
-};
 
 export const operationTransformerIrRef = ({
   id,
@@ -370,22 +302,6 @@ const processSchemaType = ({
     return nodes;
   }
 
-  if (
-    plugin.config.dates &&
-    schema.type === 'string' &&
-    (schema.format === 'date' || schema.format === 'date-time')
-  ) {
-    return dateExpressions({ dataExpression });
-  }
-
-  if (
-    plugin.config.bigInt &&
-    schema.type === 'integer' &&
-    schema.format === 'int64'
-  ) {
-    return bigIntExpressions({ dataExpression });
-  }
-
   if (schema.items) {
     if (schema.items.length === 1) {
       return processSchemaType({
@@ -449,6 +365,18 @@ const processSchemaType = ({
     }
   }
 
+  for (const transformer of plugin.config.transformers ?? []) {
+    const t = transformer({
+      config: plugin.config,
+      dataExpression,
+      file,
+      schema,
+    });
+    if (t) {
+      return t;
+    }
+  }
+
   return [];
 };
 
@@ -458,6 +386,20 @@ export const handler: HeyApiTransformersPlugin['Handler'] = ({ plugin }) => {
     id: transformersId,
     path: plugin.output,
   });
+
+  if (plugin.config.dates) {
+    plugin.config.transformers = [
+      ...(plugin.config.transformers ?? []),
+      dateExpressions,
+    ];
+  }
+
+  if (plugin.config.bigInt) {
+    plugin.config.transformers = [
+      ...(plugin.config.transformers ?? []),
+      bigIntExpressions,
+    ];
+  }
 
   plugin.forEach('operation', ({ operation }) => {
     const { response } = operationResponsesMap(operation);

--- a/packages/openapi-ts/src/plugins/@hey-api/transformers/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/transformers/types.d.ts
@@ -26,6 +26,13 @@ export type Config = Plugin.Name<'@hey-api/transformers'> & {
    * @default 'transformers'
    */
   output?: string;
+
+  /**
+   * transformers to apply to the generated code
+   * @default []
+   */
+
+  transformers?: expressionTransformer[];
 };
 
 export type HeyApiTransformersPlugin = DefinePlugin<Config>;


### PR DESCRIPTION
### config
```typescript
{
	name: "@hey-api/transformers",
	dates: true,
	bigInt: false,
	transformers: [decimalExpressions],
}
```

### custom transformer
```typescript
import { compiler, type expressionTransformer } from "@hey-api/openapi-ts";

export const decimalExpressions: expressionTransformer = ({
	dataExpression,
	schema,
	file,
}) => {
	if (schema.type !== "string" || schema.format !== "decimal") {
		return undefined;
	}

	const decimalCallExpression =
		dataExpression !== undefined
			? compiler.newExpression({
					argumentsArray: [
						typeof dataExpression === "string"
							? compiler.identifier({ text: dataExpression })
							: dataExpression,
					],
					expression: compiler.identifier({ text: "Decimal" }),
				})
			: undefined;

	if (decimalCallExpression) {
		if (typeof dataExpression === "string") {
			return [decimalCallExpression];
		}

		file.import({
			module: "decimal.js",
			name: "Decimal",
		});

		if (dataExpression) {
			return [
				compiler.assignment({
					left: dataExpression,
					right: decimalCallExpression,
				}),
			];
		}
	}

	return [];
};
```

### output
```typescript
import { Decimal } from "decimal.js";
import type { myResponse } from "./types.gen";

const myResponseSchemaResponseTransformer = (data: any) => {
	if (data.amount) {
		data.amount = new Decimal(data.amount);
	}
	if (data.createdAt) {
		data.createdAt = new Date(data.createdAt);
	}
	return data;
};

export const myResponseTransformer = async (
	data: any,
): Promise<myResponse> => {
	data = myResponseSchemaResponseTransformer(data);
	return data;
};
```


### Limitation

In `types.gen.ts` you need to change the string type to the correct type (in this example `Decimal`) as the Date type

```typescript
export type myResponse = {
	/**
	 * The amount to withdraw
	 */
	amount?: string;
	/**
	 * The time the preview was created
	 */
	createdAt?: Date;
};
```