### PR TITLE
fix(operation): ensure output case handling is robust by checking for object type

### DIFF
--- a/packages/openapi-ts/src/openApi/shared/utils/operation.ts
+++ b/packages/openapi-ts/src/openApi/shared/utils/operation.ts
@@ -39,8 +39,9 @@ export const operationToId = ({
 
   const { output } = context.config;
   const targetCase =
-    (output !== undefined && 'case' in output ? output.case : undefined) ??
-    'camelCase';
+    (output !== undefined && typeof output === 'object' && 'case' in output
+      ? output.case
+      : undefined) ?? 'camelCase';
 
   if (
     id &&


### PR DESCRIPTION
This PR validates that the `output` in the config is an object before trying to use the 'in' operator on the value.

`output` can be either a string or an object; this check helps handle the case where' output' is a string.


Created to support #1947