### PR TITLE
feat(client-axios): Accept `AxiosInstance`

### DIFF
--- a/.changeset/odd-ligers-jump.md
+++ b/.changeset/odd-ligers-jump.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(client-axios): allow passing `AxiosInstance` into `axios` field

--- a/docs/openapi-ts/clients/axios.md
+++ b/docs/openapi-ts/clients/axios.md
@@ -210,12 +210,29 @@ console.log(url); // prints '/foo/1?bar=baz'
 You can implement your own `axios` instance. This is useful if you need to extend the default `axios` instance with extra functionality, or replace it altogether.
 
 ```js
+import axios from 'axios';
 import { client } from 'client/client.gen';
 
+// Customize the default axios instance
+axios.defaults.baseURL = 'https://example.com';
+
 client.setConfig({
-  axios: () => {
-    /* custom `axios` instance */
-  },
+  axios: axios,
+});
+```
+
+or you can pass an `AxiosInstance` created with `axios.create()`:
+
+```js
+import axios from 'axios';
+import { client } from 'client/client.gen';
+
+const customAxiosInstance = axios.create({
+  baseURL: 'https://example.com',
+});
+
+client.setConfig({
+  axios: customAxiosInstance,
 });
 ```
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types.js';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/types.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/__tests__/client.test.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { describe, expect, it } from 'vitest';
 
 import { createClient } from '../bundle/client';
@@ -46,5 +47,39 @@ describe('buildUrl', () => {
 
   it.each(scenarios)('returns $url', ({ options, url }) => {
     expect(client.buildUrl(options)).toBe(url);
+  });
+});
+
+describe('AxiosInstance', () => {
+  it('should create an AxiosInstance if no axios option passed', () => {
+    const client = createClient({ baseURL: 'test-url' });
+
+    expect(client.instance).toBeDefined();
+    expect(client.instance.defaults).toBeDefined();
+    expect(client.instance.defaults.baseURL).toBe('test-url');
+  });
+
+  it('should use the provided AxiosStatic if axios option passed', () => {
+    axios.defaults.baseURL = 'test-url';
+
+    const client = createClient({ axios });
+
+    expect(client.instance).toBeDefined();
+    expect(client.instance.defaults).toBeDefined();
+    expect(client.instance.defaults.baseURL).toBe('test-url');
+  });
+
+  it('should use the provided AxiosInstance if axios option is passed', () => {
+    const axiosInstance = axios.create({ baseURL: 'test-url' });
+
+    axiosInstance.interceptors.request.use((config) => config);
+
+    const client = createClient({ axios: axiosInstance });
+
+    expect(client.instance).toBe(axiosInstance);
+    expect(client.instance.defaults.baseURL).toBe('test-url');
+    expect((client.instance.interceptors.request as any).handlers.length).toBe(
+      1,
+    );
   });
 });

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
 import type { Client, Config } from './types';
@@ -13,9 +13,15 @@ import {
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { auth, ...configWithoutAuth } = _config;
-  const instance = axios.create(configWithoutAuth);
+  let instance: AxiosInstance;
+
+  if (_config.axios && !('Axios' in _config.axios)) {
+    instance = _config.axios;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { auth, ...configWithoutAuth } = _config;
+    instance = axios.create(configWithoutAuth);
+  }
 
   const getConfig = (): Config => ({ ..._config });
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/types.ts
@@ -17,12 +17,12 @@ export interface Config<T extends ClientOptions = ClientOptions>
   extends Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
     CoreConfig {
   /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
+   * Axios implementation. You can use this option to provide either an
+   * `AxiosStatic` or an `AxiosInstance`.
    *
    * @default axios
    */
-  axios?: AxiosStatic;
+  axios?: AxiosStatic | AxiosInstance;
   /**
    * Base URL for all requests made by this client.
    */


### PR DESCRIPTION
- enhance `createClient` to accept `AxiosStatic` or `AxiosInstance`
- updated docs

closes #2374