### PR TITLE
fix: add a check to prevent a recursion issue when asClass is true and the schema contains a tag and an operationId with the same name (e.g. "TodoItem")

### DIFF
--- a/.changeset/hip-teachers-kiss.md
+++ b/.changeset/hip-teachers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(sdk): prevent infinite loop when a schema tag matches operation ID

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
@@ -162,7 +162,7 @@ const generateClassSdk = ({
         }
 
         const parentClassName = entry.path[index - 1];
-        if (parentClassName) {
+        if (parentClassName && parentClassName !== currentClassName) {
           const parentClass = sdkClasses.get(parentClassName)!;
           parentClass.classes.add(currentClassName);
           sdkClasses.set(parentClassName, parentClass);


### PR DESCRIPTION
Fixes https://github.com/hey-api/openapi-ts/issues/2377

There is an issue a recursion issue when the schema contains a Tag and an operationId that are "normalized" to the same result e.g. "TodoItem".
This only happens when `asClass`is set to `true`