### PR TITLE
fix: cjs build

### DIFF
--- a/packages/openapi-ts/src/generate/client.ts
+++ b/packages/openapi-ts/src/generate/client.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import ts from 'typescript';
 
@@ -12,11 +12,8 @@ import type { Config } from '../types/config';
 import { splitNameAndExtension } from './file';
 import { ensureDirSync, relativeModulePath } from './utils';
 
-// Use require.resolve to find the package root, then construct the path
-// This approach works with Yarn PnP and doesn't rely on specific file exports
-const packageRoot = path.dirname(
-  createRequire(import.meta.url).resolve('@hey-api/openapi-ts/package.json'),
-);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const getClientSrcPath = (name: string) => {
   const pluginFilePathComponents = name.split(path.sep);
@@ -161,7 +158,7 @@ export const generateClientBundle = ({
     // copy client core
     const coreOutputPath = path.resolve(outputPath, 'core');
     ensureDirSync(coreOutputPath);
-    const coreDistPath = path.resolve(packageRoot, 'dist', 'clients', 'core');
+    const coreDistPath = path.resolve(__dirname, 'clients', 'core');
     copyRecursivePnP(coreDistPath, coreOutputPath);
 
     if (!legacy) {
@@ -179,8 +176,7 @@ export const generateClientBundle = ({
     ensureDirSync(clientOutputPath);
     const clientDistFolderName = plugin.name.slice('@hey-api/client-'.length);
     const clientDistPath = path.resolve(
-      packageRoot,
-      'dist',
+      __dirname,
       'clients',
       clientDistFolderName,
     );


### PR DESCRIPTION
related https://github.com/hey-api/openapi-ts/issues/1079
related https://github.com/hey-api/openapi-ts/issues/2183
related https://github.com/hey-api/openapi-ts/issues/2237
related https://github.com/hey-api/openapi-ts/pull/2401

The pull request resolving the issue introduced a few problems. The first one appeared when running openapi-ts locally using `pnpm --filter @hey-api/openapi-ts dev`:

```sh
Error parsing: /hey-api/openapi-ts/packages/openapi-ts/dist/chunk-JBFAKSWW.js:2026:9
dist/chunk-JBFAKSWW.js (2026:9): Identifier "createRequire" has already been declared
```

The second one happened after trying to execute the built package using `./packages/openapi-ts/bin/index.cjs -f ./packages/openapi-ts-tests/main/test/openapi-ts.config.ts`:

```sh
🛑 @hey-api/openapi-ts encountered an error.

❗️ Error: Dynamic require of "child_process" is not supported
```

I am partially reverting related https://github.com/hey-api/openapi-ts/pull/2401 here, let's see if that makes everyone happy!