### PR TITLE
fix(tanstack-query): set correct name for pagination parameters in infinite query options

### DIFF
--- a/.changeset/perfect-berries-beam.md
+++ b/.changeset/perfect-berries-beam.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix(tanstack-query): set correct name for pagination parameters in infinite query options

--- a/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
+++ b/packages/openapi-ts/src/ir/__tests__/pagination.test.ts
@@ -7,7 +7,7 @@ import { getPaginationKeywordsRegExp } from '../pagination';
 import type { IR } from '../types';
 
 describe('paginationKeywordsRegExp', () => {
-  const defaultScenarios: Array<{
+  const defaultScenarios: ReadonlyArray<{
     result: boolean;
     value: string;
   }> = [
@@ -55,7 +55,7 @@ describe('paginationKeywordsRegExp', () => {
     },
   );
 
-  const customScenarios: Array<{
+  const customScenarios: ReadonlyArray<{
     result: boolean;
     value: string;
   }> = [
@@ -98,7 +98,7 @@ describe('operationPagination', () => {
     path: '/test' as const,
   };
 
-  const queryScenarios: Array<{
+  const queryScenarios: ReadonlyArray<{
     hasPagination: boolean;
     operation: IR.OperationObject;
   }> = [
@@ -128,19 +128,38 @@ describe('operationPagination', () => {
         },
       },
     },
+    {
+      hasPagination: true,
+      operation: {
+        ...baseOperationMeta,
+        id: 'op3',
+        method: 'get',
+        parameters: {
+          query: {
+            pagesize: queryParam('pageSize', 'string', true),
+          },
+        },
+      },
+    },
   ];
 
   it.each(queryScenarios)(
     'query params for $operation.id → $hasPagination',
-    ({
-      hasPagination,
-      operation,
-    }: {
-      hasPagination: boolean;
-      operation: IR.OperationObject;
-    }) => {
-      const result = operationPagination({ context: emptyContext, operation });
-      expect(Boolean(result)).toEqual(hasPagination);
+    ({ hasPagination, operation }: (typeof queryScenarios)[number]) => {
+      const pagination = operationPagination({
+        context: emptyContext,
+        operation,
+      });
+      expect(Boolean(pagination)).toEqual(hasPagination);
+      if (pagination && pagination.in !== 'body') {
+        const parameter =
+          operation.parameters?.[pagination.in]?.[
+            pagination.name.toLocaleLowerCase()
+          ];
+        if (parameter) {
+          expect(pagination.name).toBe(parameter.name);
+        }
+      }
     },
   );
 

--- a/packages/openapi-ts/src/ir/pagination.ts
+++ b/packages/openapi-ts/src/ir/pagination.ts
@@ -9,7 +9,7 @@ export function getPaginationKeywordsRegExp(
 }
 
 export interface Pagination {
-  in: string;
+  in: 'body' | 'cookie' | 'header' | 'path' | 'query';
   name: string;
   schema: IR.SchemaObject;
 }

--- a/packages/openapi-ts/src/ir/parameter.ts
+++ b/packages/openapi-ts/src/ir/parameter.ts
@@ -80,8 +80,8 @@ export const parameterWithPagination = ({
         in: parameter.location,
         name:
           parameter.pagination === true
-            ? name
-            : `${name}.${parameter.pagination}`,
+            ? parameter.name
+            : `${parameter.name}.${parameter.pagination}`,
         schema: getPaginationSchema({ context, parameter })!,
       };
     }
@@ -94,8 +94,8 @@ export const parameterWithPagination = ({
         in: parameter.location,
         name:
           parameter.pagination === true
-            ? name
-            : `${name}.${parameter.pagination}`,
+            ? parameter.name
+            : `${parameter.name}.${parameter.pagination}`,
         schema: getPaginationSchema({ context, parameter })!,
       };
     }
@@ -108,8 +108,8 @@ export const parameterWithPagination = ({
         in: parameter.location,
         name:
           parameter.pagination === true
-            ? name
-            : `${name}.${parameter.pagination}`,
+            ? parameter.name
+            : `${parameter.name}.${parameter.pagination}`,
         schema: getPaginationSchema({ context, parameter })!,
       };
     }
@@ -122,8 +122,8 @@ export const parameterWithPagination = ({
         in: parameter.location,
         name:
           parameter.pagination === true
-            ? name
-            : `${name}.${parameter.pagination}`,
+            ? parameter.name
+            : `${parameter.name}.${parameter.pagination}`,
         schema: getPaginationSchema({ context, parameter })!,
       };
     }


### PR DESCRIPTION
Fix https://github.com/hey-api/openapi-ts/issues/2232