### PR TITLE
Reducing security schema duplicates in OpenAPI parser

### DIFF
--- a/.changeset/ninety-kings-confess.md
+++ b/.changeset/ninety-kings-confess.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(parser): deduplicate security schemas based on name

--- a/packages/openapi-ts/src/openApi/2.0.x/parser/__tests__/operation.test.ts
+++ b/packages/openapi-ts/src/openApi/2.0.x/parser/__tests__/operation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IR } from '../../../../ir/types';
+import type { SecuritySchemeObject } from '../../types/spec';
+import { parseOperation } from '../operation';
+
+type ParseOperationProps = Parameters<typeof parseOperation>[0];
+
+describe('operation', () => {
+  const context = {
+    config: {
+      plugins: {},
+    },
+    ir: {
+      paths: {},
+      servers: [],
+    },
+  } as unknown as IR.Context;
+
+  it('should parse operation correctly', () => {
+    const method = 'get';
+    const operation: ParseOperationProps['operation'] = {
+      operationId: 'testOperation',
+      responses: {},
+      security: [
+        {
+          apiKeyAuth: [],
+          basicAuthRule: [],
+        },
+        {
+          apiKeyAuth: [],
+          oauthRule: [],
+        },
+      ],
+      summary: 'Test Operation',
+    };
+    const path = '/test';
+    const securitySchemesMap = new Map<string, SecuritySchemeObject>([
+      ['apiKeyAuth', { in: 'header', name: 'Auth', type: 'apiKey' }],
+      ['basicAuthRule', { description: 'Basic Auth', type: 'basic' }],
+      [
+        'oauthRule',
+        {
+          description: 'OAuth2',
+          flow: 'password',
+          scopes: {
+            read: 'Grants read access',
+            write: 'Grants write access',
+          },
+          tokenUrl: 'https://example.com/oauth/token',
+          type: 'oauth2',
+        },
+      ],
+    ]);
+    const state: ParseOperationProps['state'] = {
+      ids: new Map<string, string>(),
+    };
+
+    parseOperation({
+      context,
+      method,
+      operation,
+      path,
+      securitySchemesMap,
+      state,
+    });
+
+    expect(context.ir.paths?.[path]?.[method]).toEqual({
+      id: 'testOperation',
+      method,
+      operationId: 'testOperation',
+      path,
+      security: [
+        { in: 'header', name: 'Auth', type: 'apiKey' },
+        { description: 'Basic Auth', scheme: 'basic', type: 'http' },
+        {
+          description: 'OAuth2',
+          flows: {
+            password: {
+              scopes: {
+                read: 'Grants read access',
+                write: 'Grants write access',
+              },
+              tokenUrl: 'https://example.com/oauth/token',
+            },
+          },
+          type: 'oauth2',
+        },
+      ],
+      summary: 'Test Operation',
+    });
+  });
+});

--- a/packages/openapi-ts/src/openApi/2.0.x/parser/operation.ts
+++ b/packages/openapi-ts/src/openApi/2.0.x/parser/operation.ts
@@ -261,7 +261,7 @@ const operationToIrOperation = ({
   }
 
   if (operation.security) {
-    const securitySchemeObjects: Array<IR.SecurityObject> = [];
+    const securitySchemeObjects: Map<string, IR.SecurityObject> = new Map();
 
     for (const securityRequirementObject of operation.security) {
       for (const name in securityRequirementObject) {
@@ -325,12 +325,12 @@ const operationToIrOperation = ({
           continue;
         }
 
-        securitySchemeObjects.push(irSecuritySchemeObject);
+        securitySchemeObjects.set(name, irSecuritySchemeObject);
       }
     }
 
-    if (securitySchemeObjects.length) {
-      irOperation.security = securitySchemeObjects;
+    if (securitySchemeObjects.size) {
+      irOperation.security = Array.from(securitySchemeObjects.values());
     }
   }
 

--- a/packages/openapi-ts/src/openApi/3.0.x/parser/__tests__/operation.test.ts
+++ b/packages/openapi-ts/src/openApi/3.0.x/parser/__tests__/operation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IR } from '../../../../ir/types';
+import type { SecuritySchemeObject } from '../../types/spec';
+import { parseOperation } from '../operation';
+
+type ParseOperationProps = Parameters<typeof parseOperation>[0];
+
+describe('operation', () => {
+  const context = {
+    config: {
+      plugins: {},
+    },
+    ir: {
+      paths: {},
+      servers: [],
+    },
+  } as unknown as IR.Context;
+
+  it('should parse operation correctly', () => {
+    const method = 'get';
+    const operation: ParseOperationProps['operation'] = {
+      operationId: 'testOperation',
+      responses: {},
+      security: [
+        {
+          apiKeyAuth: [],
+        },
+        {
+          apiKeyAuth: [],
+        },
+        {
+          oauthRule: ['read'],
+        },
+        {
+          oauthRule: ['write'],
+        },
+      ],
+      summary: 'Test Operation',
+    };
+    const path = '/test';
+
+    const oauth2: SecuritySchemeObject = {
+      description: 'OAuth2',
+      flows: {
+        password: {
+          scopes: {
+            read: 'Grants read access',
+            write: 'Grants write access',
+          },
+          tokenUrl: 'https://example.com/oauth/token',
+        },
+      },
+      type: 'oauth2',
+    };
+    const securitySchemesMap = new Map<string, SecuritySchemeObject>([
+      ['apiKeyAuth', { in: 'header', name: 'Auth', type: 'apiKey' }],
+      [
+        'basicAuthRule',
+        { description: 'Basic Auth', scheme: 'basic', type: 'http' },
+      ],
+      ['oauthRule', oauth2],
+    ]);
+    const state: ParseOperationProps['state'] = {
+      ids: new Map<string, string>(),
+    };
+
+    parseOperation({
+      context,
+      method,
+      operation,
+      path,
+      securitySchemesMap,
+      state,
+    });
+
+    expect(context.ir.paths?.[path]?.[method]).toEqual({
+      id: 'testOperation',
+      method,
+      operationId: 'testOperation',
+      path,
+      security: [{ in: 'header', name: 'Auth', type: 'apiKey' }, oauth2],
+      summary: 'Test Operation',
+    });
+  });
+});

--- a/packages/openapi-ts/src/openApi/3.0.x/parser/operation.ts
+++ b/packages/openapi-ts/src/openApi/3.0.x/parser/operation.ts
@@ -203,7 +203,7 @@ const operationToIrOperation = ({
   }
 
   if (operation.security) {
-    const securitySchemeObjects: Array<IR.SecurityObject> = [];
+    const securitySchemeObjects: Map<string, IR.SecurityObject> = new Map();
 
     for (const securityRequirementObject of operation.security) {
       for (const name in securityRequirementObject) {
@@ -213,12 +213,12 @@ const operationToIrOperation = ({
           continue;
         }
 
-        securitySchemeObjects.push(securitySchemeObject);
+        securitySchemeObjects.set(name, securitySchemeObject);
       }
     }
 
-    if (securitySchemeObjects.length) {
-      irOperation.security = securitySchemeObjects;
+    if (securitySchemeObjects.size) {
+      irOperation.security = Array.from(securitySchemeObjects.values());
     }
   }
 

--- a/packages/openapi-ts/src/openApi/3.1.x/parser/__tests__/operation.test.ts
+++ b/packages/openapi-ts/src/openApi/3.1.x/parser/__tests__/operation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IR } from '../../../../ir/types';
+import type { SecuritySchemeObject } from '../../types/spec';
+import { parseOperation } from '../operation';
+
+type ParseOperationProps = Parameters<typeof parseOperation>[0];
+
+describe('operation', () => {
+  const context = {
+    config: {
+      plugins: {},
+    },
+    ir: {
+      paths: {},
+      servers: [],
+    },
+  } as unknown as IR.Context;
+
+  it('should parse operation correctly', () => {
+    const method = 'get';
+    const operation: ParseOperationProps['operation'] = {
+      operationId: 'testOperation',
+      responses: {},
+      security: [
+        {
+          apiKeyAuth: [],
+        },
+        {
+          apiKeyAuth: [],
+        },
+        {
+          oauthRule: ['read'],
+        },
+        {
+          oauthRule: ['write'],
+        },
+      ],
+      summary: 'Test Operation',
+    };
+    const path = '/test';
+
+    const oauth2: SecuritySchemeObject = {
+      description: 'OAuth2',
+      flows: {
+        password: {
+          scopes: {
+            read: 'Grants read access',
+            write: 'Grants write access',
+          },
+          tokenUrl: 'https://example.com/oauth/token',
+        },
+      },
+      type: 'oauth2',
+    };
+    const securitySchemesMap = new Map<string, SecuritySchemeObject>([
+      ['apiKeyAuth', { in: 'header', name: 'Auth', type: 'apiKey' }],
+      [
+        'basicAuthRule',
+        { description: 'Basic Auth', scheme: 'basic', type: 'http' },
+      ],
+      ['oauthRule', oauth2],
+    ]);
+    const state: ParseOperationProps['state'] = {
+      ids: new Map<string, string>(),
+    };
+
+    parseOperation({
+      context,
+      method,
+      operation,
+      path,
+      securitySchemesMap,
+      state,
+    });
+
+    expect(context.ir.paths?.[path]?.[method]).toEqual({
+      id: 'testOperation',
+      method,
+      operationId: 'testOperation',
+      path,
+      security: [{ in: 'header', name: 'Auth', type: 'apiKey' }, oauth2],
+      summary: 'Test Operation',
+    });
+  });
+});

--- a/packages/openapi-ts/src/openApi/3.1.x/parser/operation.ts
+++ b/packages/openapi-ts/src/openApi/3.1.x/parser/operation.ts
@@ -188,7 +188,7 @@ const operationToIrOperation = ({
   }
 
   if (operation.security) {
-    const securitySchemeObjects: Array<IR.SecurityObject> = [];
+    const securitySchemeObjects: Map<string, IR.SecurityObject> = new Map();
 
     for (const securityRequirementObject of operation.security) {
       for (const name in securityRequirementObject) {
@@ -198,12 +198,12 @@ const operationToIrOperation = ({
           continue;
         }
 
-        securitySchemeObjects.push(securitySchemeObject);
+        securitySchemeObjects.set(name, securitySchemeObject);
       }
     }
 
-    if (securitySchemeObjects.length) {
-      irOperation.security = securitySchemeObjects;
+    if (securitySchemeObjects.size) {
+      irOperation.security = Array.from(securitySchemeObjects.values());
     }
   }
 


### PR DESCRIPTION
When security schemas are provided with duplicates we end up with array with repeated security expectations
example:
```json
{
  "security": [
      {
          "security1": [],
          "security2": []
      },
      {
          "security1": [],
          "security3": []
      },
      {
          "security1": [],
          "security4": []
      },
      {
          "security5": [],
          "security2": []
      },
      {
          "security5": [],
          "security3": []
      },
      {
          "security5": [],
          "security4": []
      }
  ]
}
```
we end up with array where expected values are repeated

```js
[
      {
        name: "X-TENANT",
        type: "apiKey",
      },
      {
        scheme: "bearer",
        type: "http",
      },
      {
        name: "X-TENANT",
        type: "apiKey",
      },
      {
        name: "X-SERVICE-AUTHENTICATION",
        type: "apiKey",
      },
      {
        in: "query",
        name: "tenant_code",
        type: "apiKey",
      },
      {
        in: "query",
        name: "tenant_code",
        type: "apiKey",
      },
      {
        name: "X-SERVICE-AUTHENTICATION",
        type: "apiKey",
      },
]
```

this PR is to resolve that and obtain short list of security measures that need to be meet