### PR TITLE
docs: fix config file name

### DIFF
--- a/docs/openapi-ts/get-started.md
+++ b/docs/openapi-ts/get-started.md
@@ -89,11 +89,11 @@ The above script can be executed by running `npm run openapi-ts` or equivalent c
 
 ### Node.js
 
-You can also generate output programmatically by importing `@hey-api/openapi-ts` in a JavaScript/TypeScript file.
+You can also generate output programmatically by calling `createClient()` in a JavaScript/TypeScript file.
 
 ::: code-group
 
-```ts [openapi-ts.config.ts]
+```ts [script.ts]
 import { createClient } from '@hey-api/openapi-ts';
 
 createClient({

--- a/docs/openapi-ts/get-started.md
+++ b/docs/openapi-ts/get-started.md
@@ -93,7 +93,7 @@ You can also generate output programmatically by importing `@hey-api/openapi-ts`
 
 ::: code-group
 
-```ts [openapi-ts.ts]
+```ts [openapi-ts.config.ts]
 import { createClient } from '@hey-api/openapi-ts';
 
 createClient({


### PR DESCRIPTION
  ## Summary
Fixes config file name in documentation to resolve get-started errors. c12 doesn't support loading `.ts` files.

  ## Changes
  - Updated config file reference from `openapi.ts` to `openapi.config.ts`