### PR TITLE
fix(client-fetch): serialize body with falsey but valid json values

### DIFF
--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/__tests__/client.test.ts
@@ -220,4 +220,89 @@ describe('zero-length body handling', () => {
     expect(result.data).toBeInstanceOf(Blob);
     expect((result.data as Blob).size).toBeGreaterThan(0);
   });
+
+  it('serializes a json string to a json-parseable body', async () => {
+    const mockResponse = new Response(null, {
+      status: 200,
+    });
+
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    const result = await client.request({
+      body: { key: 'value' },
+      fetch: mockFetch,
+      method: 'PUT',
+      url: '/test',
+    });
+
+    expect(await result.request.text()).toBe('{"key":"value"}');
+  });
+
+  it('serializes an empty string to a json-parseable body', async () => {
+    const mockResponse = new Response(null, {
+      status: 200,
+    });
+
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    const result = await client.request({
+      body: '',
+      fetch: mockFetch,
+      method: 'PUT',
+      url: '/test',
+    });
+
+    expect(await result.request.text()).toBe('""');
+  });
+
+  it('serializes `0` to a json-parseable body', async () => {
+    const mockResponse = new Response(null, {
+      status: 200,
+    });
+
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    const result = await client.request({
+      body: 0,
+      fetch: mockFetch,
+      method: 'PUT',
+      url: '/test',
+    });
+
+    expect(await result.request.text()).toBe('0');
+  });
+
+  it('does not serialize a `null` body', async () => {
+    const mockResponse = new Response(null, {
+      status: 200,
+    });
+
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    const result = await client.request({
+      body: null,
+      fetch: mockFetch,
+      method: 'PUT',
+      url: '/test',
+    });
+
+    expect(await result.request.text()).toBe('');
+  });
+
+  it('does not serialize an `undefined` body', async () => {
+    const mockResponse = new Response(null, {
+      status: 200,
+    });
+
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    const result = await client.request({
+      body: undefined,
+      fetch: mockFetch,
+      method: 'PUT',
+      url: '/test',
+    });
+
+    expect(await result.request.text()).toBe('');
+  });
 });

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
@@ -58,7 +58,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== null && opts.body !== undefined && opts.bodySerializer) {
       opts.serializedBody = opts.bodySerializer(opts.body);
     }
 


### PR DESCRIPTION
Fixes #2589 .

Edit: Hmm, this looks to also be fixed in https://github.com/hey-api/openapi-ts/pull/2564 for every client, might make sense to go with that PR and close this one.