### PR TITLE
feat(pinia-colada): implicit `$fetch` for `client-nuxt` (hide `composable`)

### DIFF
--- a/.changeset/implicit-fetch.md
+++ b/.changeset/implicit-fetch.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+feat(pinia-colada): implicit `$fetch` for `client-nuxt` (hide `composable`)

--- a/docs/openapi-ts/clients/nuxt.md
+++ b/docs/openapi-ts/clients/nuxt.md
@@ -175,6 +175,10 @@ Interceptors (middleware) can be used to modify requests before they're sent or 
 
 You can pass any Nuxt/ofetch arguments to the client instance.
 
+::: tip
+If you omit `composable`, `$fetch` is used by default.
+:::
+
 ```js
 import { client } from 'client/client.gen';
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/sdk.gen.ts
@@ -4,7 +4,7 @@ import { type Options as ClientOptions, type Composable, type TDataShape, type C
 import type { ExportData, PatchApiVbyApiVersionNoTagData, ImportResponse, ImportData, FooWowData, ApiVVersionODataControllerCountResponse, ApiVVersionODataControllerCountData, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, DeleteCallWithoutParametersAndResponseData, GetCallWithoutParametersAndResponseData, HeadCallWithoutParametersAndResponseData, OptionsCallWithoutParametersAndResponseData, PatchCallWithoutParametersAndResponseData, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, DeleteFooData3, CallWithDescriptionsData, DeprecatedCallData, CallWithParametersData, CallWithWeirdParameterNamesData, GetCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithOptionalParamData, PostApiVbyApiVersionRequestBodyData, PostApiVbyApiVersionFormDataData, CallWithDefaultParametersData, CallWithDefaultOptionalParametersData, CallToTestOrderOfParamsData, DuplicateNameData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, CallWithNoContentResponseResponse, CallWithNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseAndNoContentResponseData, DummyAResponse, DummyAData, DummyBResponse, DummyBData, CallWithResponseResponse, CallWithResponseData, CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithResponsesResponse, CallWithResponsesData, CallWithResponsesError, CollectionFormatData, TypesResponse, TypesData, UploadFileResponse, UploadFileData, FileResponseResponse, FileResponseData, ComplexTypesResponse, ComplexTypesData, MultipartResponseResponse, MultipartResponseData, MultipartRequestData, ComplexParamsResponse, ComplexParamsData, CallWithResultFromHeaderData, TestErrorCodeData, NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Data, PutWithFormUrlEncodedData } from './types.gen';
 import { client as _heyApiClient } from './client.gen';
 
-export type Options<TComposable extends Composable, TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
+export type Options<TComposable extends Composable = '$fetch', TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
     /**
      * You can provide a client instance returned by `createClient()` instead of
      * individual options. This might be also useful if you want to implement a
@@ -18,21 +18,21 @@ export type Options<TComposable extends Composable, TData extends TDataShape = T
     meta?: Record<string, unknown>;
 };
 
-export const export_ = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
+export const export_ = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const patchApiVbyApiVersionNoTag = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
+export const patchApiVbyApiVersionNoTag = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const import_ = <TComposable extends Composable, DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
+export const import_ = <TComposable extends Composable = '$fetch', DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, ImportResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options,
@@ -43,84 +43,84 @@ export const import_ = <TComposable extends Composable, DefaultT extends ImportR
     });
 };
 
-export const fooWow = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
+export const fooWow = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const apiVVersionODataControllerCount = <TComposable extends Composable, DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
+export const apiVVersionODataControllerCount = <TComposable extends Composable = '$fetch', DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ApiVVersionODataControllerCountResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple/$count',
         ...options
     });
 };
 
-export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable, DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
+export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable = '$fetch', DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, GetApiVbyApiVersionSimpleOperationResponse | DefaultT, GetApiVbyApiVersionSimpleOperationError, DefaultT>({
         url: '/api/v{api-version}/simple:operation',
         ...options
     });
 };
 
-export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const getCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const getCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const headCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const headCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).head<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).options<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const patchCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const patchCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const postCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const postCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const putCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const putCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const deleteFoo = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
+export const deleteFoo = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/foo/{foo_param}/bar/{BarParam}',
         ...options
     });
 };
 
-export const callWithDescriptions = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
+export const callWithDescriptions = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/descriptions',
         ...options
@@ -130,14 +130,14 @@ export const callWithDescriptions = <TComposable extends Composable, DefaultT = 
 /**
  * @deprecated
  */
-export const deprecatedCall = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
+export const deprecatedCall = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/deprecated',
         ...options
     });
 };
 
-export const callWithParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
+export const callWithParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameterPath}',
         ...options,
@@ -148,7 +148,7 @@ export const callWithParameters = <TComposable extends Composable, DefaultT = un
     });
 };
 
-export const callWithWeirdParameterNames = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
+export const callWithWeirdParameterNames = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
         ...options,
@@ -159,7 +159,7 @@ export const callWithWeirdParameterNames = <TComposable extends Composable, Defa
     });
 };
 
-export const getCallWithOptionalParam = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
+export const getCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -170,7 +170,7 @@ export const getCallWithOptionalParam = <TComposable extends Composable, Default
     });
 };
 
-export const postCallWithOptionalParam = <TComposable extends Composable, DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
+export const postCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, PostCallWithOptionalParamResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -181,7 +181,7 @@ export const postCallWithOptionalParam = <TComposable extends Composable, Defaul
     });
 };
 
-export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionRequestBody = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/requestBody',
         ...options,
@@ -192,7 +192,7 @@ export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, 
     });
 };
 
-export const postApiVbyApiVersionFormData = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionFormData = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/formData',
@@ -204,119 +204,119 @@ export const postApiVbyApiVersionFormData = <TComposable extends Composable, Def
     });
 };
 
-export const callWithDefaultParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
+export const callWithDefaultParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callWithDefaultOptionalParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
+export const callWithDefaultOptionalParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callToTestOrderOfParams = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
+export const callToTestOrderOfParams = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const duplicateName = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
+export const duplicateName = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName2 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
+export const duplicateName2 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName3 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
+export const duplicateName3 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName4 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
+export const duplicateName4 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const callWithNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
+export const callWithNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no-content',
         ...options
     });
 };
 
-export const callWithResponseAndNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
+export const callWithResponseAndNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseAndNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/response-and-no-content',
         ...options
     });
 };
 
-export const dummyA = <TComposable extends Composable, DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
+export const dummyA = <TComposable extends Composable = '$fetch', DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyAResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/a',
         ...options
     });
 };
 
-export const dummyB = <TComposable extends Composable, DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
+export const dummyB = <TComposable extends Composable = '$fetch', DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyBResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/b',
         ...options
     });
 };
 
-export const callWithResponse = <TComposable extends Composable, DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
+export const callWithResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithDuplicateResponses = <TComposable extends Composable, DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
+export const callWithDuplicateResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, CallWithDuplicateResponsesResponse | DefaultT, CallWithDuplicateResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithResponses = <TComposable extends Composable, DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
+export const callWithResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, CallWithResponsesResponse | DefaultT, CallWithResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const collectionFormat = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
+export const collectionFormat = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/collectionFormat',
         ...options
     });
 };
 
-export const types = <TComposable extends Composable, DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
+export const types = <TComposable extends Composable = '$fetch', DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, TypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/types',
         ...options
     });
 };
 
-export const uploadFile = <TComposable extends Composable, DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
+export const uploadFile = <TComposable extends Composable = '$fetch', DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, UploadFileResponse | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/upload',
@@ -328,28 +328,28 @@ export const uploadFile = <TComposable extends Composable, DefaultT extends Uplo
     });
 };
 
-export const fileResponse = <TComposable extends Composable, DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
+export const fileResponse = <TComposable extends Composable = '$fetch', DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, FileResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/file/{id}',
         ...options
     });
 };
 
-export const complexTypes = <TComposable extends Composable, DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
+export const complexTypes = <TComposable extends Composable = '$fetch', DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ComplexTypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex',
         ...options
     });
 };
 
-export const multipartResponse = <TComposable extends Composable, DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
+export const multipartResponse = <TComposable extends Composable = '$fetch', DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, MultipartResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multipart',
         ...options
     });
 };
 
-export const multipartRequest = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
+export const multipartRequest = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/multipart',
@@ -361,7 +361,7 @@ export const multipartRequest = <TComposable extends Composable, DefaultT = unde
     });
 };
 
-export const complexParams = <TComposable extends Composable, DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
+export const complexParams = <TComposable extends Composable = '$fetch', DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, ComplexParamsResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex/{id}',
         ...options,
@@ -372,21 +372,21 @@ export const complexParams = <TComposable extends Composable, DefaultT extends C
     });
 };
 
-export const callWithResultFromHeader = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
+export const callWithResultFromHeader = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/header',
         ...options
     });
 };
 
-export const testErrorCode = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
+export const testErrorCode = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/error',
         ...options
     });
 };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable, DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable = '$fetch', DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Response | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
         ...options
@@ -396,7 +396,7 @@ export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Compos
 /**
  * Login User
  */
-export const putWithFormUrlEncoded = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
+export const putWithFormUrlEncoded = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/sdk.gen.ts
@@ -4,7 +4,7 @@ import { type Options as ClientOptions, type Composable, type TDataShape, type C
 import type { ExportData, PatchApiVbyApiVersionNoTagData, ImportResponse, ImportData, FooWowData, ApiVVersionODataControllerCountResponse, ApiVVersionODataControllerCountData, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, DeleteCallWithoutParametersAndResponseData, GetCallWithoutParametersAndResponseData, HeadCallWithoutParametersAndResponseData, OptionsCallWithoutParametersAndResponseData, PatchCallWithoutParametersAndResponseData, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, DeleteFooData3, CallWithDescriptionsData, DeprecatedCallData, CallWithParametersData, CallWithWeirdParameterNamesData, GetCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithOptionalParamData, PostApiVbyApiVersionRequestBodyData, PostApiVbyApiVersionFormDataData, CallWithDefaultParametersData, CallWithDefaultOptionalParametersData, CallToTestOrderOfParamsData, DuplicateNameData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, CallWithNoContentResponseResponse, CallWithNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseAndNoContentResponseData, DummyAResponse, DummyAData, DummyBResponse, DummyBData, CallWithResponseResponse, CallWithResponseData, CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithResponsesResponse, CallWithResponsesData, CallWithResponsesError, CollectionFormatData, TypesResponse, TypesData, UploadFileResponse, UploadFileData, FileResponseResponse, FileResponseData, ComplexTypesResponse, ComplexTypesData, MultipartResponseResponse, MultipartResponseData, MultipartRequestData, ComplexParamsResponse, ComplexParamsData, CallWithResultFromHeaderData, TestErrorCodeData, NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Data, PutWithFormUrlEncodedData } from './types.gen';
 import { client as _heyApiClient } from './client.gen';
 
-export type Options<TComposable extends Composable, TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
+export type Options<TComposable extends Composable = '$fetch', TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
     /**
      * You can provide a client instance returned by `createClient()` instead of
      * individual options. This might be also useful if you want to implement a
@@ -18,21 +18,21 @@ export type Options<TComposable extends Composable, TData extends TDataShape = T
     meta?: Record<string, unknown>;
 };
 
-export const export_ = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
+export const export_ = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const patchApiVbyApiVersionNoTag = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
+export const patchApiVbyApiVersionNoTag = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const import_ = <TComposable extends Composable, DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
+export const import_ = <TComposable extends Composable = '$fetch', DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, ImportResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options,
@@ -43,84 +43,84 @@ export const import_ = <TComposable extends Composable, DefaultT extends ImportR
     });
 };
 
-export const fooWow = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
+export const fooWow = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const apiVVersionODataControllerCount = <TComposable extends Composable, DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
+export const apiVVersionODataControllerCount = <TComposable extends Composable = '$fetch', DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ApiVVersionODataControllerCountResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple/$count',
         ...options
     });
 };
 
-export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable, DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
+export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable = '$fetch', DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, GetApiVbyApiVersionSimpleOperationResponse | DefaultT, GetApiVbyApiVersionSimpleOperationError, DefaultT>({
         url: '/api/v{api-version}/simple:operation',
         ...options
     });
 };
 
-export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const getCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const getCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const headCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const headCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).head<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).options<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const patchCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const patchCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const postCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const postCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const putCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const putCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const deleteFoo = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
+export const deleteFoo = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/foo/{foo_param}/bar/{BarParam}',
         ...options
     });
 };
 
-export const callWithDescriptions = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
+export const callWithDescriptions = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/descriptions',
         ...options
@@ -130,14 +130,14 @@ export const callWithDescriptions = <TComposable extends Composable, DefaultT = 
 /**
  * @deprecated
  */
-export const deprecatedCall = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
+export const deprecatedCall = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/deprecated',
         ...options
     });
 };
 
-export const callWithParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
+export const callWithParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameterPath}',
         ...options,
@@ -148,7 +148,7 @@ export const callWithParameters = <TComposable extends Composable, DefaultT = un
     });
 };
 
-export const callWithWeirdParameterNames = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
+export const callWithWeirdParameterNames = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
         ...options,
@@ -159,7 +159,7 @@ export const callWithWeirdParameterNames = <TComposable extends Composable, Defa
     });
 };
 
-export const getCallWithOptionalParam = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
+export const getCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -170,7 +170,7 @@ export const getCallWithOptionalParam = <TComposable extends Composable, Default
     });
 };
 
-export const postCallWithOptionalParam = <TComposable extends Composable, DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
+export const postCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, PostCallWithOptionalParamResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -181,7 +181,7 @@ export const postCallWithOptionalParam = <TComposable extends Composable, Defaul
     });
 };
 
-export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionRequestBody = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/requestBody',
         ...options,
@@ -192,7 +192,7 @@ export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, 
     });
 };
 
-export const postApiVbyApiVersionFormData = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionFormData = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/formData',
@@ -204,119 +204,119 @@ export const postApiVbyApiVersionFormData = <TComposable extends Composable, Def
     });
 };
 
-export const callWithDefaultParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
+export const callWithDefaultParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callWithDefaultOptionalParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
+export const callWithDefaultOptionalParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callToTestOrderOfParams = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
+export const callToTestOrderOfParams = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const duplicateName = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
+export const duplicateName = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName2 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
+export const duplicateName2 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName3 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
+export const duplicateName3 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName4 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
+export const duplicateName4 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const callWithNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
+export const callWithNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no-content',
         ...options
     });
 };
 
-export const callWithResponseAndNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
+export const callWithResponseAndNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseAndNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/response-and-no-content',
         ...options
     });
 };
 
-export const dummyA = <TComposable extends Composable, DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
+export const dummyA = <TComposable extends Composable = '$fetch', DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyAResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/a',
         ...options
     });
 };
 
-export const dummyB = <TComposable extends Composable, DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
+export const dummyB = <TComposable extends Composable = '$fetch', DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyBResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/b',
         ...options
     });
 };
 
-export const callWithResponse = <TComposable extends Composable, DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
+export const callWithResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithDuplicateResponses = <TComposable extends Composable, DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
+export const callWithDuplicateResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, CallWithDuplicateResponsesResponse | DefaultT, CallWithDuplicateResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithResponses = <TComposable extends Composable, DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
+export const callWithResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, CallWithResponsesResponse | DefaultT, CallWithResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const collectionFormat = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
+export const collectionFormat = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/collectionFormat',
         ...options
     });
 };
 
-export const types = <TComposable extends Composable, DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
+export const types = <TComposable extends Composable = '$fetch', DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, TypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/types',
         ...options
     });
 };
 
-export const uploadFile = <TComposable extends Composable, DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
+export const uploadFile = <TComposable extends Composable = '$fetch', DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, UploadFileResponse | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/upload',
@@ -328,28 +328,28 @@ export const uploadFile = <TComposable extends Composable, DefaultT extends Uplo
     });
 };
 
-export const fileResponse = <TComposable extends Composable, DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
+export const fileResponse = <TComposable extends Composable = '$fetch', DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, FileResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/file/{id}',
         ...options
     });
 };
 
-export const complexTypes = <TComposable extends Composable, DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
+export const complexTypes = <TComposable extends Composable = '$fetch', DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ComplexTypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex',
         ...options
     });
 };
 
-export const multipartResponse = <TComposable extends Composable, DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
+export const multipartResponse = <TComposable extends Composable = '$fetch', DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, MultipartResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multipart',
         ...options
     });
 };
 
-export const multipartRequest = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
+export const multipartRequest = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/multipart',
@@ -361,7 +361,7 @@ export const multipartRequest = <TComposable extends Composable, DefaultT = unde
     });
 };
 
-export const complexParams = <TComposable extends Composable, DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
+export const complexParams = <TComposable extends Composable = '$fetch', DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, ComplexParamsResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex/{id}',
         ...options,
@@ -372,21 +372,21 @@ export const complexParams = <TComposable extends Composable, DefaultT extends C
     });
 };
 
-export const callWithResultFromHeader = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
+export const callWithResultFromHeader = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/header',
         ...options
     });
 };
 
-export const testErrorCode = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
+export const testErrorCode = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/error',
         ...options
     });
 };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable, DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable = '$fetch', DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Response | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
         ...options
@@ -396,7 +396,7 @@ export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Compos
 /**
  * Login User
  */
-export const putWithFormUrlEncoded = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
+export const putWithFormUrlEncoded = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/sdk.gen.ts
@@ -4,7 +4,7 @@ import { type Options as ClientOptions, type Composable, type TDataShape, type C
 import type { ExportData, PatchApiVbyApiVersionNoTagData, ImportResponse, ImportData, FooWowData, ApiVVersionODataControllerCountResponse, ApiVVersionODataControllerCountData, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, DeleteCallWithoutParametersAndResponseData, GetCallWithoutParametersAndResponseData, HeadCallWithoutParametersAndResponseData, OptionsCallWithoutParametersAndResponseData, PatchCallWithoutParametersAndResponseData, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, DeleteFooData3, CallWithDescriptionsData, DeprecatedCallData, CallWithParametersData, CallWithWeirdParameterNamesData, GetCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithOptionalParamData, PostApiVbyApiVersionRequestBodyData, PostApiVbyApiVersionFormDataData, CallWithDefaultParametersData, CallWithDefaultOptionalParametersData, CallToTestOrderOfParamsData, DuplicateNameData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, CallWithNoContentResponseResponse, CallWithNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseAndNoContentResponseData, DummyAResponse, DummyAData, DummyBResponse, DummyBData, CallWithResponseResponse, CallWithResponseData, CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithResponsesResponse, CallWithResponsesData, CallWithResponsesError, CollectionFormatData, TypesResponse, TypesData, UploadFileResponse, UploadFileData, FileResponseResponse, FileResponseData, ComplexTypesResponse, ComplexTypesData, MultipartResponseResponse, MultipartResponseData, MultipartRequestData, ComplexParamsResponse, ComplexParamsData, CallWithResultFromHeaderData, TestErrorCodeData, NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Data, PutWithFormUrlEncodedData } from './types.gen';
 import { client as _heyApiClient } from './client.gen';
 
-export type Options<TComposable extends Composable, TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
+export type Options<TComposable extends Composable = '$fetch', TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
     /**
      * You can provide a client instance returned by `createClient()` instead of
      * individual options. This might be also useful if you want to implement a
@@ -18,21 +18,21 @@ export type Options<TComposable extends Composable, TData extends TDataShape = T
     meta?: Record<string, unknown>;
 };
 
-export const export_ = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
+export const export_ = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const patchApiVbyApiVersionNoTag = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
+export const patchApiVbyApiVersionNoTag = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const import_ = <TComposable extends Composable, DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
+export const import_ = <TComposable extends Composable = '$fetch', DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, ImportResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options,
@@ -43,84 +43,84 @@ export const import_ = <TComposable extends Composable, DefaultT extends ImportR
     });
 };
 
-export const fooWow = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
+export const fooWow = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const apiVVersionODataControllerCount = <TComposable extends Composable, DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
+export const apiVVersionODataControllerCount = <TComposable extends Composable = '$fetch', DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ApiVVersionODataControllerCountResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple/$count',
         ...options
     });
 };
 
-export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable, DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
+export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable = '$fetch', DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, GetApiVbyApiVersionSimpleOperationResponse | DefaultT, GetApiVbyApiVersionSimpleOperationError, DefaultT>({
         url: '/api/v{api-version}/simple:operation',
         ...options
     });
 };
 
-export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const getCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const getCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const headCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const headCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).head<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).options<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const patchCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const patchCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const postCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const postCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const putCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const putCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const deleteFoo = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
+export const deleteFoo = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/foo/{foo_param}/bar/{BarParam}',
         ...options
     });
 };
 
-export const callWithDescriptions = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
+export const callWithDescriptions = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/descriptions',
         ...options
@@ -130,14 +130,14 @@ export const callWithDescriptions = <TComposable extends Composable, DefaultT = 
 /**
  * @deprecated
  */
-export const deprecatedCall = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
+export const deprecatedCall = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/deprecated',
         ...options
     });
 };
 
-export const callWithParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
+export const callWithParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameterPath}',
         ...options,
@@ -148,7 +148,7 @@ export const callWithParameters = <TComposable extends Composable, DefaultT = un
     });
 };
 
-export const callWithWeirdParameterNames = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
+export const callWithWeirdParameterNames = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
         ...options,
@@ -159,7 +159,7 @@ export const callWithWeirdParameterNames = <TComposable extends Composable, Defa
     });
 };
 
-export const getCallWithOptionalParam = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
+export const getCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -170,7 +170,7 @@ export const getCallWithOptionalParam = <TComposable extends Composable, Default
     });
 };
 
-export const postCallWithOptionalParam = <TComposable extends Composable, DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
+export const postCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, PostCallWithOptionalParamResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -181,7 +181,7 @@ export const postCallWithOptionalParam = <TComposable extends Composable, Defaul
     });
 };
 
-export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionRequestBody = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/requestBody',
         ...options,
@@ -192,7 +192,7 @@ export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, 
     });
 };
 
-export const postApiVbyApiVersionFormData = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionFormData = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/formData',
@@ -204,119 +204,119 @@ export const postApiVbyApiVersionFormData = <TComposable extends Composable, Def
     });
 };
 
-export const callWithDefaultParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
+export const callWithDefaultParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callWithDefaultOptionalParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
+export const callWithDefaultOptionalParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callToTestOrderOfParams = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
+export const callToTestOrderOfParams = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const duplicateName = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
+export const duplicateName = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName2 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
+export const duplicateName2 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName3 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
+export const duplicateName3 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName4 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
+export const duplicateName4 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const callWithNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
+export const callWithNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no-content',
         ...options
     });
 };
 
-export const callWithResponseAndNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
+export const callWithResponseAndNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseAndNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/response-and-no-content',
         ...options
     });
 };
 
-export const dummyA = <TComposable extends Composable, DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
+export const dummyA = <TComposable extends Composable = '$fetch', DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyAResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/a',
         ...options
     });
 };
 
-export const dummyB = <TComposable extends Composable, DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
+export const dummyB = <TComposable extends Composable = '$fetch', DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyBResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/b',
         ...options
     });
 };
 
-export const callWithResponse = <TComposable extends Composable, DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
+export const callWithResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithDuplicateResponses = <TComposable extends Composable, DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
+export const callWithDuplicateResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, CallWithDuplicateResponsesResponse | DefaultT, CallWithDuplicateResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithResponses = <TComposable extends Composable, DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
+export const callWithResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, CallWithResponsesResponse | DefaultT, CallWithResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const collectionFormat = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
+export const collectionFormat = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/collectionFormat',
         ...options
     });
 };
 
-export const types = <TComposable extends Composable, DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
+export const types = <TComposable extends Composable = '$fetch', DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, TypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/types',
         ...options
     });
 };
 
-export const uploadFile = <TComposable extends Composable, DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
+export const uploadFile = <TComposable extends Composable = '$fetch', DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, UploadFileResponse | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/upload',
@@ -328,28 +328,28 @@ export const uploadFile = <TComposable extends Composable, DefaultT extends Uplo
     });
 };
 
-export const fileResponse = <TComposable extends Composable, DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
+export const fileResponse = <TComposable extends Composable = '$fetch', DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, FileResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/file/{id}',
         ...options
     });
 };
 
-export const complexTypes = <TComposable extends Composable, DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
+export const complexTypes = <TComposable extends Composable = '$fetch', DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ComplexTypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex',
         ...options
     });
 };
 
-export const multipartResponse = <TComposable extends Composable, DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
+export const multipartResponse = <TComposable extends Composable = '$fetch', DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, MultipartResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multipart',
         ...options
     });
 };
 
-export const multipartRequest = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
+export const multipartRequest = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/multipart',
@@ -361,7 +361,7 @@ export const multipartRequest = <TComposable extends Composable, DefaultT = unde
     });
 };
 
-export const complexParams = <TComposable extends Composable, DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
+export const complexParams = <TComposable extends Composable = '$fetch', DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, ComplexParamsResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex/{id}',
         ...options,
@@ -372,21 +372,21 @@ export const complexParams = <TComposable extends Composable, DefaultT extends C
     });
 };
 
-export const callWithResultFromHeader = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
+export const callWithResultFromHeader = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/header',
         ...options
     });
 };
 
-export const testErrorCode = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
+export const testErrorCode = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/error',
         ...options
     });
 };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable, DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable = '$fetch', DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Response | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
         ...options
@@ -396,7 +396,7 @@ export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Compos
 /**
  * Login User
  */
-export const putWithFormUrlEncoded = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
+export const putWithFormUrlEncoded = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/sdk.gen.ts
@@ -3,7 +3,7 @@
 import { type Options as ClientOptions, type Composable, type TDataShape, type Client, formDataBodySerializer, urlSearchParamsBodySerializer } from './client';
 import type { ExportData, PatchApiVbyApiVersionNoTagData, ImportResponse, ImportData, FooWowData, ApiVVersionODataControllerCountResponse, ApiVVersionODataControllerCountData, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, DeleteCallWithoutParametersAndResponseData, GetCallWithoutParametersAndResponseData, HeadCallWithoutParametersAndResponseData, OptionsCallWithoutParametersAndResponseData, PatchCallWithoutParametersAndResponseData, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, DeleteFooData3, CallWithDescriptionsData, DeprecatedCallData, CallWithParametersData, CallWithWeirdParameterNamesData, GetCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithOptionalParamData, PostApiVbyApiVersionRequestBodyData, PostApiVbyApiVersionFormDataData, CallWithDefaultParametersData, CallWithDefaultOptionalParametersData, CallToTestOrderOfParamsData, DuplicateNameData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, CallWithNoContentResponseResponse, CallWithNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseAndNoContentResponseData, DummyAResponse, DummyAData, DummyBResponse, DummyBData, CallWithResponseResponse, CallWithResponseData, CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithResponsesResponse, CallWithResponsesData, CallWithResponsesError, CollectionFormatData, TypesResponse, TypesData, UploadFileResponse, UploadFileData, FileResponseResponse, FileResponseData, ComplexTypesResponse, ComplexTypesData, MultipartResponseResponse, MultipartResponseData, MultipartRequestData, ComplexParamsResponse, ComplexParamsData, CallWithResultFromHeaderData, TestErrorCodeData, NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Data, PutWithFormUrlEncodedData } from './types.gen';
 
-export type Options<TComposable extends Composable, TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
+export type Options<TComposable extends Composable = '$fetch', TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
     /**
      * You can provide a client instance returned by `createClient()` instead of
      * individual options. This might be also useful if you want to implement a
@@ -17,21 +17,21 @@ export type Options<TComposable extends Composable, TData extends TDataShape = T
     meta?: Record<string, unknown>;
 };
 
-export const export_ = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
+export const export_ = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
     return options.client.get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const patchApiVbyApiVersionNoTag = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
+export const patchApiVbyApiVersionNoTag = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
     return options.client.patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const import_ = <TComposable extends Composable, DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
+export const import_ = <TComposable extends Composable = '$fetch', DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
     return options.client.post<TComposable, ImportResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options,
@@ -42,84 +42,84 @@ export const import_ = <TComposable extends Composable, DefaultT extends ImportR
     });
 };
 
-export const fooWow = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
+export const fooWow = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
     return options.client.put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const apiVVersionODataControllerCount = <TComposable extends Composable, DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
+export const apiVVersionODataControllerCount = <TComposable extends Composable = '$fetch', DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
     return options.client.get<TComposable, ApiVVersionODataControllerCountResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple/$count',
         ...options
     });
 };
 
-export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable, DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
+export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable = '$fetch', DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
     return options.client.get<TComposable, GetApiVbyApiVersionSimpleOperationResponse | DefaultT, GetApiVbyApiVersionSimpleOperationError, DefaultT>({
         url: '/api/v{api-version}/simple:operation',
         ...options
     });
 };
 
-export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const getCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const getCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const headCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const headCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.head<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.options<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const patchCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const patchCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const postCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const postCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const putCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const putCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return options.client.put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const deleteFoo = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
+export const deleteFoo = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
     return options.client.delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/foo/{foo_param}/bar/{BarParam}',
         ...options
     });
 };
 
-export const callWithDescriptions = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
+export const callWithDescriptions = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/descriptions',
         ...options
@@ -129,14 +129,14 @@ export const callWithDescriptions = <TComposable extends Composable, DefaultT = 
 /**
  * @deprecated
  */
-export const deprecatedCall = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
+export const deprecatedCall = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/deprecated',
         ...options
     });
 };
 
-export const callWithParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
+export const callWithParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameterPath}',
         ...options,
@@ -147,7 +147,7 @@ export const callWithParameters = <TComposable extends Composable, DefaultT = un
     });
 };
 
-export const callWithWeirdParameterNames = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
+export const callWithWeirdParameterNames = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
         ...options,
@@ -158,7 +158,7 @@ export const callWithWeirdParameterNames = <TComposable extends Composable, Defa
     });
 };
 
-export const getCallWithOptionalParam = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
+export const getCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
     return options.client.get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -169,7 +169,7 @@ export const getCallWithOptionalParam = <TComposable extends Composable, Default
     });
 };
 
-export const postCallWithOptionalParam = <TComposable extends Composable, DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
+export const postCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
     return options.client.post<TComposable, PostCallWithOptionalParamResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -180,7 +180,7 @@ export const postCallWithOptionalParam = <TComposable extends Composable, Defaul
     });
 };
 
-export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionRequestBody = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/requestBody',
         ...options,
@@ -191,7 +191,7 @@ export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, 
     });
 };
 
-export const postApiVbyApiVersionFormData = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionFormData = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/formData',
@@ -203,119 +203,119 @@ export const postApiVbyApiVersionFormData = <TComposable extends Composable, Def
     });
 };
 
-export const callWithDefaultParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
+export const callWithDefaultParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
     return options.client.get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callWithDefaultOptionalParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
+export const callWithDefaultOptionalParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callToTestOrderOfParams = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
+export const callToTestOrderOfParams = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
     return options.client.put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const duplicateName = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
+export const duplicateName = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
     return options.client.delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName2 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
+export const duplicateName2 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
     return options.client.get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName3 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
+export const duplicateName3 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName4 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
+export const duplicateName4 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
     return options.client.put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const callWithNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
+export const callWithNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
     return options.client.get<TComposable, CallWithNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no-content',
         ...options
     });
 };
 
-export const callWithResponseAndNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
+export const callWithResponseAndNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
     return options.client.get<TComposable, CallWithResponseAndNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/response-and-no-content',
         ...options
     });
 };
 
-export const dummyA = <TComposable extends Composable, DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
+export const dummyA = <TComposable extends Composable = '$fetch', DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
     return options.client.get<TComposable, DummyAResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/a',
         ...options
     });
 };
 
-export const dummyB = <TComposable extends Composable, DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
+export const dummyB = <TComposable extends Composable = '$fetch', DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
     return options.client.get<TComposable, DummyBResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/b',
         ...options
     });
 };
 
-export const callWithResponse = <TComposable extends Composable, DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
+export const callWithResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
     return options.client.get<TComposable, CallWithResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithDuplicateResponses = <TComposable extends Composable, DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
+export const callWithDuplicateResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
     return options.client.post<TComposable, CallWithDuplicateResponsesResponse | DefaultT, CallWithDuplicateResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithResponses = <TComposable extends Composable, DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
+export const callWithResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
     return options.client.put<TComposable, CallWithResponsesResponse | DefaultT, CallWithResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const collectionFormat = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
+export const collectionFormat = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
     return options.client.get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/collectionFormat',
         ...options
     });
 };
 
-export const types = <TComposable extends Composable, DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
+export const types = <TComposable extends Composable = '$fetch', DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
     return options.client.get<TComposable, TypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/types',
         ...options
     });
 };
 
-export const uploadFile = <TComposable extends Composable, DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
+export const uploadFile = <TComposable extends Composable = '$fetch', DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
     return options.client.post<TComposable, UploadFileResponse | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/upload',
@@ -327,28 +327,28 @@ export const uploadFile = <TComposable extends Composable, DefaultT extends Uplo
     });
 };
 
-export const fileResponse = <TComposable extends Composable, DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
+export const fileResponse = <TComposable extends Composable = '$fetch', DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
     return options.client.get<TComposable, FileResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/file/{id}',
         ...options
     });
 };
 
-export const complexTypes = <TComposable extends Composable, DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
+export const complexTypes = <TComposable extends Composable = '$fetch', DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
     return options.client.get<TComposable, ComplexTypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex',
         ...options
     });
 };
 
-export const multipartResponse = <TComposable extends Composable, DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
+export const multipartResponse = <TComposable extends Composable = '$fetch', DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
     return options.client.get<TComposable, MultipartResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multipart',
         ...options
     });
 };
 
-export const multipartRequest = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
+export const multipartRequest = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/multipart',
@@ -360,7 +360,7 @@ export const multipartRequest = <TComposable extends Composable, DefaultT = unde
     });
 };
 
-export const complexParams = <TComposable extends Composable, DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
+export const complexParams = <TComposable extends Composable = '$fetch', DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
     return options.client.put<TComposable, ComplexParamsResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex/{id}',
         ...options,
@@ -371,21 +371,21 @@ export const complexParams = <TComposable extends Composable, DefaultT extends C
     });
 };
 
-export const callWithResultFromHeader = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
+export const callWithResultFromHeader = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/header',
         ...options
     });
 };
 
-export const testErrorCode = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
+export const testErrorCode = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
     return options.client.post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/error',
         ...options
     });
 };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable, DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable = '$fetch', DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
     return options.client.post<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Response | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
         ...options
@@ -395,7 +395,7 @@ export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Compos
 /**
  * Login User
  */
-export const putWithFormUrlEncoded = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
+export const putWithFormUrlEncoded = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
     return options.client.put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/sdk.gen.ts
@@ -4,7 +4,7 @@ import { type Options as ClientOptions, type Composable, type TDataShape, type C
 import type { ExportData, PatchApiVbyApiVersionNoTagData, ImportResponse, ImportData, FooWowData, ApiVVersionODataControllerCountResponse, ApiVVersionODataControllerCountData, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, DeleteCallWithoutParametersAndResponseData, GetCallWithoutParametersAndResponseData, HeadCallWithoutParametersAndResponseData, OptionsCallWithoutParametersAndResponseData, PatchCallWithoutParametersAndResponseData, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, DeleteFooData3, CallWithDescriptionsData, DeprecatedCallData, CallWithParametersData, CallWithWeirdParameterNamesData, GetCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithOptionalParamData, PostApiVbyApiVersionRequestBodyData, PostApiVbyApiVersionFormDataData, CallWithDefaultParametersData, CallWithDefaultOptionalParametersData, CallToTestOrderOfParamsData, DuplicateNameData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, CallWithNoContentResponseResponse, CallWithNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseAndNoContentResponseData, DummyAResponse, DummyAData, DummyBResponse, DummyBData, CallWithResponseResponse, CallWithResponseData, CallWithDuplicateResponsesResponse, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithResponsesResponse, CallWithResponsesData, CallWithResponsesError, CollectionFormatData, TypesResponse, TypesData, UploadFileResponse, UploadFileData, FileResponseResponse, FileResponseData, ComplexTypesResponse, ComplexTypesData, MultipartResponseResponse, MultipartResponseData, MultipartRequestData, ComplexParamsResponse, ComplexParamsData, CallWithResultFromHeaderData, TestErrorCodeData, NonAsciiæøåÆøÅöôêÊ字符串Response, NonAsciiæøåÆøÅöôêÊ字符串Data, PutWithFormUrlEncodedData } from './types.gen.js';
 import { client as _heyApiClient } from './client.gen.js';
 
-export type Options<TComposable extends Composable, TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
+export type Options<TComposable extends Composable = '$fetch', TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
     /**
      * You can provide a client instance returned by `createClient()` instead of
      * individual options. This might be also useful if you want to implement a
@@ -18,21 +18,21 @@ export type Options<TComposable extends Composable, TData extends TDataShape = T
     meta?: Record<string, unknown>;
 };
 
-export const export_ = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
+export const export_ = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, ExportData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const patchApiVbyApiVersionNoTag = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
+export const patchApiVbyApiVersionNoTag = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchApiVbyApiVersionNoTagData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const import_ = <TComposable extends Composable, DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
+export const import_ = <TComposable extends Composable = '$fetch', DefaultT extends ImportResponse = ImportResponse>(options: Options<TComposable, ImportData, ImportResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, ImportResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options,
@@ -43,84 +43,84 @@ export const import_ = <TComposable extends Composable, DefaultT extends ImportR
     });
 };
 
-export const fooWow = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
+export const fooWow = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, FooWowData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no+tag',
         ...options
     });
 };
 
-export const apiVVersionODataControllerCount = <TComposable extends Composable, DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
+export const apiVVersionODataControllerCount = <TComposable extends Composable = '$fetch', DefaultT extends ApiVVersionODataControllerCountResponse = ApiVVersionODataControllerCountResponse>(options: Options<TComposable, ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ApiVVersionODataControllerCountResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple/$count',
         ...options
     });
 };
 
-export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable, DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
+export const getApiVbyApiVersionSimpleOperation = <TComposable extends Composable = '$fetch', DefaultT extends GetApiVbyApiVersionSimpleOperationResponse = GetApiVbyApiVersionSimpleOperationResponse>(options: Options<TComposable, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, GetApiVbyApiVersionSimpleOperationResponse | DefaultT, GetApiVbyApiVersionSimpleOperationError, DefaultT>({
         url: '/api/v{api-version}/simple:operation',
         ...options
     });
 };
 
-export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const deleteCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const getCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const getCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const headCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const headCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, HeadCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).head<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const optionsCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, OptionsCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).options<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const patchCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const patchCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PatchCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).patch<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const postCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const postCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const putCallWithoutParametersAndResponse = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
+export const putCallWithoutParametersAndResponse = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutCallWithoutParametersAndResponseData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/simple',
         ...options
     });
 };
 
-export const deleteFoo = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
+export const deleteFoo = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeleteFooData3, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/foo/{foo_param}/bar/{BarParam}',
         ...options
     });
 };
 
-export const callWithDescriptions = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
+export const callWithDescriptions = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDescriptionsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/descriptions',
         ...options
@@ -130,14 +130,14 @@ export const callWithDescriptions = <TComposable extends Composable, DefaultT = 
 /**
  * @deprecated
  */
-export const deprecatedCall = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
+export const deprecatedCall = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DeprecatedCallData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/deprecated',
         ...options
     });
 };
 
-export const callWithParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
+export const callWithParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameterPath}',
         ...options,
@@ -148,7 +148,7 @@ export const callWithParameters = <TComposable extends Composable, DefaultT = un
     });
 };
 
-export const callWithWeirdParameterNames = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
+export const callWithWeirdParameterNames = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithWeirdParameterNamesData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
         ...options,
@@ -159,7 +159,7 @@ export const callWithWeirdParameterNames = <TComposable extends Composable, Defa
     });
 };
 
-export const getCallWithOptionalParam = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
+export const getCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, GetCallWithOptionalParamData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -170,7 +170,7 @@ export const getCallWithOptionalParam = <TComposable extends Composable, Default
     });
 };
 
-export const postCallWithOptionalParam = <TComposable extends Composable, DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
+export const postCallWithOptionalParam = <TComposable extends Composable = '$fetch', DefaultT extends PostCallWithOptionalParamResponse = PostCallWithOptionalParamResponse>(options: Options<TComposable, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, PostCallWithOptionalParamResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/parameters',
         ...options,
@@ -181,7 +181,7 @@ export const postCallWithOptionalParam = <TComposable extends Composable, Defaul
     });
 };
 
-export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionRequestBody = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionRequestBodyData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/requestBody',
         ...options,
@@ -192,7 +192,7 @@ export const postApiVbyApiVersionRequestBody = <TComposable extends Composable, 
     });
 };
 
-export const postApiVbyApiVersionFormData = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
+export const postApiVbyApiVersionFormData = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PostApiVbyApiVersionFormDataData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/formData',
@@ -204,119 +204,119 @@ export const postApiVbyApiVersionFormData = <TComposable extends Composable, Def
     });
 };
 
-export const callWithDefaultParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
+export const callWithDefaultParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callWithDefaultOptionalParameters = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
+export const callWithDefaultOptionalParameters = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithDefaultOptionalParametersData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const callToTestOrderOfParams = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
+export const callToTestOrderOfParams = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallToTestOrderOfParamsData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/defaults',
         ...options
     });
 };
 
-export const duplicateName = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
+export const duplicateName = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateNameData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).delete<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName2 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
+export const duplicateName2 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName2Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName3 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
+export const duplicateName3 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName3Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const duplicateName4 = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
+export const duplicateName4 = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, DuplicateName4Data, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/duplicate',
         ...options
     });
 };
 
-export const callWithNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
+export const callWithNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithNoContentResponseResponse = CallWithNoContentResponseResponse>(options: Options<TComposable, CallWithNoContentResponseData, CallWithNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/no-content',
         ...options
     });
 };
 
-export const callWithResponseAndNoContentResponse = <TComposable extends Composable, DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
+export const callWithResponseAndNoContentResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseAndNoContentResponseResponse = CallWithResponseAndNoContentResponseResponse>(options: Options<TComposable, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseAndNoContentResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/response-and-no-content',
         ...options
     });
 };
 
-export const dummyA = <TComposable extends Composable, DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
+export const dummyA = <TComposable extends Composable = '$fetch', DefaultT extends DummyAResponse = DummyAResponse>(options: Options<TComposable, DummyAData, DummyAResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyAResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/a',
         ...options
     });
 };
 
-export const dummyB = <TComposable extends Composable, DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
+export const dummyB = <TComposable extends Composable = '$fetch', DefaultT extends DummyBResponse = DummyBResponse>(options: Options<TComposable, DummyBData, DummyBResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, DummyBResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multiple-tags/b',
         ...options
     });
 };
 
-export const callWithResponse = <TComposable extends Composable, DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
+export const callWithResponse = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponseResponse = CallWithResponseResponse>(options: Options<TComposable, CallWithResponseData, CallWithResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, CallWithResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithDuplicateResponses = <TComposable extends Composable, DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
+export const callWithDuplicateResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithDuplicateResponsesResponse = CallWithDuplicateResponsesResponse>(options: Options<TComposable, CallWithDuplicateResponsesData, CallWithDuplicateResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, CallWithDuplicateResponsesResponse | DefaultT, CallWithDuplicateResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const callWithResponses = <TComposable extends Composable, DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
+export const callWithResponses = <TComposable extends Composable = '$fetch', DefaultT extends CallWithResponsesResponse = CallWithResponsesResponse>(options: Options<TComposable, CallWithResponsesData, CallWithResponsesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, CallWithResponsesResponse | DefaultT, CallWithResponsesError, DefaultT>({
         url: '/api/v{api-version}/response',
         ...options
     });
 };
 
-export const collectionFormat = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
+export const collectionFormat = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CollectionFormatData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/collectionFormat',
         ...options
     });
 };
 
-export const types = <TComposable extends Composable, DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
+export const types = <TComposable extends Composable = '$fetch', DefaultT extends TypesResponse = TypesResponse>(options: Options<TComposable, TypesData, TypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, TypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/types',
         ...options
     });
 };
 
-export const uploadFile = <TComposable extends Composable, DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
+export const uploadFile = <TComposable extends Composable = '$fetch', DefaultT extends UploadFileResponse = UploadFileResponse>(options: Options<TComposable, UploadFileData, UploadFileResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, UploadFileResponse | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/upload',
@@ -328,28 +328,28 @@ export const uploadFile = <TComposable extends Composable, DefaultT extends Uplo
     });
 };
 
-export const fileResponse = <TComposable extends Composable, DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
+export const fileResponse = <TComposable extends Composable = '$fetch', DefaultT extends FileResponseResponse = FileResponseResponse>(options: Options<TComposable, FileResponseData, FileResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, FileResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/file/{id}',
         ...options
     });
 };
 
-export const complexTypes = <TComposable extends Composable, DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
+export const complexTypes = <TComposable extends Composable = '$fetch', DefaultT extends ComplexTypesResponse = ComplexTypesResponse>(options: Options<TComposable, ComplexTypesData, ComplexTypesResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, ComplexTypesResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex',
         ...options
     });
 };
 
-export const multipartResponse = <TComposable extends Composable, DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
+export const multipartResponse = <TComposable extends Composable = '$fetch', DefaultT extends MultipartResponseResponse = MultipartResponseResponse>(options: Options<TComposable, MultipartResponseData, MultipartResponseResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).get<TComposable, MultipartResponseResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/multipart',
         ...options
     });
 };
 
-export const multipartRequest = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
+export const multipartRequest = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, MultipartRequestData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...formDataBodySerializer,
         url: '/api/v{api-version}/multipart',
@@ -361,7 +361,7 @@ export const multipartRequest = <TComposable extends Composable, DefaultT = unde
     });
 };
 
-export const complexParams = <TComposable extends Composable, DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
+export const complexParams = <TComposable extends Composable = '$fetch', DefaultT extends ComplexParamsResponse = ComplexParamsResponse>(options: Options<TComposable, ComplexParamsData, ComplexParamsResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, ComplexParamsResponse | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/complex/{id}',
         ...options,
@@ -372,21 +372,21 @@ export const complexParams = <TComposable extends Composable, DefaultT extends C
     });
 };
 
-export const callWithResultFromHeader = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
+export const callWithResultFromHeader = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, CallWithResultFromHeaderData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/header',
         ...options
     });
 };
 
-export const testErrorCode = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
+export const testErrorCode = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, TestErrorCodeData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, unknown | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/error',
         ...options
     });
 };
 
-export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable, DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
+export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Composable = '$fetch', DefaultT extends NonAsciiæøåÆøÅöôêÊ字符串Response = NonAsciiæøåÆøÅöôêÊ字符串Response>(options: Options<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, DefaultT>) => {
     return (options.client ?? _heyApiClient).post<TComposable, NonAsciiæøåÆøÅöôêÊ字符串Response | DefaultT, unknown, DefaultT>({
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',
         ...options
@@ -396,7 +396,7 @@ export const nonAsciiæøåÆøÅöôêÊ字符串 = <TComposable extends Compos
 /**
  * Login User
  */
-export const putWithFormUrlEncoded = <TComposable extends Composable, DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
+export const putWithFormUrlEncoded = <TComposable extends Composable = '$fetch', DefaultT = undefined>(options: Options<TComposable, PutWithFormUrlEncodedData, unknown, DefaultT>) => {
     return (options.client ?? _heyApiClient).put<TComposable, unknown | DefaultT, unknown, DefaultT>({
         ...urlSearchParamsBodySerializer,
         url: '/api/v{api-version}/non-ascii-æøåÆØÅöôêÊ字符串',

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
@@ -61,7 +61,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/types.gen.ts
@@ -64,7 +64,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -89,7 +89,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -119,7 +119,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -128,7 +128,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -137,7 +137,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -181,7 +181,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/sdk.gen.ts
@@ -4,7 +4,7 @@ import type { Options as ClientOptions, Composable, TDataShape, Client } from '.
 import type { EventSubscribeResponse, EventSubscribeData } from './types.gen';
 import { client as _heyApiClient } from './client.gen';
 
-export type Options<TComposable extends Composable, TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
+export type Options<TComposable extends Composable = '$fetch', TData extends TDataShape = TDataShape, ResT = unknown, DefaultT = undefined> = ClientOptions<TComposable, TData, ResT, DefaultT> & {
     /**
      * You can provide a client instance returned by `createClient()` instead of
      * individual options. This might be also useful if you want to implement a
@@ -21,7 +21,7 @@ export type Options<TComposable extends Composable, TData extends TDataShape = T
 /**
  * Get events
  */
-export const eventSubscribe = <TComposable extends Composable, DefaultT extends EventSubscribeResponse = EventSubscribeResponse>(options: Options<TComposable, EventSubscribeData, EventSubscribeResponse, DefaultT>) => {
+export const eventSubscribe = <TComposable extends Composable = '$fetch', DefaultT extends EventSubscribeResponse = EventSubscribeResponse>(options: Options<TComposable, EventSubscribeData, EventSubscribeResponse, DefaultT>) => {
     return (options.client ?? _heyApiClient).sse.get<TComposable, EventSubscribeResponse | DefaultT, unknown, DefaultT>({
         url: '/event',
         ...options

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
 
   const request: Client['request'] = ({
     asyncDataOptions,
-    composable,
+    composable = '$fetch',
     ...options
   }) => {
     const key = options.key;

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/types.ts
@@ -62,7 +62,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
-  TComposable extends Composable = Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   DefaultT = undefined,
   Url extends string = string,
@@ -87,7 +87,7 @@ export interface RequestOptions<
       | 'sseMaxRetryDelay'
     > {
   asyncDataOptions?: AsyncDataOptions<ResT, ResT, KeysOf<ResT>, DefaultT>;
-  composable: TComposable;
+  composable?: TComposable;
   key?: string;
   /**
    * Security mechanism(s) to use for the request.
@@ -117,7 +117,7 @@ export interface ClientOptions {
 }
 
 type MethodFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -126,7 +126,7 @@ type MethodFn = <
 ) => RequestResult<TComposable, ResT, TError>;
 
 type SseFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -135,7 +135,7 @@ type SseFn = <
 ) => Promise<ServerSentEventsResult<RequestResult<TComposable, ResT, TError>>>;
 
 type RequestFn = <
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   ResT = unknown,
   TError = unknown,
   DefaultT = undefined,
@@ -179,7 +179,7 @@ export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn, SseFn>;
 type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Options<
-  TComposable extends Composable,
+  TComposable extends Composable = '$fetch',
   TData extends TDataShape = TDataShape,
   ResT = unknown,
   DefaultT = undefined,

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/plugin.ts
@@ -205,7 +205,7 @@ const generateClassSdk = ({
           types: isNuxtClient
             ? [
                 {
-                  // default: tsc.ots.string('$fetch'),
+                  default: tsc.ots.string('$fetch'),
                   extends: tsc.typeNode('Composable'),
                   name: nuxtTypeComposable,
                 },
@@ -379,7 +379,7 @@ const generateFlatSdk = ({
         types: isNuxtClient
           ? [
               {
-                // default: tsc.ots.string('$fetch'),
+                default: tsc.ots.string('$fetch'),
                 extends: tsc.typeNode('Composable'),
                 name: nuxtTypeComposable,
               },

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/typeOptions.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/typeOptions.ts
@@ -86,6 +86,7 @@ export const createTypeOptions = ({
       ? [
           tsc.typeParameterDeclaration({
             constraint: tsc.typeReferenceNode({ typeName: 'Composable' }),
+            defaultType: tsc.typeNode("'$fetch'"),
             name: 'TComposable',
           }),
           tsc.typeParameterDeclaration({

--- a/packages/openapi-ts/src/plugins/@pinia/colada/queryKey.ts
+++ b/packages/openapi-ts/src/plugins/@pinia/colada/queryKey.ts
@@ -7,7 +7,7 @@ import type { IR } from '../../../ir/types';
 import { type Property, tsc } from '../../../tsc';
 import { getClientBaseUrlKey } from '../../@hey-api/client-core/utils';
 import type { PiniaColadaPlugin } from './types';
-import { useTypeData } from './utils';
+import { getPublicTypeData, useTypeData } from './utils';
 
 const createQueryKeyFn = 'createQueryKey';
 const queryKeyName = 'QueryKey';
@@ -352,6 +352,7 @@ export const queryKeyStatement = ({
   plugin: PiniaColadaPlugin['Instance'];
 }) => {
   const typeData = useTypeData({ file, operation, plugin });
+  const { strippedTypeData } = getPublicTypeData({ plugin, typeData });
   const identifier = file.identifier({
     // TODO: refactor for better cross-plugin compatibility
     $ref: `#/pinia-colada-query-key/${operation.id}`,
@@ -367,7 +368,7 @@ export const queryKeyStatement = ({
         {
           isRequired: hasOperationDataRequired(operation),
           name: 'options',
-          type: typeData,
+          type: strippedTypeData,
         },
       ],
       statements: createQueryKeyLiteral({

--- a/packages/openapi-ts/src/plugins/@pinia/colada/queryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@pinia/colada/queryOptions.ts
@@ -16,7 +16,12 @@ import {
 } from './queryKey';
 import type { PluginState } from './state';
 import type { PiniaColadaPlugin } from './types';
-import { useTypeData, useTypeError, useTypeResponse } from './utils';
+import {
+  getPublicTypeData,
+  useTypeData,
+  useTypeError,
+  useTypeResponse,
+} from './utils';
 
 const queryOptionsType = 'UseQueryOptions';
 const optionsParamName = 'options';
@@ -75,6 +80,10 @@ export const createQueryOptions = ({
   const typeData = useTypeData({ file, operation, plugin });
   const typeError = useTypeError({ file, operation, plugin });
   const typeResponse = useTypeResponse({ file, operation, plugin });
+  const { isNuxtClient, strippedTypeData } = getPublicTypeData({
+    plugin,
+    typeData,
+  });
 
   const identifierQueryOptions = file.identifier({
     $ref: `#/pinia-colada-query-options/${operation.id}`,
@@ -152,9 +161,12 @@ export const createQueryOptions = ({
         async: true,
         multiLine: true,
         parameters: [
-          {
-            name: fnOptions,
-          },
+          isNuxtClient
+            ? {
+                name: fnOptions,
+                type: `Partial<${strippedTypeData}>`,
+              }
+            : { name: fnOptions },
         ],
         statements,
       }),
@@ -180,11 +192,12 @@ export const createQueryOptions = ({
         {
           isRequired: isRequiredOptions,
           name: optionsParamName,
-          type: typeData,
+          type: strippedTypeData,
         },
       ],
-      // TODO: better types syntax
-      returnType: `${queryOptionsType}<${typeResponse}, ${typeError.name}>`,
+      returnType: isNuxtClient
+        ? `${queryOptionsType}<${typeResponse}, ${strippedTypeData}, ${typeError.name}>`
+        : `${queryOptionsType}<${typeResponse}, ${typeError.name}>`,
       statements: [
         tsc.returnStatement({
           expression: tsc.objectExpression({

--- a/packages/openapi-ts/src/plugins/@pinia/colada/queryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@pinia/colada/queryOptions.ts
@@ -164,7 +164,7 @@ export const createQueryOptions = ({
           isNuxtClient
             ? {
                 name: fnOptions,
-                type: `Partial<${strippedTypeData}>`,
+                type: strippedTypeData,
               }
             : { name: fnOptions },
         ],

--- a/packages/openapi-ts/src/plugins/@pinia/colada/utils.ts
+++ b/packages/openapi-ts/src/plugins/@pinia/colada/utils.ts
@@ -49,6 +49,22 @@ export const getFileForOperation = ({
   };
 };
 
+export const getPublicTypeData = ({
+  plugin,
+  typeData,
+}: {
+  plugin: PiniaColadaPlugin['Instance'];
+  typeData: string;
+}) => {
+  const client = getClientPlugin(plugin.context.config);
+  const isNuxtClient = client.name === '@hey-api/client-nuxt';
+  const strippedTypeData = isNuxtClient
+    ? `Omit<${typeData}, 'composable'>`
+    : typeData;
+
+  return { isNuxtClient, strippedTypeData };
+};
+
 export const useTypeData = ({
   file,
   operation,
@@ -59,8 +75,7 @@ export const useTypeData = ({
   plugin: PiniaColadaPlugin['Instance'];
 }) => {
   const pluginSdk = plugin.getPlugin('@hey-api/sdk')!;
-  const typeData = operationOptionsType({ file, operation, plugin: pluginSdk });
-  return typeData;
+  return operationOptionsType({ file, operation, plugin: pluginSdk });
 };
 
 export const useTypeError = ({


### PR DESCRIPTION
### Description
Now for the `@pinia/colada` plugin together with `client-nuxt`, the default transport is always `$fetch`, because using `@pinia/colada` in a nuxt.js environment means a more advanced replacement for nuxt composables (`useAsyncData` / `useFetch` and etc)

For all other transport layers of `@pinia/colada` (when used outside a nuxt.js environment), the plugin stays transport‑independent and can be used with any client as before without changes

The `client-nuxt` transport now uses `$fetch` by default, but it does not break the public API, so there are no breaking changes at all (I added a small tip to the docs that `composable` now defaults to `$fetch`)

Close #2595