### PR TITLE
fix(client-axios): ensures falsy request body can be serialized

### DIFF
--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/client/client.gen.ts
@@ -59,7 +59,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -80,7 +80,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -113,6 +113,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
@@ -57,7 +57,7 @@ export const createClient = (config: Config = {}): Client => {
       await opts.requestValidator(opts);
     }
 
-    if (opts.body && opts.bodySerializer) {
+    if (opts.body !== undefined && opts.bodySerializer) {
       opts.body = opts.bodySerializer(opts.body);
     }
 
@@ -78,7 +78,7 @@ export const createClient = (config: Config = {}): Client => {
       const response = await _axios({
         ...optsWithoutAuth,
         baseURL: opts.baseURL as string,
-        data: opts.body,
+        data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
         params: opts.paramsSerializer ? opts.query : undefined,
@@ -111,6 +111,23 @@ export const createClient = (config: Config = {}): Client => {
       return e;
     }
   };
+
+  function getValidRequestBody(options: RequestOptions) {
+    const hasBody = options.body !== undefined;
+    const isSerializedBody = hasBody && options.bodySerializer;
+
+    if (isSerializedBody) {
+      return options.body !== '' ? options.body : null;
+    }
+
+    // plain/text body
+    if (hasBody) {
+      return options.body;
+    }
+
+    // no body was provided
+    return undefined;
+  }
 
   const makeMethodFn =
     (method: Uppercase<HttpMethod>) => (options: RequestOptions) =>


### PR DESCRIPTION
Resolves: #2599

This PR ensures that when a request defines a falsy `options.body`,  and an `options.bodySerializer`, the body is serialized, and valid request data is sent in the request.