### PR TITLE
Send explicitly-provided empty object bodies

### DIFF
--- a/.changeset/early-bodies-stay.md
+++ b/.changeset/early-bodies-stay.md
@@ -1,0 +1,8 @@
+---
+"@hey-api/openapi-ts": patch
+"@hey-api/custom-client": patch
+---
+
+**client**: send an explicitly-provided empty object request body instead of dropping it
+
+When an operation was called with an empty object body (for example when every body field is optional and none were supplied), `buildClientParams` treated the empty object as an unused slot and stripped it. The request was then sent with no body and no `Content-Type` header, which servers requiring `application/json` reject. An explicitly-provided body — including an empty object — is now preserved and sent as-is, while requests genuinely without a body continue to send none.

--- a/.changeset/early-bodies-stay.md
+++ b/.changeset/early-bodies-stay.md
@@ -1,8 +1,5 @@
 ---
 "@hey-api/openapi-ts": patch
-"@hey-api/custom-client": patch
 ---
 
-**client**: send an explicitly-provided empty object request body instead of dropping it
-
-When an operation was called with an empty object body (for example when every body field is optional and none were supplied), `buildClientParams` treated the empty object as an unused slot and stripped it. The request was then sent with no body and no `Content-Type` header, which servers requiring `application/json` reject. An explicitly-provided body — including an empty object — is now preserved and sent as-is, while requests genuinely without a body continue to send none.
+**plugin(@hey-api/client-angular)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/.changeset/new-owls-wait.md
+++ b/.changeset/new-owls-wait.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-next)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/.changeset/new-ties-say.md
+++ b/.changeset/new-ties-say.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-axios)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/.changeset/pretty-pandas-talk.md
+++ b/.changeset/pretty-pandas-talk.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-ky)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/.changeset/salty-poems-taste.md
+++ b/.changeset/salty-poems-taste.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-nuxt)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/.changeset/sharp-places-roll.md
+++ b/.changeset/sharp-places-roll.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-ofetch)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/.changeset/shy-moose-press.md
+++ b/.changeset/shy-moose-press.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-fetch)**: fix: send an empty object request body when explicitly provided in flat parameters mode

--- a/examples/openapi-ts-angular-common/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-angular-common/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-angular/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-angular/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-angular/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-angular/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-axios/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-axios/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-axios/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-axios/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-fastify/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-fastify/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-fetch/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-fetch/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-ky/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-ky/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-ky/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-ky/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-nestjs/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-nestjs/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-next/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-next/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-next/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-next/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-ofetch/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-ofetch/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-ofetch/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-ofetch/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-openai/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-openai/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-openai/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-openai/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-pinia-colada/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-pinia-colada/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-tanstack-react-query/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-tanstack-react-query/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/examples/openapi-ts-tanstack-vue-query/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/core/params.gen.ts
@@ -89,20 +89,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -118,18 +112,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/examples/openapi-ts-tanstack-vue-query/src/client/core/params.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/core/params.gen.ts
@@ -88,16 +88,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +110,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +147,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +159,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +168,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +184,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/custom-client/src/core/params.ts
+++ b/packages/custom-client/src/core/params.ts
@@ -58,25 +58,19 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
-    if (value && typeof value === 'object' && !Object.keys(value).length) {
+    if (slot === 'body') continue;
+    if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
   const params: Params = {
@@ -87,18 +81,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -115,7 +105,9 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
       if (config.key) {
         const field = map.get(config.key)!;
         const name = field.map || config.key;
-        writeSlot(field.in, name, arg);
+        if (field.in) {
+          writeSlot(field.in, name, arg);
+        }
       } else {
         params.body = arg;
       }

--- a/packages/custom-client/src/core/params.ts
+++ b/packages/custom-client/src/core/params.ts
@@ -57,14 +57,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
 const stripEmptySlots = (params: Params) => {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -73,13 +80,25 @@ const stripEmptySlots = (params: Params) => {
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
   const params: Params = {
-    body: Object.create(null),
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -96,7 +115,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
       if (config.key) {
         const field = map.get(config.key)!;
         const name = field.map || config.key;
-        (params[field.in] as Record<string, unknown>)[name] = arg;
+        writeSlot(field.in, name, arg);
       } else {
         params.body = arg;
       }
@@ -106,17 +125,17 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
         if (field) {
           const name = field.map || key;
-          (params[field.in] as Record<string, unknown>)[name] = value;
+          writeSlot(field.in, name, value);
         } else {
           const extra = extraPrefixes.find(([prefix]) => key.startsWith(prefix));
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else {
             for (const [slot, allowed] of Object.entries(config.allowExtra ?? {})) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer-duplicate/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer-duplicate/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-number/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-number/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-strict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-strict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-string/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-string/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/clean-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/clean-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/import-file-extension-ts/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/import-file-extension-ts/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-optional/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-optional/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-required/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-required/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-node16-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-node16-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-nodenext-sdk/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-nodenext-sdk/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-false/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-false/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-number/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-number/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-strict/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-strict/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-string/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/base-url-string/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/bundle/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/bundle/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/default/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/default/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/sdk-client-optional/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/sdk-client-optional/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/sdk-client-required/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/my-client/sdk-client-required/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer-duplicate/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer-duplicate/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-temporal/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-temporal/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/core/params.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/main/test/custom/client/core/params.ts
+++ b/packages/openapi-ts-tests/main/test/custom/client/core/params.ts
@@ -63,13 +63,13 @@ interface Params {
   query: Record<string, unknown>;
 }
 
-const stripEmptySlots = (params: Params) => {
+function stripEmptySlots(params: Params) {
   for (const [slot, value] of Object.entries(params)) {
     if (value && typeof value === 'object' && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
   }
-};
+}
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/core/params.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/core/params.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/core/params.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/core/params.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/core/params.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/core/params.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/asClass/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/asClass/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/axios/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/axios/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/full-config/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/full-config/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/name-builder/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/name-builder/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/internal-name-conflict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/internal-name-conflict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/asClass/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/asClass/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/axios/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/axios/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/full-config/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/full-config/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/name-builder/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/name-builder/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/internal-name-conflict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/internal-name-conflict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/angular-query-experimental/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/angular-query-experimental/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/preact-query/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/preact-query/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/react-query/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/react-query/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/solid-query/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/solid-query/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/svelte-query/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/svelte-query/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/vue-query/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/vue-query/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/pagination-ref/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/pagination-ref/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/asClass/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/asClass/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/axios/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/axios/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/fetch/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/fetch/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/full-config/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/full-config/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/name-builder/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/name-builder/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/query-options-name-conflict/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/query-options-name-conflict/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/sse-react-query/core/params.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/sse-react-query/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/transformer/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/transformer/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/transformer/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/transformer/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/transformer/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/transformer/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/core/params.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -105,14 +104,22 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -130,7 +137,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -142,7 +149,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -151,11 +158,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -167,5 +174,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/params.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/params.test.ts
@@ -405,7 +405,7 @@ describe('buildClientParams', () => {
         queryFields,
       );
       expect(Object.getPrototypeOf(result.query)).toBeNull();
-      expect(result.query!.q).toBe('hello');
+      expect(result.query.q).toBe('hello');
     });
 
     it('$query_constructor writes a plain property', () => {
@@ -431,8 +431,8 @@ describe('buildClientParams', () => {
 
     it('still processes legitimate $query_ extra keys', () => {
       const result = buildClientParams([{ $query_extra: 'value', q: 'hello' }], queryFields);
-      expect(result.query!.extra).toBe('value');
-      expect(result.query!.q).toBe('hello');
+      expect(result.query.extra).toBe('value');
+      expect(result.query.q).toBe('hello');
     });
   });
 });

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/params.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/params.test.ts
@@ -356,6 +356,35 @@ describe('buildClientParams', () => {
         body: [],
       },
     },
+    {
+      args: [{}],
+      config: [
+        {
+          in: 'body',
+        },
+      ],
+      description: 'empty object positional body',
+      params: {
+        body: {},
+      },
+    },
+    {
+      args: [
+        {
+          foo: {},
+        },
+      ],
+      config: [
+        {
+          key: 'foo',
+          map: 'body',
+        },
+      ],
+      description: 'empty object aliased body',
+      params: {
+        body: {},
+      },
+    },
   ];
 
   it.each(scenarios)('$description', async ({ args, config, params }) => {
@@ -376,7 +405,7 @@ describe('buildClientParams', () => {
         queryFields,
       );
       expect(Object.getPrototypeOf(result.query)).toBeNull();
-      expect(result.query.q).toBe('hello');
+      expect(result.query!.q).toBe('hello');
     });
 
     it('$query_constructor writes a plain property', () => {
@@ -402,8 +431,8 @@ describe('buildClientParams', () => {
 
     it('still processes legitimate $query_ extra keys', () => {
       const result = buildClientParams([{ $query_extra: 'value', q: 'hello' }], queryFields);
-      expect(result.query.extra).toBe('value');
-      expect(result.query.q).toBe('hello');
+      expect(result.query!.extra).toBe('value');
+      expect(result.query!.q).toBe('hello');
     });
   });
 });

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/params.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/params.ts
@@ -86,16 +86,21 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
-  headers: Record<string, unknown>;
-  path: Record<string, unknown>;
-  query: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+// Strips constructed slots (headers/path/query) that ended up empty, so we
+// don't send an empty object the caller never populated. `body` is deliberately
+// excluded: unlike the other slots it is supplied by the caller, so an explicit
+// empty body (e.g. `{}`) is a real value and must be sent as-is.
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === 'body') {
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -103,14 +108,26 @@ function stripEmptySlots(params: ParamsSlotMap): void {
 }
 
 export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsConfig): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  // Writes a single field into its slot. `body` has no placeholder and is
+  // created on first write, so a request without a body sends none, while an
+  // explicitly-provided body is preserved by `stripEmptySlots`. The null
+  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
+  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  };
 
   let config: FieldsConfig[number] | undefined;
 
@@ -128,7 +145,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -140,7 +157,7 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -149,11 +166,11 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ('allowExtra' in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -165,5 +182,5 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/params.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/params.ts
@@ -87,20 +87,14 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 
 interface Params {
   body?: unknown;
-  headers?: Record<string, unknown>;
-  path?: Record<string, unknown>;
-  query?: Record<string, unknown>;
+  headers: Record<string, unknown>;
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
 }
 
-// Strips constructed slots (headers/path/query) that ended up empty, so we
-// don't send an empty object the caller never populated. `body` is deliberately
-// excluded: unlike the other slots it is supplied by the caller, so an explicit
-// empty body (e.g. `{}`) is a real value and must be sent as-is.
 function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
-    if (slot === 'body') {
-      continue;
-    }
+    if (slot === 'body') continue;
     if (value && typeof value === 'object' && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot];
     }
@@ -116,18 +110,14 @@ export function buildClientParams(args: ReadonlyArray<unknown>, fields: FieldsCo
 
   const map = buildKeyMap(fields);
 
-  // Writes a single field into its slot. `body` has no placeholder and is
-  // created on first write, so a request without a body sends none, while an
-  // explicitly-provided body is preserved by `stripEmptySlots`. The null
-  // prototype guards against prototype pollution (GHSA-hhx9-57xq-r5rw).
-  const writeSlot = (slot: Slot, key: string, value: unknown): void => {
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
     let record = params[slot] as Record<string, unknown> | undefined;
     if (record === undefined) {
       record = Object.create(null) as Record<string, unknown>;
       params[slot] = record;
     }
     record[key] = value;
-  };
+  }
 
   let config: FieldsConfig[number] | undefined;
 

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/shared/operation.ts
@@ -410,10 +410,12 @@ export function operationStatements({
       }
       config.push(shape);
     }
-    const symbol = plugin.imports.buildClientParams;
     statements.push(
       $.const('params').assign(
-        $(symbol).call($.array(...args), $.array($.object().prop('args', $.array(...config)))),
+        $(plugin.imports.buildClientParams).call(
+          $.array(...args),
+          $.array($.object().prop('args', $.array(...config))),
+        ),
       ),
     );
     reqOptions.spread('params');


### PR DESCRIPTION
Fixes https://github.com/hey-api/openapi-ts/issues/4069

## Fix: preserve an explicitly-provided empty object request body

**Problem:** `buildClientParams` initialized every slot (`body`/`headers`/`path`/`query`) as an empty object, then stripped any that stayed empty. This couldn't distinguish an unused slot from a body the caller deliberately passed as `{}`, so empty bodies were deleted — the request went out with no body and no `Content-Type`. (See linked issue.)

**Fix:** Treat `body` specially. It no longer gets an empty placeholder — it's set only when the caller provides it — and `stripEmptySlots` now skips `body`. So an explicit body (including `{}`) is sent as-is, while requests genuinely without a body still send none. `headers`/`path`/`query` keep their existing strip-when-empty behavior.

Also fixes the `Params` return type, which declared the slots as always-present but `delete`d them at runtime — they're now optional.

**Changes**
- `client-core/bundle/params.ts` — body excluded from stripping; lazy `writeSlot` helper; optional `Params`.
- `custom-client/src/core/params.ts` — same fix (mirror copy).
- `params.test.ts` — added empty-object body cases (positional + aliased).

**Tests:** all client-core/client params + fetch/custom-client suites pass; typecheck and lint clean.
