### PR TITLE
fix: guard against non-object values when iterating path items in examples plugin

### DIFF
--- a/packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts
@@ -65,6 +65,10 @@ export const handler: HeyApiExamplesPlugin['Handler'] = ({ plugin }) => {
 
   for (const [, pathItem] of Object.entries(spec.paths)) {
     for (const [, operation] of Object.entries(pathItem)) {
+      if (typeof operation !== 'object' || operation === null) {
+        continue;
+      }
+
       if ('parameters' in operation || 'summary' in operation || 'description' in operation) {
         continue;
       }


### PR DESCRIPTION
## Why

When an OpenAPI spec contains `x-*` extension fields at the path item level (e.g. `x-codegen-method-type: "ADD"`), the examples plugin crashes with:

```
Cannot use 'in' operator to search for 'parameters' in ADD
```

The code in `plugin.ts` iterates over all entries of a path item with `Object.entries(pathItem)`, which includes `x-*` extension fields. The `in` operator is then used on string values, causing a `TypeError`.

This is valid per the OpenAPI specification, which allows `x-*` extensions at any level.

## What Changed

Added a type guard in `packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts` to skip non-object values before using the `in` operator:

```ts
if (typeof operation !== 'object' || operation === null) {
  continue;
}
```

This safely filters out `x-*` extension fields (strings, numbers, etc.) as well as other non-operation path item fields like `$ref` and `parameters` (array).

Closes #4142
