### PR TITLE
fix(client): sanitize Request init for Deno and Bun compatibility

### DIFF
--- a/.changeset/honest-rabbits-deno-bun.md
+++ b/.changeset/honest-rabbits-deno-bun.md
@@ -1,0 +1,7 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**fix**: generated fetch and SSE clients no longer leak internal options into the `Request` init, fixing `TypeError: Failed to construct 'Request'` on Deno and Bun
+
+The `client-fetch` and core SSE runtimes spread their internal options object into `new Request(url, init)`. Node, undici and browsers ignore unknown `RequestInit` keys, but Deno and Bun validate the init strictly (Deno treats `client` as a `Deno.HttpClient`) and throw on every request. The init is now sanitized to standard `RequestInit` fields before constructing the `Request`. This is a no-op on Node and in the browser.

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/utils.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { getValidRequestBody } from '../../client-core/bundle/utils';
+import { getValidRequestBody, toRequestInit } from '../../client-core/bundle/utils';
 
 describe('getValidRequestBody', () => {
   const noBodySerializer = [
@@ -61,4 +61,76 @@ describe('getValidRequestBody', () => {
       expect(getValidRequestBody(options)).toBe(expectedBody);
     },
   );
+});
+
+describe('toRequestInit', () => {
+  it('keeps standard RequestInit fields', () => {
+    const signal = new AbortController().signal;
+    const headers = new Headers({ 'content-type': 'application/json' });
+    const init = toRequestInit({
+      body: '{"a":1}',
+      headers,
+      method: 'POST',
+      redirect: 'follow',
+      signal,
+    });
+    expect(init).toEqual({
+      body: '{"a":1}',
+      headers,
+      method: 'POST',
+      redirect: 'follow',
+      signal,
+    });
+  });
+
+  it('drops non-standard keys that break Deno and Bun', () => {
+    const init = toRequestInit({
+      baseUrl: 'http://localhost',
+      bodySerializer: () => {},
+      client: {},
+      fetch: globalThis.fetch,
+      method: 'GET',
+      parseAs: 'json',
+      path: {},
+      querySerializer: () => {},
+      requestValidator: () => {},
+      responseValidator: () => {},
+      serializedBody: 'x',
+      throwOnError: true,
+      url: '/anything',
+    });
+    expect(init).toEqual({ method: 'GET' });
+    expect(Object.keys(init)).not.toContain('client');
+  });
+
+  it('omits keys whose value is undefined', () => {
+    const init = toRequestInit({ body: undefined, method: 'GET' });
+    expect(Object.keys(init)).toEqual(['method']);
+  });
+
+  it('constructs a valid Request when a runtime rejects non-standard init (Deno/Bun)', () => {
+    const NativeRequest = globalThis.Request;
+    class StrictRequest extends NativeRequest {
+      constructor(input: RequestInfo | URL, init?: RequestInit) {
+        if (init && 'client' in init) {
+          throw new TypeError(
+            "Failed to construct 'Request': Argument 2 `client` must be a Deno.HttpClient",
+          );
+        }
+        super(input, init);
+      }
+    }
+    globalThis.Request = StrictRequest as unknown as typeof Request;
+    try {
+      const leaky = {
+        client: {},
+        fetch: globalThis.fetch,
+        headers: new Headers(),
+        method: 'GET',
+      };
+      expect(() => new Request('http://localhost/anything', toRequestInit(leaky))).not.toThrow();
+    } finally {
+      globalThis.Request = NativeRequest;
+    }
+  });
 });

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/serverSentEvents.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/serverSentEvents.ts
@@ -1,4 +1,5 @@
 import type { Config } from './types';
+import { toRequestInit } from './utils';
 
 export type ServerSentEventsOptions<TData = unknown> = Omit<RequestInit, 'method'> &
   Pick<Config, 'method' | 'responseTransformer' | 'responseValidator'> & {
@@ -114,13 +115,13 @@ export function createSseClient<TData = unknown>({
       }
 
       try {
-        const requestInit: RequestInit = {
+        const requestInit: RequestInit = toRequestInit({
           redirect: 'follow',
           ...options,
           body: options.serializedBody,
           headers,
           signal,
-        };
+        });
         let request = new Request(url, requestInit);
         if (onRequest) {
           request = await onRequest(url, requestInit);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/utils.ts
@@ -108,6 +108,45 @@ export const getUrl = ({
   return url;
 };
 
+const STANDARD_REQUEST_INIT_KEYS = [
+  'body',
+  'cache',
+  'credentials',
+  'duplex',
+  'headers',
+  'integrity',
+  'keepalive',
+  'method',
+  'mode',
+  'priority',
+  'redirect',
+  'referrer',
+  'referrerPolicy',
+  'signal',
+  'window',
+] as const;
+
+/**
+ * Returns a `RequestInit` containing only standard fields, dropping any
+ * non-standard keys (e.g. internal client options such as `client`, `fetch`,
+ * `baseUrl`, serializers and validators) that are otherwise spread into the
+ * init.
+ *
+ * Node, undici and browsers ignore unknown `RequestInit` keys, but Deno and
+ * Bun validate the init strictly and throw (e.g. Deno treats `client` as a
+ * `Deno.HttpClient`). Sanitizing here keeps the generated client portable
+ * across runtimes; it is a no-op on Node and in the browser.
+ */
+export const toRequestInit = (init: Record<PropertyKey, unknown>): RequestInit => {
+  const result: Record<string, unknown> = {};
+  for (const key of STANDARD_REQUEST_INIT_KEYS) {
+    if (init[key] !== undefined) {
+      result[key] = init[key];
+    }
+  }
+  return result as RequestInit;
+};
+
 export function getValidRequestBody(options: {
   body?: unknown;
   bodySerializer?: BodySerializer | null;

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
@@ -1,6 +1,6 @@
 import { createSseClient } from '../../client-core/bundle/serverSentEvents';
 import type { HttpMethod } from '../../client-core/bundle/types';
-import { getValidRequestBody } from '../../client-core/bundle/utils';
+import { getValidRequestBody, toRequestInit } from '../../client-core/bundle/utils';
 import type { Client, Config, RequestOptions, ResolvedRequestOptions } from './types';
 import {
   buildUrl,
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         body: getValidRequestBody(opts),
       };
 
-      request = new Request(url, requestInit);
+      request = new Request(url, toRequestInit(requestInit as Record<PropertyKey, unknown>));
 
       for (const fn of interceptors.request.fns) {
         if (fn) {


### PR DESCRIPTION
## What

Fixes the generated fetch and SSE clients throwing on Deno and Bun:

```
TypeError: Failed to construct 'Request': Argument 2 `client` must be a Deno.HttpClient
```

Closes #4177. Related: #554.

## Why

The `client-fetch` runtime and the core SSE runtime spread their internal options object into `new Request(url, init)`. Node, undici and browsers ignore unknown `RequestInit` keys, but **Deno and Bun validate the init strictly** (Deno treats `client` as a `Deno.HttpClient`) and throw on every request. A custom `fetch` cannot work around it because the `Request` is constructed before `fetch` runs.

## How

- Add a `toRequestInit()` helper to `client-core/bundle/utils.ts` that returns a `RequestInit` containing only standard fields (`method`, `headers`, `body`, `signal`, `redirect`, `cache`, `credentials`, `mode`, `referrer`, `referrerPolicy`, `integrity`, `keepalive`, `duplex`, `priority`, `window`).
- Use it at the affected `new Request(...)` sites:
  - `client-fetch/bundle/client.ts` (main request path)
  - `client-core/bundle/serverSentEvents.ts` (SSE path; this also sanitizes the `init` handed to the `onRequest` callbacks of the fetch / ofetch / ky / next clients)
- `client-ofetch` and `client-ky` already build clean inits on their main paths, so they need no change there.

Behaviour on Node and in the browser is unchanged — the removed keys were already ignored by those runtimes.

## Tests

`client-core/__tests__/utils.test.ts` adds `toRequestInit` coverage, including a test that stubs `globalThis.Request` to reject the non-standard `client` key (emulating Deno/Bun) and asserts the sanitized init constructs successfully. Runs in the normal vitest suite (no Deno/Bun runtime needed). A changeset is included.

## Downstream

Found while making `@camunda8/orchestration-cluster-api` run on Deno (camunda/orchestration-cluster-api-js#283 / #284). Once this lands, the downstream post-gen workaround can be removed.
