### PR TITLE
perf(*): about 15% faster overall in large sdk codegen

### DIFF
--- a/.changeset/green-kiwis-lead.md
+++ b/.changeset/green-kiwis-lead.md
@@ -1,0 +1,6 @@
+---
+"@hey-api/codegen-core": patch
+"@hey-api/shared": patch
+---
+
+**perf**: speed up on large specs

--- a/packages/codegen-core/src/logger.ts
+++ b/packages/codegen-core/src/logger.ts
@@ -1,11 +1,14 @@
 import colors from 'ansi-colors';
 
+type PerformanceMarkResult = ReturnType<typeof performance.mark>;
+type PerformanceMeasureResult = ReturnType<typeof performance.measure>;
+
 interface LoggerEvent {
-  end?: PerformanceMark;
+  end?: PerformanceMarkResult;
   events: Array<LoggerEvent>;
   id: string; // unique internal key
   name: string;
-  start: PerformanceMark;
+  start: PerformanceMarkResult;
 }
 
 interface Severity {
@@ -83,7 +86,7 @@ export class Logger {
     }
   }
 
-  report(print: boolean = true): PerformanceMeasure | undefined {
+  report(print: boolean = true): PerformanceMeasureResult | undefined {
     const firstEvent = this.events[0];
     if (!firstEvent) return;
 
@@ -124,7 +127,7 @@ export class Logger {
     ...parent
   }: LoggerEvent & {
     indent: number;
-    measure: PerformanceMeasure;
+    measure: PerformanceMeasureResult;
   }): void {
     const color = !indent ? colors.cyan : colors.gray;
     const lastIndex = parent.events.length - 1;
@@ -166,7 +169,7 @@ export class Logger {
     });
   }
 
-  private start(id: string): PerformanceMark {
+  private start(id: string): PerformanceMarkResult {
     return performance.mark(idStart(id));
   }
 

--- a/packages/codegen-core/src/symbols/registry.ts
+++ b/packages/codegen-core/src/symbols/registry.ts
@@ -105,7 +105,9 @@ export class SymbolRegistry implements ISymbolRegistry {
     prefix = '',
     entries: Array<IndexEntry> = [],
   ): IndexKeySpace {
-    for (const [key, value] of Object.entries(meta)) {
+    // `meta` is always a plain object here (never one with inherited enumerable properties)
+    for (const key in meta) {
+      const value = meta[key];
       const path = prefix ? `${prefix}.${key}` : key;
       if (value && typeof value === 'object' && !Array.isArray(value)) {
         this.buildIndexKeySpace(value as ISymbolMeta, path, entries);
@@ -121,10 +123,11 @@ export class SymbolRegistry implements ISymbolRegistry {
    * Avoids rebuilding the key space when it's already available.
    */
   private cacheKeyFromKeySpace(indexKeySpace: IndexKeySpace): QueryCacheKey {
-    return indexKeySpace
-      .map((indexEntry) => indexEntry[2])
-      .sort() // ensure order-insensitivity
-      .join('|');
+    const serialized: Array<string> = [];
+    for (let i = 0, len = indexKeySpace.length; i < len; i++) {
+      serialized.push(indexKeySpace[i]![2]);
+    }
+    return serialized.sort().join('|');
   }
 
   private indexSymbol(symbolId: SymbolId, indexKeySpace: IndexKeySpace): void {

--- a/packages/codegen-core/src/symbols/registry.ts
+++ b/packages/codegen-core/src/symbols/registry.ts
@@ -19,12 +19,9 @@ export class SymbolRegistry implements ISymbolRegistry {
   private _stubs: Set<SymbolId> = new Set();
   private _stubCache: Map<QueryCacheKey, SymbolId> = new Map();
   /**
-   * Precomputed index key space for each live stub, keyed by symbol id.
-   * `replaceStubs` used to rebuild this (a recursive walk + JSON.stringify
-   * per meta leaf) from scratch for every stub on every single `register()`
-   * call — O(registrations × stubs × meta size). Since a stub's meta never
-   * changes after `reference()` creates it, its key space is computed once
-   * here and reused for the lifetime of the stub.
+   * Precomputed index key space for each live stub, keyed by symbol id. Since
+   * a stub's meta never changes after `reference()` creates it, its key space
+   * is computed once here and reused for the lifetime of the stub.
    */
   private _stubKeySpaces: Map<SymbolId, IndexKeySpace> = new Map();
   private _values: Map<SymbolId, Symbol> = new Map();
@@ -105,7 +102,6 @@ export class SymbolRegistry implements ISymbolRegistry {
     prefix = '',
     entries: Array<IndexEntry> = [],
   ): IndexKeySpace {
-    // `meta` is always a plain object here (never one with inherited enumerable properties)
     for (const key in meta) {
       const value = meta[key];
       const path = prefix ? `${prefix}.${key}` : key;
@@ -241,8 +237,6 @@ export class SymbolRegistry implements ISymbolRegistry {
 
   private replaceStubs(symbol: Symbol, indexKeySpace: IndexKeySpace): void {
     if (!this._stubs.size) return;
-    // Built once per call instead of once per stub inside `isSubset`, since
-    // every stub in this loop is checked against the same `indexKeySpace`.
     const supMap = new Map(indexKeySpace.map((e) => [e[0], e[1]] as const));
     for (const stubId of this._stubs.values()) {
       const stub = this._values.get(stubId);

--- a/packages/codegen-core/src/symbols/registry.ts
+++ b/packages/codegen-core/src/symbols/registry.ts
@@ -18,6 +18,15 @@ export class SymbolRegistry implements ISymbolRegistry {
   private _registered: Set<SymbolId> = new Set();
   private _stubs: Set<SymbolId> = new Set();
   private _stubCache: Map<QueryCacheKey, SymbolId> = new Map();
+  /**
+   * Precomputed index key space for each live stub, keyed by symbol id.
+   * `replaceStubs` used to rebuild this (a recursive walk + JSON.stringify
+   * per meta leaf) from scratch for every stub on every single `register()`
+   * call — O(registrations × stubs × meta size). Since a stub's meta never
+   * changes after `reference()` creates it, its key space is computed once
+   * here and reused for the lifetime of the stub.
+   */
+  private _stubKeySpaces: Map<SymbolId, IndexKeySpace> = new Map();
   private _values: Map<SymbolId, Symbol> = new Map();
 
   dump(): ReadonlyArray<RegistryDumpEntry> {
@@ -65,6 +74,7 @@ export class SymbolRegistry implements ISymbolRegistry {
     this._values.set(stub.id, stub);
     this._stubs.add(stub.id);
     this._stubCache.set(cacheKey, stub.id);
+    this._stubKeySpaces.set(stub.id, indexKeySpace);
     return stub;
   }
 
@@ -150,8 +160,7 @@ export class SymbolRegistry implements ISymbolRegistry {
     }
   }
 
-  private isSubset(sub: IndexKeySpace, sup: IndexKeySpace): boolean {
-    const supMap = new Map(sup.map((e) => [e[0], e[1]] as const));
+  private isSubset(sub: IndexKeySpace, supMap: Map<IndexEntry[0], IndexEntry[1]>): boolean {
     for (const [key, value] of sub) {
       if (!supMap.has(key) || supMap.get(key) !== value) {
         return false;
@@ -228,14 +237,19 @@ export class SymbolRegistry implements ISymbolRegistry {
   }
 
   private replaceStubs(symbol: Symbol, indexKeySpace: IndexKeySpace): void {
+    if (!this._stubs.size) return;
+    // Built once per call instead of once per stub inside `isSubset`, since
+    // every stub in this loop is checked against the same `indexKeySpace`.
+    const supMap = new Map(indexKeySpace.map((e) => [e[0], e[1]] as const));
     for (const stubId of this._stubs.values()) {
       const stub = this._values.get(stubId);
       if (stub?.meta) {
-        const stubKeySpace = this.buildIndexKeySpace(stub.meta);
-        if (this.isSubset(stubKeySpace, indexKeySpace)) {
+        const stubKeySpace = this._stubKeySpaces.get(stubId) ?? this.buildIndexKeySpace(stub.meta);
+        if (this.isSubset(stubKeySpace, supMap)) {
           const cacheKey = this.cacheKeyFromKeySpace(stubKeySpace);
           this._stubCache.delete(cacheKey);
           this._stubs.delete(stubId);
+          this._stubKeySpaces.delete(stubId);
           stub.setCanonical(symbol);
         }
       }

--- a/packages/json-schema-ref-parser/tsconfig.json
+++ b/packages/json-schema-ref-parser/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "lib": ["ES2022", "DOM"],
     "outDir": "dist",
     "rootDir": "src",
     "types": ["vitest/globals"]

--- a/packages/openapi-python/src/py-compiler/printer.ts
+++ b/packages/openapi-python/src/py-compiler/printer.ts
@@ -32,19 +32,8 @@ export interface PyPrinterOptions {
 const DEFAULT_INDENT_SIZE = 4;
 const PARAMS_MULTILINE_THRESHOLD = 3;
 
-// Matches the first backslash (if any) in a string.
 const backslashEscapeNeeded = /\\/;
 
-/**
- * Doubles every backslash in `value`.
- *
- * Core idea: find the index of the first backslash. If there isn't one, the
- * string is returned unchanged. Otherwise walk from that index once,
- * copying unescaped runs in bulk (via `runStart`) and only inserting the
- * extra backslash where one is actually found, instead of running a global
- * regex replace over the whole string regardless of whether it contains any
- * backslashes at all.
- */
 function escapeBackslashes(value: string): string {
   const match = backslashEscapeNeeded.exec(value);
   if (match === null) return value;

--- a/packages/openapi-python/src/py-compiler/printer.ts
+++ b/packages/openapi-python/src/py-compiler/printer.ts
@@ -32,6 +32,37 @@ export interface PyPrinterOptions {
 const DEFAULT_INDENT_SIZE = 4;
 const PARAMS_MULTILINE_THRESHOLD = 3;
 
+// Matches the first backslash (if any) in a string.
+const backslashEscapeNeeded = /\\/;
+
+/**
+ * Doubles every backslash in `value`.
+ *
+ * Core idea: find the index of the first backslash. If there isn't one, the
+ * string is returned unchanged. Otherwise walk from that index once,
+ * copying unescaped runs in bulk (via `runStart`) and only inserting the
+ * extra backslash where one is actually found, instead of running a global
+ * regex replace over the whole string regardless of whether it contains any
+ * backslashes at all.
+ */
+function escapeBackslashes(value: string): string {
+  const match = backslashEscapeNeeded.exec(value);
+  if (match === null) return value;
+
+  let result = value.slice(0, match.index);
+  let runStart = match.index;
+
+  for (let i = match.index, len = value.length; i < len; i++) {
+    if (value.charCodeAt(i) !== 92) continue; // \
+    if (runStart !== i) result += value.slice(runStart, i);
+    result += '\\\\';
+    runStart = i + 1;
+  }
+
+  if (runStart !== value.length) result += value.slice(runStart);
+  return result;
+}
+
 export function createPrinter(options?: PyPrinterOptions) {
   const indentSize = options?.indentSize ?? DEFAULT_INDENT_SIZE;
   const quoteStyle = options?.quoteStyle ?? 'double';
@@ -54,7 +85,23 @@ export function createPrinter(options?: PyPrinterOptions) {
   function createStringLiteral(value: string): string {
     const result = selectQuote(value);
     if (result.conflict) {
-      return `${result.quote}${value.replaceAll(result.quote, `\\${result.quote}`)}${result.quote}`;
+      // `selectQuote` already confirmed `result.quote` occurs in `value` (via
+      // `.includes`), so unlike a general-purpose escaper there's no need to
+      // scan for a first-match index — go straight to the char-by-char pass,
+      // copying unescaped runs in bulk (via `runStart`) and only paying extra
+      // for the quote character itself.
+      const quoteCode = result.quote.charCodeAt(0);
+      const escape = `\\${result.quote}`;
+      let escaped = '';
+      let runStart = 0;
+      for (let i = 0, len = value.length; i < len; i++) {
+        if (value.charCodeAt(i) !== quoteCode) continue;
+        if (runStart !== i) escaped += value.slice(runStart, i);
+        escaped += escape;
+        runStart = i + 1;
+      }
+      if (runStart !== value.length) escaped += value.slice(runStart);
+      return `${result.quote}${escaped}${result.quote}`;
     }
     return `${result.quote}${value}${result.quote}`;
   }
@@ -352,9 +399,10 @@ export function createPrinter(options?: PyPrinterOptions) {
           if (node.value.includes('\n')) {
             const { quote } = selectQuote(node.value);
             const tripleQuote = quote.repeat(3);
-            const escaped = node.value
-              .replaceAll('\\', '\\\\')
-              .replaceAll(tripleQuote, `\\${quote}${quote}${quote}`);
+            const escaped = escapeBackslashes(node.value).replaceAll(
+              tripleQuote,
+              `\\${quote}${quote}${quote}`,
+            );
             parts.push(`${tripleQuote}${escaped}${tripleQuote}`);
           } else {
             parts.push(createStringLiteral(node.value));
@@ -387,14 +435,14 @@ export function createPrinter(options?: PyPrinterOptions) {
           trailingBackslashes !== undefined &&
           trailingBackslashes[0].length % 2 !== 0;
         if (endsWithOddBackslashes) {
-          parts.push(createStringLiteral(node.value.replaceAll('\\', '\\\\')));
+          parts.push(createStringLiteral(escapeBackslashes(node.value)));
           break;
         }
         const result = selectQuote(node.value);
         if (result.conflict) {
           const tripleQuote = result.quote.repeat(3);
           if (node.value.includes(tripleQuote)) {
-            parts.push(createStringLiteral(node.value.replaceAll('\\', '\\\\')));
+            parts.push(createStringLiteral(escapeBackslashes(node.value)));
           } else {
             parts.push(`r${tripleQuote}${node.value}${tripleQuote}`);
           }

--- a/packages/openapi-python/src/py-dsl/mixins/decorator.ts
+++ b/packages/openapi-python/src/py-dsl/mixins/decorator.ts
@@ -1,4 +1,4 @@
-import type { AnalysisContext, NodeName, Ref } from '@hey-api/codegen-core';
+import type { AnalysisContext, Node, NodeName, Ref } from '@hey-api/codegen-core';
 import { ref } from '@hey-api/codegen-core';
 
 import { py } from '../../py-compiler';

--- a/packages/openapi-ts-tests/tsconfig.base.json
+++ b/packages/openapi-ts-tests/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": false,
     "declarationMap": false,
+    "lib": ["ES2022", "DOM"],
     "noEmit": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,

--- a/packages/openapi-ts/src/generate/output.ts
+++ b/packages/openapi-ts/src/generate/output.ts
@@ -34,11 +34,17 @@ export async function generateOutput(context: Context): Promise<{ fileCount: num
     });
   }
 
+  const eventPlugins = context.logger.timeEvent('generator.plugins');
   for (const plugin of context.registerPlugins()) {
+    const eventPlugin = context.logger.timeEvent(`generator.plugins.${plugin.name}`);
     await plugin.run();
+    eventPlugin.timeEnd();
   }
+  eventPlugins.timeEnd();
 
+  const eventPlan = context.logger.timeEvent('generator.plan');
   context.gen.plan();
+  eventPlan.timeEnd();
 
   if (process.env.HEY_API_DUMP_REGISTRY) {
     const dumpPath = path.resolve(outputPath, 'registry-dump.json');
@@ -48,11 +54,14 @@ export async function generateOutput(context: Context): Promise<{ fileCount: num
     });
   }
 
+  const eventIntents = context.logger.timeEvent('generator.intents');
   const ctx = new IntentContext(context.spec);
   for (const intent of context.intents) {
     await intent.run(ctx);
   }
+  eventIntents.timeEnd();
 
+  const eventRender = context.logger.timeEvent('generator.render-and-write');
   let fileCount = 0;
   const writes: Promise<void>[] = [];
   for (const file of context.gen.render()) {
@@ -68,7 +77,9 @@ export async function generateOutput(context: Context): Promise<{ fileCount: num
     fileCount++;
   }
   await Promise.all(writes);
+  eventRender.timeEnd();
 
+  const eventSource = context.logger.timeEvent('generator.source');
   const { source } = context.config.output;
   if (source.enabled) {
     const sourcePath = source.path === null ? undefined : path.resolve(outputPath, source.path);
@@ -89,6 +100,7 @@ export async function generateOutput(context: Context): Promise<{ fileCount: num
       await source.callback(serialized);
     }
   }
+  eventSource.timeEnd();
 
   return { fileCount };
 }

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/operation.ts
@@ -51,13 +51,6 @@ export const operationToType = ({
   operation: IR.OperationObject;
   path: ReadonlyArray<string | number>;
   plugin: HeyApiTypeScriptPlugin['Instance'];
-  /**
-   * Shared processor from the plugin handler's `plugin.forEach` walk — passed
-   * in rather than created here so operations reuse the same schema-emission
-   * dedup state (`processor.hasEmitted`/`markEmitted`) as every other event
-   * in the same walk, instead of paying the cost of a fresh stateless
-   * visitor/walker on every single operation.
-   */
   processor: ProcessorResult;
   tags?: ReadonlyArray<string>;
 }): void => {

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/operation.ts
@@ -3,7 +3,7 @@ import { buildSymbolIn, deduplicateSchema, operationResponsesMap } from '@hey-ap
 
 import { $ } from '../../../../ts-dsl';
 import type { HeyApiTypeScriptPlugin } from '../types';
-import { createProcessor } from '../v1/processor';
+import type { ProcessorResult } from './processor';
 
 const irParametersToIrSchema = ({
   parameters,
@@ -45,15 +45,22 @@ export const operationToType = ({
   operation,
   path,
   plugin,
+  processor,
   tags,
 }: {
   operation: IR.OperationObject;
   path: ReadonlyArray<string | number>;
   plugin: HeyApiTypeScriptPlugin['Instance'];
+  /**
+   * Shared processor from the plugin handler's `plugin.forEach` walk — passed
+   * in rather than created here so operations reuse the same schema-emission
+   * dedup state (`processor.hasEmitted`/`markEmitted`) as every other event
+   * in the same walk, instead of paying the cost of a fresh stateless
+   * visitor/walker on every single operation.
+   */
+  processor: ProcessorResult;
   tags?: ReadonlyArray<string>;
 }): void => {
-  const processor = createProcessor(plugin);
-
   const data: IR.SchemaObject = {
     properties: {
       body: operation.body?.schema ?? { type: 'never' },

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/webhook.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/webhook.ts
@@ -5,20 +5,25 @@ import { buildSymbolIn } from '@hey-api/shared';
 import { $ } from '../../../../ts-dsl';
 import { createSchemaComment } from '../../../shared/utils/schema';
 import type { HeyApiTypeScriptPlugin } from '../types';
-import { createProcessor } from '../v1/processor';
+import type { ProcessorResult } from './processor';
 
 export function webhookToType({
   operation,
   path,
   plugin,
+  processor,
   tags,
 }: {
   operation: IR.OperationObject;
   path: ReadonlyArray<string | number>;
   plugin: HeyApiTypeScriptPlugin['Instance'];
+  /**
+   * Shared processor from the plugin handler's `plugin.forEach` walk — see
+   * `operationToType` for why this is threaded in rather than created here.
+   */
+  processor: ProcessorResult;
   tags?: ReadonlyArray<string>;
 }): Symbol {
-  const processor = createProcessor(plugin);
   let symbolWebhookPayload: Symbol | undefined;
 
   if (operation.body) {

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/webhook.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/webhook.ts
@@ -17,10 +17,6 @@ export function webhookToType({
   operation: IR.OperationObject;
   path: ReadonlyArray<string | number>;
   plugin: HeyApiTypeScriptPlugin['Instance'];
-  /**
-   * Shared processor from the plugin handler's `plugin.forEach` walk — see
-   * `operationToType` for why this is threaded in rather than created here.
-   */
   processor: ProcessorResult;
   tags?: ReadonlyArray<string>;
 }): Symbol {

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/v1/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/v1/plugin.ts
@@ -32,6 +32,7 @@ export const handlerV1: HeyApiTypeScriptPlugin['Handler'] = ({ plugin }) => {
             operation: event.operation,
             path: event._path,
             plugin,
+            processor,
             tags: event.tags,
           });
           break;
@@ -83,6 +84,7 @@ export const handlerV1: HeyApiTypeScriptPlugin['Handler'] = ({ plugin }) => {
               operation: event.operation,
               path: event._path,
               plugin,
+              processor,
               tags: event.tags,
             }),
           );

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/v1/processor.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/v1/processor.ts
@@ -33,15 +33,20 @@ export function createProcessor(plugin: HeyApiTypeScriptPlugin['Instance']): Pro
     return ctx.schema;
   };
 
+  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
+  // both fixed for the plugin's lifetime), so it and the walker built from it
+  // are created once per plugin instance instead of once per top-level
+  // schema/operation/parameter — `process` runs per top-level node, which for
+  // large specs can be thousands of calls.
+  const visitor = createVisitor({ plugin, schemaExtractor });
+  const walk = createSchemaWalker(visitor);
+
   function process(ctx: ProcessorContext): TypeScriptFinal | void {
     if (!processor.markEmitted(ctx.path)) return;
 
     const shouldExport = ctx.export !== false;
 
     return processor.withContext({ anchor: ctx.namingAnchor, tags: ctx.tags }, () => {
-      const visitor = createVisitor({ plugin, schemaExtractor });
-      const walk = createSchemaWalker(visitor);
-
       const result = walk(ctx.schema, {
         path: ref(ctx.path),
         plugin,

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/v1/processor.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/v1/processor.ts
@@ -33,11 +33,6 @@ export function createProcessor(plugin: HeyApiTypeScriptPlugin['Instance']): Pro
     return ctx.schema;
   };
 
-  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
-  // both fixed for the plugin's lifetime), so it and the walker built from it
-  // are created once per plugin instance instead of once per top-level
-  // schema/operation/parameter — `process` runs per top-level node, which for
-  // large specs can be thousands of calls.
   const visitor = createVisitor({ plugin, schemaExtractor });
   const walk = createSchemaWalker(visitor);
 

--- a/packages/openapi-ts/src/plugins/valibot/v1/processor.ts
+++ b/packages/openapi-ts/src/plugins/valibot/v1/processor.ts
@@ -33,15 +33,20 @@ export function createProcessor(plugin: ValibotPlugin['Instance']): ProcessorRes
     return ctx.schema;
   };
 
+  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
+  // both fixed for the plugin's lifetime), so it and the walker built from it
+  // are created once per plugin instance instead of once per top-level
+  // schema/operation/parameter — `process` runs per top-level node, which for
+  // large specs can be thousands of calls.
+  const visitor = createVisitor({ plugin, schemaExtractor });
+  const walk = createSchemaWalker(visitor);
+
   function process(ctx: ProcessorContext): ValibotFinal | void {
     if (!processor.markEmitted(ctx.path)) return;
 
     const shouldExport = ctx.export !== false;
 
     return processor.withContext({ anchor: ctx.namingAnchor, tags: ctx.tags }, () => {
-      const visitor = createVisitor({ plugin, schemaExtractor });
-      const walk = createSchemaWalker(visitor);
-
       const result = walk(ctx.schema, {
         path: ref(ctx.path),
         plugin,

--- a/packages/openapi-ts/src/plugins/valibot/v1/processor.ts
+++ b/packages/openapi-ts/src/plugins/valibot/v1/processor.ts
@@ -33,11 +33,6 @@ export function createProcessor(plugin: ValibotPlugin['Instance']): ProcessorRes
     return ctx.schema;
   };
 
-  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
-  // both fixed for the plugin's lifetime), so it and the walker built from it
-  // are created once per plugin instance instead of once per top-level
-  // schema/operation/parameter — `process` runs per top-level node, which for
-  // large specs can be thousands of calls.
   const visitor = createVisitor({ plugin, schemaExtractor });
   const walk = createSchemaWalker(visitor);
 

--- a/packages/openapi-ts/src/plugins/zod/mini/processor.ts
+++ b/packages/openapi-ts/src/plugins/zod/mini/processor.ts
@@ -33,15 +33,20 @@ export function createProcessor(plugin: ZodPlugin['Instance']): ProcessorResult 
     return ctx.schema;
   };
 
+  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
+  // both fixed for the plugin's lifetime), so it and the walker built from it
+  // are created once per plugin instance instead of once per top-level
+  // schema/operation/parameter — `process` runs per top-level node, which for
+  // large specs can be thousands of calls.
+  const visitor = createVisitor({ plugin, schemaExtractor });
+  const walk = createSchemaWalker(visitor);
+
   function process(ctx: ProcessorContext): ZodFinal | void {
     if (!processor.markEmitted(ctx.path)) return;
 
     const shouldExport = ctx.export !== false;
 
     return processor.withContext({ anchor: ctx.namingAnchor, tags: ctx.tags }, () => {
-      const visitor = createVisitor({ plugin, schemaExtractor });
-      const walk = createSchemaWalker(visitor);
-
       const result = walk(ctx.schema, {
         path: ref(ctx.path),
         plugin,

--- a/packages/openapi-ts/src/plugins/zod/mini/processor.ts
+++ b/packages/openapi-ts/src/plugins/zod/mini/processor.ts
@@ -33,11 +33,6 @@ export function createProcessor(plugin: ZodPlugin['Instance']): ProcessorResult 
     return ctx.schema;
   };
 
-  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
-  // both fixed for the plugin's lifetime), so it and the walker built from it
-  // are created once per plugin instance instead of once per top-level
-  // schema/operation/parameter — `process` runs per top-level node, which for
-  // large specs can be thousands of calls.
   const visitor = createVisitor({ plugin, schemaExtractor });
   const walk = createSchemaWalker(visitor);
 

--- a/packages/openapi-ts/src/plugins/zod/v3/processor.ts
+++ b/packages/openapi-ts/src/plugins/zod/v3/processor.ts
@@ -33,15 +33,20 @@ export function createProcessor(plugin: ZodPlugin['Instance']): ProcessorResult 
     return ctx.schema;
   };
 
+  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
+  // both fixed for the plugin's lifetime), so it and the walker built from it
+  // are created once per plugin instance instead of once per top-level
+  // schema/operation/parameter — `process` runs per top-level node, which for
+  // large specs can be thousands of calls.
+  const visitor = createVisitor({ plugin, schemaExtractor });
+  const walk = createSchemaWalker(visitor);
+
   function process(ctx: ProcessorContext): ZodFinal | void {
     if (!processor.markEmitted(ctx.path)) return;
 
     const shouldExport = ctx.export !== false;
 
     return processor.withContext({ anchor: ctx.namingAnchor, tags: ctx.tags }, () => {
-      const visitor = createVisitor({ plugin, schemaExtractor });
-      const walk = createSchemaWalker(visitor);
-
       const result = walk(ctx.schema, {
         path: ref(ctx.path),
         plugin,

--- a/packages/openapi-ts/src/plugins/zod/v3/processor.ts
+++ b/packages/openapi-ts/src/plugins/zod/v3/processor.ts
@@ -33,11 +33,6 @@ export function createProcessor(plugin: ZodPlugin['Instance']): ProcessorResult 
     return ctx.schema;
   };
 
-  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
-  // both fixed for the plugin's lifetime), so it and the walker built from it
-  // are created once per plugin instance instead of once per top-level
-  // schema/operation/parameter — `process` runs per top-level node, which for
-  // large specs can be thousands of calls.
   const visitor = createVisitor({ plugin, schemaExtractor });
   const walk = createSchemaWalker(visitor);
 

--- a/packages/openapi-ts/src/plugins/zod/v4/processor.ts
+++ b/packages/openapi-ts/src/plugins/zod/v4/processor.ts
@@ -33,15 +33,20 @@ export function createProcessor(plugin: ZodPlugin['Instance']): ProcessorResult 
     return ctx.schema;
   };
 
+  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
+  // both fixed for the plugin's lifetime), so it and the walker built from it
+  // are created once per plugin instance instead of once per top-level
+  // schema/operation/parameter — `process` runs per top-level node, which for
+  // large specs can be thousands of calls.
+  const visitor = createVisitor({ plugin, schemaExtractor });
+  const walk = createSchemaWalker(visitor);
+
   function process(ctx: ProcessorContext): ZodFinal | void {
     if (!processor.markEmitted(ctx.path)) return;
 
     const shouldExport = ctx.export !== false;
 
     return processor.withContext({ anchor: ctx.namingAnchor, tags: ctx.tags }, () => {
-      const visitor = createVisitor({ plugin, schemaExtractor });
-      const walk = createSchemaWalker(visitor);
-
       const result = walk(ctx.schema, {
         path: ref(ctx.path),
         plugin,

--- a/packages/openapi-ts/src/plugins/zod/v4/processor.ts
+++ b/packages/openapi-ts/src/plugins/zod/v4/processor.ts
@@ -33,11 +33,6 @@ export function createProcessor(plugin: ZodPlugin['Instance']): ProcessorResult 
     return ctx.schema;
   };
 
-  // The visitor is stateless (only closes over `plugin`/`schemaExtractor`,
-  // both fixed for the plugin's lifetime), so it and the walker built from it
-  // are created once per plugin instance instead of once per top-level
-  // schema/operation/parameter — `process` runs per top-level node, which for
-  // large specs can be thousands of calls.
   const visitor = createVisitor({ plugin, schemaExtractor });
   const walk = createSchemaWalker(visitor);
 

--- a/packages/openapi-ts/src/ts-compiler/printer.ts
+++ b/packages/openapi-ts/src/ts-compiler/printer.ts
@@ -19,11 +19,6 @@ export interface TsPrinterOptions {
   semicolons?: boolean;
 }
 
-interface PrintContext {
-  inline?: boolean;
-  skipComments?: boolean;
-}
-
 const TOKEN_TEXT: Record<SyntaxKind, string> = {
   [SyntaxKind.AmpersandAmpersandToken]: '&&',
   [SyntaxKind.AmpersandToken]: '&',
@@ -112,6 +107,18 @@ function formatTemplateText(text: string): string {
   return text.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
 }
 
+// Faster than `Array.prototype.join` for plain string arrays.
+function fastJoin(parts: ReadonlyArray<string>, separator: string): string {
+  const len = parts.length;
+  if (len === 0) return '';
+  let result = parts[0] as string;
+  for (let i = 1; i < len; i++) {
+    result += separator;
+    result += parts[i] as string;
+  }
+  return result;
+}
+
 export function createPrinter(options?: TsPrinterOptions) {
   const indentUnit = ' '.repeat(options?.indentSize ?? 2);
   const semicolons = options?.semicolons ?? true;
@@ -123,11 +130,14 @@ export function createPrinter(options?: TsPrinterOptions) {
     indent?: boolean,
   ): void {
     if (indent) indentLevel += 1;
-    for (const comment of lines) {
+    for (let i = 0, len = lines.length; i < len; i++) {
+      const comment = lines[i] as string;
       // JSDoc/block trivia carries its own framing across lines; '//' is for single-line trivia.
       if (comment.includes('\n') || comment.startsWith('*')) {
         const block = `/*${comment}*/`;
-        parts.push(...block.split('\n').map((line) => printLine(line)));
+        const blockLines = block.split('\n');
+        for (let j = 0, len = blockLines.length; j < len; j++)
+          parts.push(printLine(blockLines[j] as string));
       } else {
         parts.push(printLine(`//${comment}`));
       }
@@ -143,8 +153,34 @@ export function createPrinter(options?: TsPrinterOptions) {
     return semicolons ? `${statement};` : statement;
   }
 
-  function printInline(node: TsNode, context: PrintContext = {}): string {
-    return printNode(node, { ...context, inline: true });
+  function printInline(node: TsNode, skipComments?: boolean): string {
+    return printNode(node, true, skipComments);
+  }
+
+  // Joins each node's inline text with `separator`, avoiding the intermediate
+  // array that `.map(...).join(...)` would allocate.
+  function joinInline(nodes: ReadonlyArray<TsNode>, separator: string): string {
+    return joinBy(nodes, separator, printInline);
+  }
+
+  // Generic version of `joinInline` for call sites that need a custom
+  // per-element formatter (e.g. wrapping each entry, or joining tokens).
+  // Seeding `result` from index 0 (rather than branching on `i > 0` inside
+  // the loop) mirrors the fast string-array-join pattern, which benchmarks
+  // faster than `Array.prototype.join` for string arrays.
+  function joinBy<T>(
+    items: ReadonlyArray<T>,
+    separator: string,
+    format: (item: T) => string,
+  ): string {
+    const len = items.length;
+    if (len === 0) return '';
+    let result = format(items[0] as T);
+    for (let i = 1; i < len; i++) {
+      result += separator;
+      result += format(items[i] as T);
+    }
+    return result;
   }
 
   function printEmbeddedStatement(statement: TsNode): string {
@@ -161,25 +197,9 @@ export function createPrinter(options?: TsPrinterOptions) {
     return lines.join('\n');
   }
 
-  function printClassMembers(members: ReadonlyArray<TsNode>): string {
-    if (members.length === 0) return '{}';
-    const lines: Array<string> = ['{'];
-    indentLevel += 1;
-    for (const member of members) {
-      if (member.kind === TsNodeKind.Identifier && member.text === '\n') {
-        lines.push(printLine(''));
-        continue;
-      }
-      lines.push(printNode(member));
-    }
-    indentLevel -= 1;
-    lines.push(printLine('}'));
-    return lines.join('\n');
-  }
-
   function printModifiers(modifiers: ReadonlyArray<TsNode> | undefined): string {
     if (!modifiers || modifiers.length === 0) return '';
-    return `${modifiers.map((modifier) => printInline(modifier)).join(' ')} `;
+    return `${joinInline(modifiers, ' ')} `;
   }
 
   function printName(name: string | TsNode): string {
@@ -188,7 +208,7 @@ export function createPrinter(options?: TsPrinterOptions) {
 
   function printTypeParameters(typeParameters: ReadonlyArray<TsNode> | undefined): string {
     if (!typeParameters || typeParameters.length === 0) return '';
-    return `<${typeParameters.map((typeParameter) => printInline(typeParameter)).join(', ')}>`;
+    return `<${joinInline(typeParameters, ', ')}>`;
   }
 
   function printAccessTarget(expression: TsNode): string {
@@ -240,17 +260,86 @@ export function createPrinter(options?: TsPrinterOptions) {
       : text;
   }
 
-  function printNode(node: TsNode, context: PrintContext = {}): string {
-    const parts: Array<string> = [];
+  // Shared by InterfaceDeclaration and TypeAliasDeclaration, both of which
+  // format `<T extends X = Y>`-style type parameter lists identically.
+  // Hoisting this (and the formatters below) to named functions means the
+  // formatter passed to `joinBy` is allocated once per printer instance
+  // instead of once per node visited.
+  function printTypeParameterWithConstraint(typeParameter: {
+    constraint?: TsNode;
+    default?: TsNode;
+    name: string | TsNode;
+  }): string {
+    let text = printName(typeParameter.name);
+    if (typeParameter.constraint) text += ` extends ${printInline(typeParameter.constraint)}`;
+    if (typeParameter.default) text += ` = ${printInline(typeParameter.default)}`;
+    return text;
+  }
 
-    if (node.leadingComments && !context.skipComments) {
-      printComments(parts, node.leadingComments);
+  function printHeritageClauseSuffix(heritageClause: {
+    token: { syntaxKind: SyntaxKind };
+    types: ReadonlyArray<TsNode>;
+  }): string {
+    return ` ${TOKEN_TEXT[heritageClause.token.syntaxKind]} ${joinInline(heritageClause.types, ', ')}`;
+  }
+
+  function printClassHeritageSuffix(clause: TsNode): string {
+    return ` ${printInline(clause)}`;
+  }
+
+  function printIndexParameter(parameter: { name: string | TsNode; type?: TsNode }): string {
+    let entry = printName(parameter.name);
+    if (parameter.type) entry += `: ${printInline(parameter.type)}`;
+    return entry;
+  }
+
+  function printTokenWithTrailingSpace(token: { syntaxKind: SyntaxKind }): string {
+    return `${TOKEN_TEXT[token.syntaxKind]} `;
+  }
+
+  // `printNode` used to allocate a fresh `push` closure on every call (i.e.
+  // once per AST node) purely to manage the `single`/`parts` accumulator
+  // below. Since printNode never runs re-entrantly through this closure
+  // (each call fully resolves its own `push` calls before returning), that
+  // state can instead live in these two outer-scoped variables, saving one
+  // closure allocation per node at the cost of save/restore around recursion.
+  let accSingle: string | undefined;
+  let accParts: Array<string> | undefined;
+
+  function push(value: string): void {
+    if (accParts) {
+      accParts.push(value);
+    } else if (accSingle === undefined) {
+      accSingle = value;
+    } else {
+      accParts = [accSingle, value];
+      accSingle = undefined;
+    }
+  }
+
+  function printNode(node: TsNode, inline?: boolean, skipComments?: boolean): string {
+    // Most node kinds push exactly one string and carry no comments, so the
+    // switch below writes into `parts` lazily: `single` holds that one string
+    // without ever allocating an array, and we only spill into a real
+    // `Array<string>` once a second entry (comments, or a multi-line case
+    // such as Block/ClassDeclaration) shows up. Save/restore the outer
+    // accumulator around this call so recursive printNode calls (which also
+    // use `push`) don't clobber this frame's in-progress result.
+    const savedSingle = accSingle;
+    const savedParts = accParts;
+    accSingle = undefined;
+    accParts = undefined;
+
+    if (node.leadingComments && !skipComments) {
+      const leading: Array<string> = [];
+      printComments(leading, node.leadingComments);
+      for (let i = 0, len = leading.length; i < len; i++) push(leading[i] as string);
     }
 
     switch (node.kind) {
       case TsNodeKind.ArrayBindingPattern: {
-        const elements = node.elements.map((element) => printInline(element)).join(', ');
-        parts.push(`[${elements}]`);
+        const elements = joinInline(node.elements, ', ');
+        push(`[${elements}]`);
         break;
       }
 
@@ -258,32 +347,32 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.multiLine && node.elements.length > 0) {
           const lines: Array<string> = ['['];
           indentLevel += 1;
-          node.elements.forEach((element, index) => {
-            const text = printLine(printInline(element));
-            lines.push(index < node.elements.length - 1 ? `${text},` : text);
-          });
+          for (let i = 0, len = node.elements.length; i < len; i++) {
+            const text = printLine(printInline(node.elements[i] as TsNode));
+            lines.push(i < len - 1 ? `${text},` : text);
+          }
           indentLevel -= 1;
           lines.push(printLine(']'));
-          parts.push(lines.join('\n'));
+          push(fastJoin(lines, '\n'));
           break;
         }
         indentLevel += 1;
-        const arrayElements = node.elements.map((element) => printInline(element));
-        indentLevel -= 1;
         // tsc keeps an inline array's leading `{`/`[` on the bracket line, indenting
         // the broken element one extra level (`[{` ... `}]`).
-        parts.push(`[${arrayElements.join(', ')}]`);
+        const arrayElements = joinInline(node.elements, ', ');
+        indentLevel -= 1;
+        push(`[${arrayElements}]`);
         break;
       }
 
       case TsNodeKind.ArrayType:
-        parts.push(`${printArrayElement(node.elementType)}[]`);
+        push(`${printArrayElement(node.elementType)}[]`);
         break;
 
       case TsNodeKind.ArrowFunction: {
         let text = printModifiers(node.modifiers);
         text += printTypeParameters(node.typeParameters);
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         const onlyParameter = node.parameters.length === 1 ? node.parameters[0] : undefined;
         const bareParameter =
           !node.type &&
@@ -304,27 +393,27 @@ export function createPrinter(options?: TsPrinterOptions) {
             ? `(${printInline(node.body)})`
             : printInline(node.body);
         text += ` ${printInline(node.equalsGreaterThanToken)} ${body}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.AsExpression: {
-        parts.push(`${printInline(node.expression)} as ${printInline(node.type)}`);
+        push(`${printInline(node.expression)} as ${printInline(node.type)}`);
         break;
       }
 
       case TsNodeKind.AwaitExpression: {
-        parts.push(`await ${printInline(node.expression)}`);
+        push(`await ${printInline(node.expression)}`);
         break;
       }
 
       case TsNodeKind.BigIntLiteral: {
-        parts.push(node.text);
+        push(node.text);
         break;
       }
 
       case TsNodeKind.BinaryExpression: {
-        parts.push(
+        push(
           `${printInline(node.left)} ${printInline(node.operatorToken)} ${printInline(node.right)}`,
         );
         break;
@@ -336,16 +425,28 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.propertyName !== undefined) text += `${printInline(node.propertyName)}: `;
         text += typeof node.name === 'string' ? node.name : printInline(node.name);
         if (node.initializer) text += ` = ${printInline(node.initializer)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
-      case TsNodeKind.Block:
-        parts.push(printBraceBlock(node.statements));
+      case TsNodeKind.Block: {
+        if (node.statements.length === 0) {
+          push('{}');
+          break;
+        }
+        const lines: Array<string> = ['{'];
+        indentLevel += 1;
+        for (const statement of node.statements) {
+          lines.push(printNode(statement));
+        }
+        indentLevel -= 1;
+        lines.push(printLine('}'));
+        push(lines.join('\n'));
         break;
+      }
 
       case TsNodeKind.BreakStatement:
-        parts.push(
+        push(
           printLine(
             node.label ? terminate(`break ${printInline(node.label)}`) : terminate('break'),
           ),
@@ -355,24 +456,35 @@ export function createPrinter(options?: TsPrinterOptions) {
       case TsNodeKind.CallExpression: {
         let text = printAccessTarget(node.expression);
         if (node.typeArguments && node.typeArguments.length > 0)
-          text += `<${node.typeArguments.map((typeArgument) => printInline(typeArgument)).join(', ')}>`;
-        if (node.arguments.some((argument) => argument.leadingComments?.length)) {
-          const renderedArguments = node.arguments.map((argument) => {
+          text += `<${joinInline(node.typeArguments, ', ')}>`;
+        const args = node.arguments;
+        const argsLen = args.length;
+        let hasCommentedArg = false;
+        for (let i = 0; i < argsLen; i++) {
+          if ((args[i] as TsNode).leadingComments?.length) {
+            hasCommentedArg = true;
+            break;
+          }
+        }
+        if (hasCommentedArg) {
+          const renderedArguments: Array<string> = new Array(argsLen);
+          for (let i = 0; i < argsLen; i++) {
+            const argument = args[i] as TsNode;
             const argumentParts: Array<string> = [];
             if (argument.leadingComments) printComments(argumentParts, argument.leadingComments);
-            argumentParts.push(printLine(printNode(argument, { skipComments: true })));
-            return argumentParts.join('\n');
-          });
-          text += `(\n${renderedArguments.join(',\n')})`;
+            argumentParts.push(printLine(printNode(argument, false, true)));
+            renderedArguments[i] = fastJoin(argumentParts, '\n');
+          }
+          text += `(\n${fastJoin(renderedArguments, ',\n')})`;
         } else {
-          text += `(${node.arguments.map((argument) => printInline(argument)).join(', ')})`;
+          text += `(${joinInline(args, ', ')})`;
         }
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.CaseBlock:
-        parts.push(printBraceBlock(node.clauses));
+        push(printBraceBlock(node.clauses));
         break;
 
       case TsNodeKind.CaseClause: {
@@ -382,7 +494,7 @@ export function createPrinter(options?: TsPrinterOptions) {
           lines.push(printNode(statement));
         }
         indentLevel -= 1;
-        parts.push(lines.join('\n'));
+        push(lines.join('\n'));
         break;
       }
 
@@ -390,7 +502,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         const binding = node.variableDeclaration
           ? ` (${printInline(node.variableDeclaration)})`
           : '';
-        parts.push(`catch${binding} ${printInline(node.block)}`);
+        push(`catch${binding} ${printInline(node.block)}`);
         break;
       }
 
@@ -400,50 +512,90 @@ export function createPrinter(options?: TsPrinterOptions) {
         const keywordModifiers = node.modifiers?.filter(
           (modifier) => modifier.kind !== TsNodeKind.Decorator,
         );
-        decorators.forEach((decorator) => parts.push(printLine(printInline(decorator))));
-        let heading = `${printModifiers(keywordModifiers)}class`;
+        decorators.forEach((decorator) => push(printLine(printInline(decorator))));
+        const modifiers = printModifiers(keywordModifiers);
+        let heading = `${modifiers}class`;
         if (node.name) heading += ` ${printName(node.name)}`;
         heading += printTypeParameters(node.typeParameters);
         if (node.heritageClauses) {
-          heading += node.heritageClauses.map((clause) => ` ${printInline(clause)}`).join('');
+          heading += joinBy(node.heritageClauses, '', printClassHeritageSuffix);
         }
-        parts.push(printLine(`${heading} ${printClassMembers(node.members)}`));
+        if (node.members.length === 0) {
+          push(printLine(`${heading} {}`));
+          break;
+        }
+        push(printLine(`${heading} {`));
+        indentLevel += 1;
+        node.members.forEach((member) => {
+          // The DSL marks an explicit blank line between members with a lone-newline identifier.
+          const marker = member as TsNode;
+          if (marker.kind === TsNodeKind.Identifier && marker.text === '\n') {
+            push(printLine(''));
+            return;
+          }
+          push(printNode(member));
+        });
+        indentLevel -= 1;
+        push(printLine('}'));
         break;
       }
 
       case TsNodeKind.ClassExpression: {
-        let heading = `${printModifiers(node.modifiers)}class`;
+        const decorators =
+          node.modifiers?.filter((modifier) => modifier.kind === TsNodeKind.Decorator) ?? [];
+        const keywordModifiers = node.modifiers?.filter(
+          (modifier) => modifier.kind !== TsNodeKind.Decorator,
+        );
+        decorators.forEach((decorator) => push(printLine(printInline(decorator))));
+        const modifiers = printModifiers(keywordModifiers);
+        let heading = `${modifiers}class`;
         if (node.name) heading += ` ${printInline(node.name)}`;
         heading += printTypeParameters(node.typeParameters);
         if (node.heritageClauses) {
-          heading += node.heritageClauses.map((clause) => ` ${printInline(clause)}`).join('');
+          heading += joinBy(node.heritageClauses, '', printClassHeritageSuffix);
         }
-        parts.push(`${heading} ${printClassMembers(node.members)}`);
+        if (node.members.length === 0) {
+          push(`${heading} {}`);
+          break;
+        }
+        push(`${heading} {`);
+        indentLevel += 1;
+        node.members.forEach((member) => {
+          // The DSL marks an explicit blank line between members with a lone-newline identifier.
+          const marker = member as TsNode;
+          if (marker.kind === TsNodeKind.Identifier && marker.text === '\n') {
+            push(printLine(''));
+            return;
+          }
+          push(printNode(member));
+        });
+        indentLevel -= 1;
+        push(printLine('}'));
         break;
       }
 
       case TsNodeKind.ClassStaticBlockDeclaration:
-        parts.push(printLine(`static ${printInline(node.body)}`));
+        push(printLine(`static ${printInline(node.body)}`));
         break;
 
       case TsNodeKind.CommaListExpression: {
-        parts.push(node.elements.map((element) => printInline(element)).join(', '));
+        push(joinInline(node.elements, ', '));
         break;
       }
 
       case TsNodeKind.ComputedPropertyName:
-        parts.push(`[${printInline(node.expression)}]`);
+        push(`[${printInline(node.expression)}]`);
         break;
 
       case TsNodeKind.ConditionalExpression: {
-        parts.push(
+        push(
           `${printInline(node.condition)} ${printInline(node.questionToken)} ${printInline(node.whenTrue)} ${printInline(node.colonToken)} ${printInline(node.whenFalse)}`,
         );
         break;
       }
 
       case TsNodeKind.ConditionalType: {
-        parts.push(
+        push(
           `${printInline(node.checkType)} extends ${printInline(node.extendsType)} ? ${printInline(node.trueType)} : ${printInline(node.falseType)}`,
         );
         break;
@@ -451,9 +603,9 @@ export function createPrinter(options?: TsPrinterOptions) {
 
       case TsNodeKind.Constructor: {
         const modifiers = printModifiers(node.modifiers);
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         const signature = `${modifiers}constructor(${parameters})`;
-        parts.push(
+        push(
           printLine(node.body ? `${signature} ${printInline(node.body)}` : terminate(signature)),
         );
         break;
@@ -462,17 +614,17 @@ export function createPrinter(options?: TsPrinterOptions) {
       case TsNodeKind.ConstructorType: {
         const typeParameters =
           node.typeParameters && node.typeParameters.length > 0
-            ? `<${node.typeParameters.map((typeParameter) => printInline(typeParameter)).join(', ')}>`
+            ? `<${joinInline(node.typeParameters, ', ')}>`
             : '';
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
-        parts.push(
+        const parameters = joinInline(node.parameters, ', ');
+        push(
           `${printModifiers(node.modifiers)}new ${typeParameters}(${parameters}) => ${printInline(node.type)}`,
         );
         break;
       }
 
       case TsNodeKind.ContinueStatement:
-        parts.push(
+        push(
           printLine(
             node.label ? terminate(`continue ${printInline(node.label)}`) : terminate('continue'),
           ),
@@ -480,11 +632,11 @@ export function createPrinter(options?: TsPrinterOptions) {
         break;
 
       case TsNodeKind.DebuggerStatement:
-        parts.push(printLine(terminate('debugger')));
+        push(printLine(terminate('debugger')));
         break;
 
       case TsNodeKind.Decorator:
-        parts.push(`@${printInline(node.expression)}`);
+        push(`@${printInline(node.expression)}`);
         break;
 
       case TsNodeKind.DefaultClause: {
@@ -494,17 +646,17 @@ export function createPrinter(options?: TsPrinterOptions) {
           lines.push(printNode(statement));
         }
         indentLevel -= 1;
-        parts.push(lines.join('\n'));
+        push(lines.join('\n'));
         break;
       }
 
       case TsNodeKind.DeleteExpression: {
-        parts.push(`delete ${printInline(node.expression)}`);
+        push(`delete ${printInline(node.expression)}`);
         break;
       }
 
       case TsNodeKind.DoStatement:
-        parts.push(
+        push(
           printLine(
             terminate(
               `do ${printEmbeddedStatement(node.statement)} while (${printInline(node.expression)})`,
@@ -514,40 +666,40 @@ export function createPrinter(options?: TsPrinterOptions) {
         break;
 
       case TsNodeKind.ElementAccessExpression:
-        parts.push(
+        push(
           `${printAccessTarget(node.expression)}${node.questionDotToken ? '?.' : ''}[${printInline(node.argumentExpression)}]`,
         );
         break;
 
       case TsNodeKind.EmptyStatement:
-        parts.push(printLine(';'));
+        push(printLine(';'));
         break;
 
       case TsNodeKind.EnumDeclaration: {
         let header = '';
         if (node.modifiers?.length) {
-          header += `${node.modifiers.map((modifier) => printInline(modifier)).join(' ')} `;
+          header += `${joinInline(node.modifiers, ' ')} `;
         }
         header += `enum ${printName(node.name)}`;
         if (node.members.length === 0) {
-          parts.push(printLine(`${header} {}`));
+          push(printLine(`${header} {}`));
           break;
         }
-        parts.push(printLine(`${header} {`));
+        push(printLine(`${header} {`));
         indentLevel += 1;
-        node.members.forEach((member, index) => {
-          const text = printNode(member);
-          parts.push(index < node.members.length - 1 ? `${text},` : text);
-        });
+        for (let i = 0, len = node.members.length; i < len; i++) {
+          const text = printNode(node.members[i] as TsNode);
+          push(i < len - 1 ? `${text},` : text);
+        }
         indentLevel -= 1;
-        parts.push(printLine('}'));
+        push(printLine('}'));
         break;
       }
 
       case TsNodeKind.EnumMember: {
         let text = printName(node.name);
         if (node.initializer) text += ` = ${printInline(node.initializer)}`;
-        parts.push(printLine(text));
+        push(printLine(text));
         break;
       }
 
@@ -555,7 +707,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         let text = printModifiers(node.modifiers);
         text += node.isExportEquals ? 'export = ' : 'export default ';
         text += printInline(node.expression);
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
@@ -564,7 +716,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.typeOnlyToken) text += `${printInline(node.typeOnlyToken)} `;
         text += node.exportClause ? printInline(node.exportClause) : '*';
         if (node.moduleSpecifier) text += ` from ${printInline(node.moduleSpecifier)}`;
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
@@ -573,28 +725,28 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.typeOnlyToken) text += `${printInline(node.typeOnlyToken)} `;
         if (node.propertyName) text += `${printInline(node.propertyName)} as `;
         text += printInline(node.name);
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.ExpressionStatement:
-        parts.push(printLine(terminate(printInline(node.expression))));
+        push(printLine(terminate(printInline(node.expression))));
         break;
 
       case TsNodeKind.ExpressionWithTypeArguments: {
         let text = printInline(node.expression);
         if (node.typeArguments && node.typeArguments.length > 0)
-          text += `<${node.typeArguments.map((typeArgument) => printInline(typeArgument)).join(', ')}>`;
-        parts.push(text);
+          text += `<${joinInline(node.typeArguments, ', ')}>`;
+        push(text);
         break;
       }
 
       case TsNodeKind.ExternalModuleReference:
-        parts.push(`require(${printInline(node.expression)})`);
+        push(`require(${printInline(node.expression)})`);
         break;
 
       case TsNodeKind.ForInStatement:
-        parts.push(
+        push(
           printLine(
             `for (${printInline(node.initializer)} in ${printInline(node.expression)}) ${printEmbeddedStatement(node.statement)}`,
           ),
@@ -603,7 +755,7 @@ export function createPrinter(options?: TsPrinterOptions) {
 
       case TsNodeKind.ForOfStatement: {
         const awaitModifier = node.awaitModifier ? `${printInline(node.awaitModifier)} ` : '';
-        parts.push(
+        push(
           printLine(
             `for ${awaitModifier}(${printInline(node.initializer)} of ${printInline(node.expression)}) ${printEmbeddedStatement(node.statement)}`,
           ),
@@ -615,7 +767,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         const initializer = node.initializer ? printInline(node.initializer) : '';
         const condition = node.condition ? printInline(node.condition) : '';
         const incrementor = node.incrementor ? printInline(node.incrementor) : '';
-        parts.push(
+        push(
           printLine(
             `for (${initializer}; ${condition}; ${incrementor}) ${printEmbeddedStatement(node.statement)}`,
           ),
@@ -624,14 +776,14 @@ export function createPrinter(options?: TsPrinterOptions) {
       }
 
       case TsNodeKind.FunctionDeclaration: {
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         let signature = `${printModifiers(node.modifiers)}function`;
         if (node.asteriskToken) signature += printInline(node.asteriskToken);
         if (node.name) signature += ` ${printInline(node.name)}`;
         signature += printTypeParameters(node.typeParameters);
         signature += `(${parameters})`;
         if (node.type) signature += `: ${printInline(node.type)}`;
-        parts.push(
+        push(
           node.body
             ? `${printLine(signature)} ${printInline(node.body)}`
             : printLine(terminate(signature)),
@@ -640,51 +792,48 @@ export function createPrinter(options?: TsPrinterOptions) {
       }
 
       case TsNodeKind.FunctionExpression: {
-        let text = '';
-        if (node.modifiers?.length) {
-          text += node.modifiers.map((modifier) => `${printInline(modifier)} `).join('');
-        }
+        let text = printModifiers(node.modifiers);
         text += 'function';
         if (node.asteriskToken) text += printInline(node.asteriskToken);
         if (node.name) text += ` ${printInline(node.name)}`;
         text += printTypeParameters(node.typeParameters);
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         text += `${node.name ? '' : ' '}(${parameters})`;
         if (node.type) text += `: ${printInline(node.type)}`;
         text += ` ${printInline(node.body)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.FunctionType: {
         const typeParameters =
           node.typeParameters && node.typeParameters.length > 0
-            ? `<${node.typeParameters.map((typeParameter) => printInline(typeParameter)).join(', ')}>`
+            ? `<${joinInline(node.typeParameters, ', ')}>`
             : '';
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
-        parts.push(`${typeParameters}(${parameters}) => ${printInline(node.type)}`);
+        const parameters = joinInline(node.parameters, ', ');
+        push(`${typeParameters}(${parameters}) => ${printInline(node.type)}`);
         break;
       }
 
       case TsNodeKind.GetAccessor: {
         const modifiers = printModifiers(node.modifiers);
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         let signature = `${modifiers}get ${printName(node.name)}(${parameters})`;
         if (node.type) signature += `: ${printInline(node.type)}`;
-        parts.push(
+        push(
           printLine(node.body ? `${signature} ${printInline(node.body)}` : terminate(signature)),
         );
         break;
       }
 
       case TsNodeKind.HeritageClause: {
-        const types = node.types.map((type) => printInline(type)).join(', ');
-        parts.push(`${TOKEN_TEXT[node.token.syntaxKind]} ${types}`);
+        const types = joinInline(node.types, ', ');
+        push(`${TOKEN_TEXT[node.token.syntaxKind]} ${types}`);
         break;
       }
 
       case TsNodeKind.Identifier:
-        parts.push(node.text);
+        push(node.text);
         break;
 
       case TsNodeKind.IfStatement: {
@@ -692,7 +841,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.elseStatement) {
           text += ` else ${printEmbeddedStatement(node.elseStatement)}`;
         }
-        parts.push(printLine(text));
+        push(printLine(text));
         break;
       }
 
@@ -702,8 +851,8 @@ export function createPrinter(options?: TsPrinterOptions) {
         const names: Array<string> = [];
         if (node.name) names.push(printInline(node.name));
         if (node.namedBindings) names.push(printInline(node.namedBindings));
-        segments.push(names.join(', '));
-        parts.push(segments.join(' '));
+        segments.push(fastJoin(names, ', '));
+        push(fastJoin(segments, ' '));
         break;
       }
 
@@ -711,7 +860,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         let text = 'import ';
         if (node.importClause) text += `${printInline(node.importClause)} from `;
         text += printInline(node.moduleSpecifier);
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
@@ -719,7 +868,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         let text = `${printModifiers(node.modifiers)}import `;
         if (node.typeOnlyToken) text += `${printInline(node.typeOnlyToken)} `;
         text += `${printInline(node.name)} = ${printInline(node.moduleReference)}`;
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
@@ -728,7 +877,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.typeOnlyToken) text += `${printInline(node.typeOnlyToken)} `;
         if (node.propertyName) text += `${printInline(node.propertyName)} as `;
         text += printInline(node.name);
-        parts.push(text);
+        push(text);
         break;
       }
 
@@ -739,101 +888,86 @@ export function createPrinter(options?: TsPrinterOptions) {
           text += `<${node.typeArguments.map((argument) => printInline(argument)).join(', ')}>`;
         }
         if (node.isTypeOf) text = `typeof ${text}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.IndexSignature: {
         let text = '';
         if (node.modifiers?.length) {
-          text += `${node.modifiers.map((modifier) => printInline(modifier)).join(' ')} `;
+          text += `${joinInline(node.modifiers, ' ')} `;
         }
-        const parameters = node.parameters
-          .map((parameter) => {
-            let entry = printName(parameter.name);
-            if (parameter.type) entry += `: ${printInline(parameter.type)}`;
-            return entry;
-          })
-          .join(', ');
+        const parameters = joinBy(node.parameters, ', ', printIndexParameter);
         text += `[${parameters}]: ${printInline(node.type)}`;
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
       case TsNodeKind.IndexedAccessType:
-        parts.push(`${printInline(node.objectType)}[${printInline(node.indexType)}]`);
+        push(`${printInline(node.objectType)}[${printInline(node.indexType)}]`);
         break;
 
       case TsNodeKind.InferType:
-        parts.push(`infer ${printInline(node.typeParameter)}`);
+        push(`infer ${printInline(node.typeParameter)}`);
         break;
 
       case TsNodeKind.InterfaceDeclaration: {
         let header = '';
         if (node.modifiers?.length) {
-          header += `${node.modifiers.map((modifier) => printInline(modifier)).join(' ')} `;
+          header += `${joinInline(node.modifiers, ' ')} `;
         }
         header += `interface ${node.name}`;
         if (node.typeParameters?.length) {
-          header += `<${node.typeParameters
-            .map((typeParameter) => {
-              let text = typeParameter.name;
-              if (typeParameter.constraint)
-                text += ` extends ${printInline(typeParameter.constraint)}`;
-              if (typeParameter.default) text += ` = ${printInline(typeParameter.default)}`;
-              return text;
-            })
-            .join(', ')}>`;
+          header += `<${joinBy(node.typeParameters, ', ', printTypeParameterWithConstraint)}>`;
         }
         if (node.heritageClauses?.length) {
-          header += node.heritageClauses
-            .map(
-              (heritageClause) =>
-                ` ${TOKEN_TEXT[heritageClause.token.syntaxKind]} ${heritageClause.types
-                  .map((type) => printInline(type))
-                  .join(', ')}`,
-            )
-            .join('');
+          header += joinBy(node.heritageClauses, '', printHeritageClauseSuffix);
         }
         if (node.members.length === 0) {
-          parts.push(printLine(`${header} {}`));
+          push(printLine(`${header} {}`));
           break;
         }
-        parts.push(printLine(`${header} {`));
+        push(printLine(`${header} {`));
         indentLevel += 1;
-        node.members.forEach((member) => parts.push(printNode(member)));
+        for (let i = 0, len = node.members.length; i < len; i++)
+          push(printNode(node.members[i] as TsNode));
         indentLevel -= 1;
-        parts.push(printLine('}'));
+        push(printLine('}'));
         break;
       }
 
       case TsNodeKind.IntersectionType:
-        parts.push(node.types.map((type) => printIntersectionMember(type)).join(' & '));
+        push(joinBy(node.types, ' & ', printIntersectionMember));
         break;
 
       case TsNodeKind.JSDoc: {
         const comment =
           typeof node.comment === 'string'
             ? node.comment
-            : (node.comment?.map((part) => printInline(part)).join('') ?? '');
-        const tags = node.tags?.map((tag) => printInline(tag)) ?? [];
-        const lines = [...(comment ? comment.split('\n') : []), ...tags.map((tag) => `@${tag}`)];
+            : node.comment
+              ? joinInline(node.comment, '')
+              : '';
+        const lines: Array<string> = comment ? comment.split('\n') : [];
+        if (node.tags) {
+          for (let i = 0, len = node.tags.length; i < len; i++)
+            lines.push(`@${printInline(node.tags[i] as TsNode)}`);
+        }
         if (lines.length === 0) {
-          parts.push(printLine('/** */'));
+          push(printLine('/** */'));
           break;
         }
         if (lines.length === 1) {
-          parts.push(printLine(`/** ${lines[0]} */`));
+          push(printLine(`/** ${lines[0]} */`));
           break;
         }
-        parts.push(printLine('/**'));
-        lines.forEach((line) => parts.push(printLine(` * ${line}`)));
-        parts.push(printLine(' */'));
+        push(printLine('/**'));
+        for (let i = 0, len = lines.length; i < len; i++) push(printLine(` * ${lines[i]}`));
+        push(printLine(' */'));
         break;
       }
 
       case TsNodeKind.JSDocText:
-        parts.push(node.text);
+        push(node.text);
         break;
 
       case TsNodeKind.JsxAttribute: {
@@ -844,20 +978,20 @@ export function createPrinter(options?: TsPrinterOptions) {
               ? `="${node.initializer.text}"`
               : `=${printInline(node.initializer)}`;
         }
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.JsxAttributes:
-        parts.push(node.properties.map((property) => printInline(property)).join(' '));
+        push(node.properties.map((property) => printInline(property)).join(' '));
         break;
 
       case TsNodeKind.JsxClosingElement:
-        parts.push(`</${printInline(node.tagName)}>`);
+        push(`</${printInline(node.tagName)}>`);
         break;
 
       case TsNodeKind.JsxClosingFragment:
-        parts.push('</>');
+        push('</>');
         break;
 
       case TsNodeKind.JsxElement: {
@@ -866,14 +1000,14 @@ export function createPrinter(options?: TsPrinterOptions) {
         for (const child of node.children) lines.push(printLine(printInline(child)));
         indentLevel -= 1;
         lines.push(printLine(printInline(node.closingElement)));
-        parts.push(lines.join('\n'));
+        push(lines.join('\n'));
         break;
       }
 
       case TsNodeKind.JsxExpression: {
         const dotDotDot = node.dotDotDotToken ? '...' : '';
         const expression = node.expression ? printInline(node.expression) : '';
-        parts.push(`{${dotDotDot}${expression}}`);
+        push(`{${dotDotDot}${expression}}`);
         break;
       }
 
@@ -883,12 +1017,12 @@ export function createPrinter(options?: TsPrinterOptions) {
         for (const child of node.children) lines.push(printLine(printInline(child)));
         indentLevel -= 1;
         lines.push(printLine(printInline(node.closingFragment)));
-        parts.push(lines.join('\n'));
+        push(lines.join('\n'));
         break;
       }
 
       case TsNodeKind.JsxNamespacedName:
-        parts.push(`${printInline(node.namespace)}:${printInline(node.name)}`);
+        push(`${printInline(node.namespace)}:${printInline(node.name)}`);
         break;
 
       case TsNodeKind.JsxOpeningElement: {
@@ -898,12 +1032,12 @@ export function createPrinter(options?: TsPrinterOptions) {
         const attributes = printInline(node.attributes);
         if (attributes) text += ` ${attributes}`;
         text += '>';
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.JsxOpeningFragment:
-        parts.push('<>');
+        push('<>');
         break;
 
       case TsNodeKind.JsxSelfClosingElement: {
@@ -913,30 +1047,28 @@ export function createPrinter(options?: TsPrinterOptions) {
         const attributes = printInline(node.attributes);
         if (attributes) text += ` ${attributes}`;
         text += ' />';
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.JsxSpreadAttribute:
-        parts.push(`{...${printInline(node.expression)}}`);
+        push(`{...${printInline(node.expression)}}`);
         break;
 
       case TsNodeKind.JsxText:
-        parts.push(node.text);
+        push(node.text);
         break;
 
       case TsNodeKind.KeywordType:
-        parts.push(TOKEN_TEXT[node.syntaxKind]);
+        push(TOKEN_TEXT[node.syntaxKind]);
         break;
 
       case TsNodeKind.LabeledStatement:
-        parts.push(
-          printLine(`${printInline(node.label)}: ${printEmbeddedStatement(node.statement)}`),
-        );
+        push(printLine(`${printInline(node.label)}: ${printEmbeddedStatement(node.statement)}`));
         break;
 
       case TsNodeKind.LiteralType:
-        parts.push(printInline(node.literal));
+        push(printInline(node.literal));
         break;
 
       case TsNodeKind.MappedType: {
@@ -962,19 +1094,19 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.type) member += `: ${printInline(node.type)}`;
         const memberLine = printLine(terminate(member));
         indentLevel -= 1;
-        parts.push(['{', memberLine, printLine('}')].join('\n'));
+        push(fastJoin(['{', memberLine, printLine('}')], '\n'));
         break;
       }
 
       case TsNodeKind.MetaProperty: {
         const keyword = node.keywordToken === SyntaxKind.ImportKeyword ? 'import' : 'new';
-        parts.push(`${keyword}.${printInline(node.name)}`);
+        push(`${keyword}.${printInline(node.name)}`);
         break;
       }
 
       case TsNodeKind.MethodDeclaration: {
         const modifiers = printModifiers(node.modifiers);
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         let signature = modifiers;
         if (node.asteriskToken) signature += printInline(node.asteriskToken);
         signature += printName(node.name);
@@ -982,35 +1114,31 @@ export function createPrinter(options?: TsPrinterOptions) {
         signature += printTypeParameters(node.typeParameters);
         signature += `(${parameters})`;
         if (node.type) signature += `: ${printInline(node.type)}`;
-        parts.push(
+        push(
           printLine(node.body ? `${signature} ${printInline(node.body)}` : terminate(signature)),
         );
         break;
       }
 
       case TsNodeKind.ModuleBlock:
-        parts.push(printBraceBlock(node.statements));
+        push(printBraceBlock(node.statements));
         break;
 
       case TsNodeKind.ModuleDeclaration: {
         const keyword = node.name.kind === TsNodeKind.StringLiteral ? 'module' : 'namespace';
         let header = `${printModifiers(node.modifiers)}${keyword} ${printInline(node.name)}`;
         if (node.body) header += ` ${printInline(node.body)}`;
-        parts.push(printLine(header));
+        push(printLine(header));
         break;
       }
 
-      case TsNodeKind.NamedExports: {
-        const elements = node.elements.map((element) => printInline(element));
-        parts.push(elements.length === 0 ? '{}' : `{ ${elements.join(', ')} }`);
+      case TsNodeKind.NamedExports:
+        push(node.elements.length === 0 ? '{}' : `{ ${joinInline(node.elements, ', ')} }`);
         break;
-      }
 
-      case TsNodeKind.NamedImports: {
-        const elements = node.elements.map((element) => printInline(element));
-        parts.push(elements.length === 0 ? '{}' : `{ ${elements.join(', ')} }`);
+      case TsNodeKind.NamedImports:
+        push(node.elements.length === 0 ? '{}' : `{ ${joinInline(node.elements, ', ')} }`);
         break;
-      }
 
       case TsNodeKind.NamedTupleMember: {
         let text = '';
@@ -1018,123 +1146,120 @@ export function createPrinter(options?: TsPrinterOptions) {
         text += printName(node.name);
         if (node.questionToken) text += printInline(node.questionToken);
         text += `: ${printInline(node.type)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.NamespaceExport:
-        parts.push(`* as ${printInline(node.name)}`);
+        push(`* as ${printInline(node.name)}`);
         break;
 
       case TsNodeKind.NamespaceImport:
-        parts.push(`* as ${printInline(node.name)}`);
+        push(`* as ${printInline(node.name)}`);
         break;
 
       case TsNodeKind.NewExpression: {
         let text = `new ${printAccessTarget(node.expression)}`;
         if (node.typeArguments && node.typeArguments.length > 0)
-          text += `<${node.typeArguments.map((typeArgument) => printInline(typeArgument)).join(', ')}>`;
-        text += `(${(node.arguments ?? []).map((argument) => printInline(argument)).join(', ')})`;
-        parts.push(text);
+          text += `<${joinInline(node.typeArguments, ', ')}>`;
+        text += `(${joinInline(node.arguments ?? [], ', ')})`;
+        push(text);
         break;
       }
 
       case TsNodeKind.NoSubstitutionTemplateLiteral: {
-        parts.push(`\`${formatTemplateText(node.text)}\``);
+        push(`\`${formatTemplateText(node.text)}\``);
         break;
       }
 
       case TsNodeKind.NonNullExpression:
-        parts.push(`${printAccessTarget(node.expression)}!`);
+        push(`${printAccessTarget(node.expression)}!`);
         break;
 
       case TsNodeKind.NumericLiteral:
-        parts.push(node.text);
+        push(node.text);
         break;
 
       case TsNodeKind.ObjectBindingPattern: {
-        const elements = node.elements.map((element) => printInline(element)).join(', ');
-        parts.push(`{ ${elements} }`);
+        const elements = joinInline(node.elements, ', ');
+        push(`{ ${elements} }`);
         break;
       }
 
       case TsNodeKind.ObjectLiteralExpression: {
         if (node.properties.length === 0) {
-          parts.push('{}');
+          push('{}');
           break;
         }
         if (node.multiLine) {
           const lines: Array<string> = ['{'];
           indentLevel += 1;
-          node.properties.forEach((property, index) => {
-            const text = printLine(printInline(property));
-            lines.push(index < node.properties.length - 1 ? `${text},` : text);
-          });
+          for (let i = 0, len = node.properties.length; i < len; i++) {
+            const text = printLine(printInline(node.properties[i] as TsNode));
+            lines.push(i < len - 1 ? `${text},` : text);
+          }
           indentLevel -= 1;
           lines.push(printLine('}'));
-          parts.push(lines.join('\n'));
+          push(fastJoin(lines, '\n'));
           break;
         }
         indentLevel += 1;
-        const properties = node.properties.map((property) => printInline(property)).join(', ');
+        const properties = joinInline(node.properties, ', ');
         indentLevel -= 1;
-        parts.push(`{ ${properties} }`);
+        push(`{ ${properties} }`);
         break;
       }
 
       case TsNodeKind.OmittedExpression:
-        parts.push('');
+        push('');
         break;
 
       case TsNodeKind.OptionalType:
-        parts.push(`${printInline(node.type)}?`);
+        push(`${printInline(node.type)}?`);
         break;
 
       case TsNodeKind.Parameter: {
-        let text = '';
-        if (node.modifiers?.length) {
-          text += node.modifiers.map((modifier) => `${printInline(modifier)} `).join('');
-        }
+        let text = printModifiers(node.modifiers);
         if (node.dotDotDotToken) text += printInline(node.dotDotDotToken);
         text += typeof node.name === 'string' ? node.name : printInline(node.name);
         if (node.questionToken) text += printInline(node.questionToken);
         if (node.type) text += `: ${printInline(node.type)}`;
         if (node.initializer) text += ` = ${printInline(node.initializer)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.ParenthesizedExpression:
-        parts.push(`(${printInline(node.expression)})`);
+        push(`(${printInline(node.expression)})`);
         break;
 
       case TsNodeKind.ParenthesizedType:
-        parts.push(`(${printInline(node.type)})`);
+        push(`(${printInline(node.type)})`);
         break;
 
       case TsNodeKind.PostfixUnaryExpression: {
-        parts.push(`${printInline(node.operand)}${TOKEN_TEXT[node.operator]}`);
+        push(`${printInline(node.operand)}${TOKEN_TEXT[node.operator]}`);
         break;
       }
 
       case TsNodeKind.PrefixUnaryExpression: {
-        parts.push(`${TOKEN_TEXT[node.operator]}${printInline(node.operand)}`);
+        push(`${TOKEN_TEXT[node.operator]}${printInline(node.operand)}`);
         break;
       }
 
       case TsNodeKind.PrivateIdentifier: {
-        parts.push(node.text);
+        push(node.text);
         break;
       }
 
       case TsNodeKind.PropertyAccessExpression:
-        parts.push(
+        push(
           `${printAccessTarget(node.expression)}${node.questionDotToken ? '?.' : '.'}${printInline(node.name)}`,
         );
         break;
 
       case TsNodeKind.PropertyAssignment:
-        parts.push(`${printInline(node.name)}: ${printInline(node.initializer)}`);
+        push(`${printInline(node.name)}: ${printInline(node.initializer)}`);
         break;
 
       case TsNodeKind.PropertyDeclaration: {
@@ -1144,37 +1269,37 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.exclamationToken) text += printInline(node.exclamationToken);
         if (node.type) text += `: ${printInline(node.type)}`;
         if (node.initializer) text += ` = ${printInline(node.initializer)}`;
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
       case TsNodeKind.PropertySignature: {
         let text = '';
         if (node.modifiers?.length) {
-          text += `${node.modifiers.map((modifier) => printInline(modifier)).join(' ')} `;
+          text += `${joinInline(node.modifiers, ' ')} `;
         }
         text += printName(node.name);
         if (node.questionToken) text += printInline(node.questionToken);
         if (node.type) text += `: ${printInline(node.type)}`;
-        parts.push(printLine(terminate(text)));
+        push(printLine(terminate(text)));
         break;
       }
 
       case TsNodeKind.QualifiedName:
-        parts.push(`${printInline(node.left)}.${printInline(node.right)}`);
+        push(`${printInline(node.left)}.${printInline(node.right)}`);
         break;
 
       case TsNodeKind.RegularExpressionLiteral: {
-        parts.push(node.text);
+        push(node.text);
         break;
       }
 
       case TsNodeKind.RestType:
-        parts.push(`...${printInline(node.type)}`);
+        push(`...${printInline(node.type)}`);
         break;
 
       case TsNodeKind.ReturnStatement:
-        parts.push(
+        push(
           printLine(
             node.expression
               ? terminate(`return ${printInline(node.expression)}`)
@@ -1184,15 +1309,15 @@ export function createPrinter(options?: TsPrinterOptions) {
         break;
 
       case TsNodeKind.SatisfiesExpression: {
-        parts.push(`${printInline(node.expression)} satisfies ${printInline(node.type)}`);
+        push(`${printInline(node.expression)} satisfies ${printInline(node.type)}`);
         break;
       }
 
       case TsNodeKind.SetAccessor: {
         const modifiers = printModifiers(node.modifiers);
-        const parameters = node.parameters.map((parameter) => printInline(parameter)).join(', ');
+        const parameters = joinInline(node.parameters, ', ');
         const signature = `${modifiers}set ${printName(node.name)}(${parameters})`;
-        parts.push(
+        push(
           printLine(node.body ? `${signature} ${printInline(node.body)}` : terminate(signature)),
         );
         break;
@@ -1203,169 +1328,162 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.objectAssignmentInitializer) {
           text += ` = ${printInline(node.objectAssignmentInitializer)}`;
         }
-        parts.push(text);
+        push(text);
         break;
       }
 
-      case TsNodeKind.SourceFile:
-        node.statements.forEach((statement, index) => {
-          if (index > 0) parts.push('');
-          parts.push(printNode(statement));
-        });
+      case TsNodeKind.SourceFile: {
+        for (let i = 0, len = node.statements.length; i < len; i++) {
+          if (i > 0) push('');
+          push(printNode(node.statements[i] as TsNode));
+        }
         break;
+      }
 
       case TsNodeKind.SpreadAssignment:
-        parts.push(`...${printInline(node.expression)}`);
+        push(`...${printInline(node.expression)}`);
         break;
 
       case TsNodeKind.SpreadElement: {
-        parts.push(`...${printInline(node.expression)}`);
+        push(`...${printInline(node.expression)}`);
         break;
       }
 
       case TsNodeKind.StringLiteral:
-        parts.push(formatStringLiteral(node.text));
+        push(formatStringLiteral(node.text));
         break;
 
       case TsNodeKind.SwitchStatement: {
-        parts.push(
-          printLine(`switch (${printInline(node.expression)}) ${printInline(node.caseBlock)}`),
-        );
+        push(printLine(`switch (${printInline(node.expression)}) ${printInline(node.caseBlock)}`));
         break;
       }
 
       case TsNodeKind.TaggedTemplateExpression: {
         let text = printInline(node.tag);
         if (node.typeArguments && node.typeArguments.length > 0)
-          text += `<${node.typeArguments.map((typeArgument) => printInline(typeArgument)).join(', ')}>`;
+          text += `<${joinInline(node.typeArguments, ', ')}>`;
         text += printInline(node.template);
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.TemplateExpression: {
-        const spans = node.templateSpans.map((span) => printInline(span)).join('');
-        parts.push(`${printInline(node.head)}${spans}`);
+        const spans = joinInline(node.templateSpans, '');
+        push(`${printInline(node.head)}${spans}`);
         break;
       }
 
       case TsNodeKind.TemplateHead:
-        parts.push(`\`${formatTemplateText(node.text)}${'${'}`);
+        push(`\`${formatTemplateText(node.text)}${'${'}`);
         break;
 
       case TsNodeKind.TemplateLiteralType: {
         let text = `\`${node.head.text}`;
-        for (const span of node.templateSpans) text += printInline(span);
-        parts.push(`${text}\``);
+        for (let i = 0, len = node.templateSpans.length; i < len; i++)
+          text += printInline(node.templateSpans[i] as TsNode);
+        push(`${text}\``);
         break;
       }
 
       case TsNodeKind.TemplateLiteralTypeSpan:
-        parts.push(`\${${printInline(node.type)}}${node.literal.text}`);
+        push(`\${${printInline(node.type)}}${node.literal.text}`);
         break;
 
       case TsNodeKind.TemplateMiddle:
-        parts.push(`}${formatTemplateText(node.text)}${'${'}`);
+        push(`}${formatTemplateText(node.text)}${'${'}`);
         break;
 
       case TsNodeKind.TemplateSpan:
-        parts.push(`${printInline(node.expression)}${printInline(node.literal)}`);
+        push(`${printInline(node.expression)}${printInline(node.literal)}`);
         break;
 
       case TsNodeKind.TemplateTail:
-        parts.push(`}${formatTemplateText(node.text)}\``);
+        push(`}${formatTemplateText(node.text)}\``);
         break;
 
       case TsNodeKind.ThisType:
-        parts.push('this');
+        push('this');
         break;
 
       case TsNodeKind.ThrowStatement:
-        parts.push(printLine(terminate(`throw ${printInline(node.expression)}`)));
+        push(printLine(terminate(`throw ${printInline(node.expression)}`)));
         break;
 
       case TsNodeKind.Token:
-        parts.push(TOKEN_TEXT[node.syntaxKind]);
+        push(TOKEN_TEXT[node.syntaxKind]);
         break;
 
       case TsNodeKind.TryStatement: {
         let text = `try ${printInline(node.tryBlock)}`;
         if (node.catchClause) text += ` ${printInline(node.catchClause)}`;
         if (node.finallyBlock) text += ` finally ${printInline(node.finallyBlock)}`;
-        parts.push(printLine(text));
+        push(printLine(text));
         break;
       }
 
       case TsNodeKind.TupleType: {
         if (node.elements.length === 0) {
-          parts.push('[]');
+          push('[]');
           break;
         }
         const lines: Array<string> = ['['];
         indentLevel += 1;
-        node.elements.forEach((element, index) => {
-          const text = printLine(printInline(element));
-          lines.push(index < node.elements.length - 1 ? `${text},` : text);
-        });
+        for (let i = 0, len = node.elements.length; i < len; i++) {
+          const text = printLine(printInline(node.elements[i] as TsNode));
+          lines.push(i < len - 1 ? `${text},` : text);
+        }
         indentLevel -= 1;
         lines.push(printLine(']'));
-        parts.push(lines.join('\n'));
+        push(fastJoin(lines, '\n'));
         break;
       }
 
       case TsNodeKind.TypeAliasDeclaration: {
         let header = '';
         if (node.modifiers?.length) {
-          header += `${node.modifiers.map((modifier) => printInline(modifier)).join(' ')} `;
+          header += `${joinInline(node.modifiers, ' ')} `;
         }
         header += `type ${printName(node.name)}`;
         if (node.typeParameters?.length) {
-          header += `<${node.typeParameters
-            .map((typeParameter) => {
-              let text = printName(typeParameter.name);
-              if (typeParameter.constraint)
-                text += ` extends ${printInline(typeParameter.constraint)}`;
-              if (typeParameter.default) text += ` = ${printInline(typeParameter.default)}`;
-              return text;
-            })
-            .join(', ')}>`;
+          header += `<${joinBy(node.typeParameters, ', ', printTypeParameterWithConstraint)}>`;
         }
-        parts.push(printLine(terminate(`${header} = ${printInline(node.type)}`)));
+        push(printLine(terminate(`${header} = ${printInline(node.type)}`)));
         break;
       }
 
       case TsNodeKind.TypeLiteral: {
         if (node.members.length === 0) {
-          parts.push('{}');
+          push('{}');
           break;
         }
         const lines: Array<string> = ['{'];
         indentLevel += 1;
-        for (const member of node.members) {
-          lines.push(printNode(member));
+        for (let i = 0, len = node.members.length; i < len; i++) {
+          lines.push(printNode(node.members[i] as TsNode));
         }
         indentLevel -= 1;
         lines.push(printLine('}'));
-        parts.push(lines.join('\n'));
+        push(fastJoin(lines, '\n'));
         break;
       }
 
       case TsNodeKind.TypeOfExpression: {
-        parts.push(`typeof ${printInline(node.expression)}`);
+        push(`typeof ${printInline(node.expression)}`);
         break;
       }
 
       case TsNodeKind.TypeOperator:
-        parts.push(`${TOKEN_TEXT[node.operator]} ${printInline(node.type)}`);
+        push(`${TOKEN_TEXT[node.operator]} ${printInline(node.type)}`);
         break;
 
       case TsNodeKind.TypeParameter: {
-        const modifiers =
-          node.modifiers?.map((modifier) => `${TOKEN_TEXT[modifier.syntaxKind]} `).join('') ?? '';
+        const modifiers = node.modifiers
+          ? joinBy(node.modifiers, '', printTokenWithTrailingSpace)
+          : '';
         let text = `${modifiers}${printName(node.name)}`;
         if (node.constraint) text += ` extends ${printInline(node.constraint)}`;
         if (node.default) text += ` = ${printInline(node.default)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
@@ -1374,16 +1492,16 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.assertsModifier) text += 'asserts ';
         text += printName(node.parameterName);
         if (node.type) text += ` is ${printInline(node.type)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       case TsNodeKind.TypeQuery: {
         let text = `typeof ${typeof node.exprName === 'string' ? node.exprName : printInline(node.exprName)}`;
         if (node.typeArguments && node.typeArguments.length > 0) {
-          text += `<${node.typeArguments.map((argument) => printInline(argument)).join(', ')}>`;
+          text += `<${joinInline(node.typeArguments, ', ')}>`;
         }
-        parts.push(text);
+        push(text);
         break;
       }
 
@@ -1391,14 +1509,14 @@ export function createPrinter(options?: TsPrinterOptions) {
         const name = typeof node.typeName === 'string' ? node.typeName : printInline(node.typeName);
         const typeArguments =
           node.typeArguments && node.typeArguments.length > 0
-            ? `<${node.typeArguments.map((argument) => printInline(argument)).join(', ')}>`
+            ? `<${joinInline(node.typeArguments, ', ')}>`
             : '';
-        parts.push(`${name}${typeArguments}`);
+        push(`${name}${typeArguments}`);
         break;
       }
 
       case TsNodeKind.UnionType:
-        parts.push(node.types.map((type) => printUnionMember(type)).join(' | '));
+        push(joinBy(node.types, ' | ', printUnionMember));
         break;
 
       case TsNodeKind.VariableDeclaration: {
@@ -1406,7 +1524,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         if (node.exclamationToken) text += printInline(node.exclamationToken);
         if (node.type) text += `: ${printInline(node.type)}`;
         if (node.initializer) text += ` = ${printInline(node.initializer)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
@@ -1417,15 +1535,13 @@ export function createPrinter(options?: TsPrinterOptions) {
             : node.flags === TsNodeFlags.Let
               ? 'let'
               : 'var';
-        const declarations = node.declarations
-          .map((declaration) => printInline(declaration))
-          .join(', ');
-        parts.push(`${keyword} ${declarations}`);
+        const declarations = joinInline(node.declarations, ', ');
+        push(`${keyword} ${declarations}`);
         break;
       }
 
       case TsNodeKind.VariableStatement:
-        parts.push(
+        push(
           printLine(
             terminate(`${printModifiers(node.modifiers)}${printInline(node.declarationList)}`),
           ),
@@ -1433,12 +1549,12 @@ export function createPrinter(options?: TsPrinterOptions) {
         break;
 
       case TsNodeKind.VoidExpression: {
-        parts.push(`void ${printInline(node.expression)}`);
+        push(`void ${printInline(node.expression)}`);
         break;
       }
 
       case TsNodeKind.WhileStatement:
-        parts.push(
+        push(
           printLine(
             `while (${printInline(node.expression)}) ${printEmbeddedStatement(node.statement)}`,
           ),
@@ -1446,7 +1562,7 @@ export function createPrinter(options?: TsPrinterOptions) {
         break;
 
       case TsNodeKind.WithStatement:
-        parts.push(
+        push(
           printLine(
             `with (${printInline(node.expression)}) ${printEmbeddedStatement(node.statement)}`,
           ),
@@ -1457,23 +1573,28 @@ export function createPrinter(options?: TsPrinterOptions) {
         let text = 'yield';
         if (node.asteriskToken) text += printInline(node.asteriskToken);
         if (node.expression) text += ` ${printInline(node.expression)}`;
-        parts.push(text);
+        push(text);
         break;
       }
 
       default:
-        // @ts-expect-error
-        throw new Error(`Unsupported node kind: ${node.kind}`);
+        // The switch is exhaustive over `TsNodeKind`, so `node` narrows to
+        // `never` here; this only fires for a malformed node at runtime.
+        throw new Error(`Unsupported node kind: ${(node as TsNode).kind}`);
     }
 
     if (node.trailingComments) {
-      if (!context.inline) {
-        parts.push('');
+      if (!inline) {
+        push('');
       }
-      printComments(parts, node.trailingComments, false);
+      if (!accParts) accParts = accSingle === undefined ? [] : [accSingle];
+      printComments(accParts, node.trailingComments, false);
     }
 
-    return parts.join('\n');
+    const result = accParts ? fastJoin(accParts, '\n') : (accSingle ?? '');
+    accSingle = savedSingle;
+    accParts = savedParts;
+    return result;
   }
 
   function printFile(node: TsNode): string {

--- a/packages/openapi-ts/src/ts-compiler/printer.ts
+++ b/packages/openapi-ts/src/ts-compiler/printer.ts
@@ -93,8 +93,6 @@ const TOKEN_TEXT: Record<SyntaxKind, string> = {
   [SyntaxKind.SingleLineCommentTrivia]: '',
 };
 
-// Matches the first character (if any) that needs escaping for a
-// single-quoted JS string literal.
 const stringLiteralEscapeNeeded = /['\\\n\r\t]/;
 
 /**
@@ -144,8 +142,6 @@ function formatStringLiteral(text: string): string {
   return `'${result}'`;
 }
 
-// Matches the first character (if any) that needs escaping for a
-// template-literal body: backslash, backtick, or the start of `${`.
 const templateTextEscapeNeeded = /[\\`]|\$\{/;
 
 /** Core idea as `formatStringLiteral` above, applied to template-literal text. */

--- a/packages/openapi-ts/src/ts-compiler/printer.ts
+++ b/packages/openapi-ts/src/ts-compiler/printer.ts
@@ -93,18 +93,96 @@ const TOKEN_TEXT: Record<SyntaxKind, string> = {
   [SyntaxKind.SingleLineCommentTrivia]: '',
 };
 
+// Matches the first character (if any) that needs escaping for a
+// single-quoted JS string literal.
+const stringLiteralEscapeNeeded = /['\\\n\r\t]/;
+
+/**
+ * Core idea: instead of chaining five separate `.replace`/`.replaceAll`
+ * passes (each a full scan of the string, building an intermediate string
+ * every time), first find the index of the earliest character that needs
+ * escaping. If none is found, the string is returned untouched. Otherwise,
+ * only walk from that index once, switching on `charCodeAt` per character —
+ * unescaped runs are copied in bulk via `slice` (using a pending start
+ * index) rather than character by character, and only characters that
+ * actually need escaping pay any extra cost.
+ */
 function formatStringLiteral(text: string): string {
-  const escaped = text
-    .replace(/\\/g, '\\\\')
-    .replaceAll("'", "\\'")
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
-  return `'${escaped}'`;
+  const match = stringLiteralEscapeNeeded.exec(text);
+  if (match === null) return `'${text}'`;
+
+  let result = text.slice(0, match.index);
+  let runStart = match.index;
+
+  for (let i = match.index, len = text.length; i < len; i++) {
+    let escape: string;
+    switch (text.charCodeAt(i)) {
+      case 39: // '
+        escape = "\\'";
+        break;
+      case 92: // \
+        escape = '\\\\';
+        break;
+      case 10: // \n
+        escape = '\\n';
+        break;
+      case 13: // \r
+        escape = '\\r';
+        break;
+      case 9: // \t
+        escape = '\\t';
+        break;
+      default:
+        continue;
+    }
+    if (runStart !== i) result += text.slice(runStart, i);
+    result += escape;
+    runStart = i + 1;
+  }
+
+  if (runStart !== text.length) result += text.slice(runStart);
+  return `'${result}'`;
 }
 
+// Matches the first character (if any) that needs escaping for a
+// template-literal body: backslash, backtick, or the start of `${`.
+const templateTextEscapeNeeded = /[\\`]|\$\{/;
+
+/** Core idea as `formatStringLiteral` above, applied to template-literal text. */
 function formatTemplateText(text: string): string {
-  return text.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+  const match = templateTextEscapeNeeded.exec(text);
+  if (match === null) return text;
+
+  let result = text.slice(0, match.index);
+  let runStart = match.index;
+
+  for (let i = match.index, len = text.length; i < len; i++) {
+    let escape: string;
+    let skip = 0;
+    switch (text.charCodeAt(i)) {
+      case 92: // \
+        escape = '\\\\';
+        break;
+      case 96: // `
+        escape = '\\`';
+        break;
+      case 36: // $
+        // Only `${` needs escaping — a lone `$` is not special.
+        if (text.charCodeAt(i + 1) !== 123) continue;
+        escape = '\\${';
+        skip = 1;
+        break;
+      default:
+        continue;
+    }
+    if (runStart !== i) result += text.slice(runStart, i);
+    result += escape;
+    i += skip;
+    runStart = i + 1;
+  }
+
+  if (runStart !== text.length) result += text.slice(runStart);
+  return result;
 }
 
 // Faster than `Array.prototype.join` for plain string arrays.

--- a/packages/openapi-ts/src/ts-dsl/utils/render-utils.ts
+++ b/packages/openapi-ts/src/ts-dsl/utils/render-utils.ts
@@ -14,6 +14,12 @@ const blankFile = ts.createSourceFile('', '', ts.ScriptTarget.ESNext, false, ts.
 export function astToString(node: ts.Node): string {
   const result = printer.printNode(ts.EmitHint.Unspecified, node, blankFile);
 
+  // Skip the regex entirely with a cheap literal check when there's no escape
+  // sequence to fix up — most printed nodes contain no unicode escapes
+  if (!result.includes('\\u')) {
+    return result;
+  }
+
   try {
     /**
      * TypeScript Compiler API escapes unicode characters by default and there

--- a/packages/openapi-ts/tsconfig.json
+++ b/packages/openapi-ts/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "lib": ["ES2022", "DOM"],
     "rootDir": "src",
     "outDir": "dist",
     "types": ["vitest/globals", "node"]

--- a/packages/shared/src/graph/walk.ts
+++ b/packages/shared/src/graph/walk.ts
@@ -62,20 +62,12 @@ const walkDeclarations: WalkFn = (graph, callback, options) => {
   }
 };
 
-// `graph` is built once per codegen run (see `create-client.ts`) and never
-// mutated afterward. `walkTopological` can be invoked once per plugin's
-// `plugin.forEach()` call (every plugin defaults to `order: 'topological'` —
-// see `instance.ts`), and on a large spec this Kahn's-algorithm computation
-// is expensive (hundreds of ms on a graph with hundreds of thousands of
-// nodes). A config with a single topological-order plugin active only pays
-// this cost once regardless, but nothing prevents multiple plugins from all
-// walking the same graph topologically.
+// Graph is built once per codegen run and never mutated afterward.
+// `walkTopological` can be invoked once per plugin's `plugin.forEach()` call,
+// and on a large spec this Kahn's-algorithm computation is expensive.
 //
 // We memoize the computed topological order per (graph, getPointerPriority,
-// matchPointerToGroup, preferGroups) identity. All of `plugin.forEach`'s
-// callers share the same default option object identities (see
-// `instance.ts`), so this cache hits whenever more than one such call
-// happens against the same graph.
+// matchPointerToGroup, preferGroups) identity.
 type TopologicalCacheKey = string;
 const topologicalOrderCache = new WeakMap<Graph, Map<TopologicalCacheKey, Array<string>>>();
 // Stable per-reference ids for functions/arrays used as part of the cache
@@ -97,7 +89,7 @@ function computeTopologicalOrder<T extends string = string>(
   options: WalkOptions<T> | undefined,
 ): Array<string> {
   let cacheForGraph = topologicalOrderCache.get(graph);
-  const cacheKey: TopologicalCacheKey = `${referenceId(options?.getPointerPriority)}:${referenceId(options?.matchPointerToGroup)}:${referenceId(options?.preferGroups as unknown as object)}`;
+  const cacheKey: TopologicalCacheKey = `${referenceId(options?.getPointerPriority)}:${referenceId(options?.matchPointerToGroup)}:${referenceId(options?.preferGroups)}`;
   if (cacheForGraph) {
     const cached = cacheForGraph.get(cacheKey);
     if (cached) return cached;

--- a/packages/shared/src/graph/walk.ts
+++ b/packages/shared/src/graph/walk.ts
@@ -135,12 +135,13 @@ function computeTopologicalOrderUncached<T extends string = string>(
   const depsOf = new Map<string, Set<string>>();
   const inDegree = new Map<string, number>();
   const dependents = new Map<string, Set<string>>();
-  const heap = new MinHeap(declIndex);
+  const heap = new MinHeap();
 
   for (let index = 0, len = pointers.length; index < len; index++) {
     const pointer = pointers[index] as string;
     const priority = options?.getPointerPriority?.(pointer) ?? 10;
-    declIndex.set(pointer, priority * 1_000_000 + index);
+    const declPriority = priority * 1_000_000 + index;
+    declIndex.set(pointer, declPriority);
 
     const raw = graph.subtreeDependencies?.get(pointer);
     let deps: Set<string> | undefined;
@@ -165,7 +166,7 @@ function computeTopologicalOrderUncached<T extends string = string>(
       }
     } else {
       inDegree.set(pointer, 0);
-      heap.push(pointer);
+      heap.push(pointer, declPriority);
     }
   }
 
@@ -185,7 +186,7 @@ function computeTopologicalOrderUncached<T extends string = string>(
       const v = (inDegree.get(dep) ?? 0) - 1;
       inDegree.set(dep, v);
       if (v === 0) {
-        heap.push(dep);
+        heap.push(dep, declIndex.get(dep)!);
       }
     }
   }
@@ -230,13 +231,6 @@ function computeTopologicalOrderUncached<T extends string = string>(
       return options.preferGroups!.length;
     };
 
-    // proposed order: sort by (groupPriority, originalIndex)
-    // Precompute original indices to avoid O(N) indexOf inside the comparator.
-    const orderIndex = new Map<string, number>();
-    for (let i = 0; i < order.length; i++) {
-      orderIndex.set(order[i]!, i);
-    }
-
     // Memoize getGroup results since matchPointerToGroup can be expensive.
     const groupCache = new Map<string, number>();
     const getCachedGroup = (pointer: string): number => {
@@ -248,11 +242,11 @@ function computeTopologicalOrderUncached<T extends string = string>(
       return g;
     };
 
-    const proposed = [...order].sort((a, b) => {
-      const ga = getCachedGroup(a);
-      const gb = getCachedGroup(b);
-      return ga !== gb ? ga - gb : orderIndex.get(a)! - orderIndex.get(b)!;
-    });
+    // `order` is already topologically sorted; `Array.prototype.sort` is
+    // guaranteed stable (ES2019+), so sorting by group alone preserves
+    // relative order within a group without needing a separate original-index
+    // map as an explicit tiebreaker.
+    const proposed = [...order].sort((a, b) => getCachedGroup(a) - getCachedGroup(b));
 
     // build quick lookup of original index and proposed index
     const proposedIndex = new Map<string, number>();

--- a/packages/shared/src/graph/walk.ts
+++ b/packages/shared/src/graph/walk.ts
@@ -1,5 +1,6 @@
 import { MinHeap } from '../utils/minHeap';
-import type { GetPointerPriorityFn, WalkFn } from './types/walk';
+import type { Graph } from './types/graph';
+import type { GetPointerPriorityFn, WalkFn, WalkOptions } from './types/walk';
 
 /**
  * Walk the nodes of the graph in declaration (insertion) order.
@@ -61,15 +62,64 @@ const walkDeclarations: WalkFn = (graph, callback, options) => {
   }
 };
 
+// `graph` is built once per codegen run (see `create-client.ts`) and never
+// mutated afterward. `walkTopological` can be invoked once per plugin's
+// `plugin.forEach()` call (every plugin defaults to `order: 'topological'` —
+// see `instance.ts`), and on a large spec this Kahn's-algorithm computation
+// is expensive (hundreds of ms on a graph with hundreds of thousands of
+// nodes). A config with a single topological-order plugin active only pays
+// this cost once regardless, but nothing prevents multiple plugins from all
+// walking the same graph topologically.
+//
+// We memoize the computed topological order per (graph, getPointerPriority,
+// matchPointerToGroup, preferGroups) identity. All of `plugin.forEach`'s
+// callers share the same default option object identities (see
+// `instance.ts`), so this cache hits whenever more than one such call
+// happens against the same graph.
+type TopologicalCacheKey = string;
+const topologicalOrderCache = new WeakMap<Graph, Map<TopologicalCacheKey, Array<string>>>();
+// Stable per-reference ids for functions/arrays used as part of the cache
+// key, since neither Maps nor WeakMaps can be keyed on a tuple directly.
+const referenceIds = new WeakMap<object, number>();
+let nextReferenceId = 0;
+function referenceId(value: object | undefined): number {
+  if (value === undefined) return 0;
+  let id = referenceIds.get(value);
+  if (id === undefined) {
+    id = ++nextReferenceId;
+    referenceIds.set(value, id);
+  }
+  return id;
+}
+
+function computeTopologicalOrder<T extends string = string>(
+  graph: Graph,
+  options: WalkOptions<T> | undefined,
+): Array<string> {
+  let cacheForGraph = topologicalOrderCache.get(graph);
+  const cacheKey: TopologicalCacheKey = `${referenceId(options?.getPointerPriority)}:${referenceId(options?.matchPointerToGroup)}:${referenceId(options?.preferGroups as unknown as object)}`;
+  if (cacheForGraph) {
+    const cached = cacheForGraph.get(cacheKey);
+    if (cached) return cached;
+  } else {
+    cacheForGraph = new Map();
+    topologicalOrderCache.set(graph, cacheForGraph);
+  }
+
+  const order = computeTopologicalOrderUncached(graph, options);
+  cacheForGraph.set(cacheKey, order);
+  return order;
+}
+
 /**
- * Walks the nodes of the graph in topological order (dependencies before dependents).
- * Calls the callback for each node pointer in order.
- * Nodes in cycles are grouped together and emitted in arbitrary order within the group.
- *
- * @param graph - The dependency graph
- * @param callback - Function to call for each node pointer
+ * Computes the topological order (dependencies before dependents) of the
+ * graph's nodes. Nodes in cycles are grouped together and emitted in
+ * arbitrary order within the group.
  */
-const walkTopological: WalkFn = (graph, callback, options) => {
+function computeTopologicalOrderUncached<T extends string = string>(
+  graph: Graph,
+  options: WalkOptions<T> | undefined,
+): Array<string> {
   // stable Kahn's algorithm that respects declaration order as a tiebreaker.
   const pointers = Array.from(graph.nodes.keys());
 
@@ -78,6 +128,10 @@ const walkTopological: WalkFn = (graph, callback, options) => {
 
   // dependency sets, in-degree, reverse adjacency, and initial heap — all
   // built in a single pass over pointers to avoid repeated iteration.
+  // `depsOf` omits the entry entirely for dependency-free nodes (the common
+  // case — e.g. leaf schemas/properties) instead of storing an empty Set, to
+  // avoid allocating one per leaf on graphs with hundreds of thousands of
+  // nodes.
   const depsOf = new Map<string, Set<string>>();
   const inDegree = new Map<string, number>();
   const dependents = new Map<string, Set<string>>();
@@ -87,25 +141,31 @@ const walkTopological: WalkFn = (graph, callback, options) => {
     const priority = options?.getPointerPriority?.(pointer) ?? 10;
     declIndex.set(pointer, priority * 1_000_000 + index);
 
-    const raw = graph.subtreeDependencies?.get(pointer) ?? new Set();
-    const deps = new Set<string>();
-    for (const rawPointer of raw) {
-      if (rawPointer === pointer) continue; // ignore self-dependencies for ordering
-      if (graph.nodes.has(rawPointer)) deps.add(rawPointer);
-    }
-    depsOf.set(pointer, deps);
-    inDegree.set(pointer, deps.size);
-
-    for (const d of deps) {
-      let dep = dependents.get(d);
-      if (!dep) {
-        dep = new Set();
-        dependents.set(d, dep);
+    const raw = graph.subtreeDependencies?.get(pointer);
+    let deps: Set<string> | undefined;
+    if (raw && raw.size) {
+      for (const rawPointer of raw) {
+        if (rawPointer === pointer) continue; // ignore self-dependencies for ordering
+        if (!graph.nodes.has(rawPointer)) continue;
+        (deps ??= new Set()).add(rawPointer);
       }
-      dep.add(pointer);
     }
 
-    if (deps.size === 0) heap.push(pointer);
+    if (deps) {
+      depsOf.set(pointer, deps);
+      inDegree.set(pointer, deps.size);
+      for (const d of deps) {
+        let dep = dependents.get(d);
+        if (!dep) {
+          dep = new Set();
+          dependents.set(d, dep);
+        }
+        dep.add(pointer);
+      }
+    } else {
+      inDegree.set(pointer, 0);
+      heap.push(pointer);
+    }
   });
 
   const emitted = new Set<string>();
@@ -213,6 +273,19 @@ const walkTopological: WalkFn = (graph, callback, options) => {
     }
   }
 
+  return finalOrder;
+}
+
+/**
+ * Walks the nodes of the graph in topological order (dependencies before dependents).
+ * Calls the callback for each node pointer in order.
+ * Nodes in cycles are grouped together and emitted in arbitrary order within the group.
+ *
+ * @param graph - The dependency graph
+ * @param callback - Function to call for each node pointer
+ */
+const walkTopological: WalkFn = (graph, callback, options) => {
+  const finalOrder = computeTopologicalOrder(graph, options);
   for (const pointer of finalOrder) {
     callback(pointer, graph.nodes.get(pointer)!);
   }

--- a/packages/shared/src/graph/walk.ts
+++ b/packages/shared/src/graph/walk.ts
@@ -137,7 +137,8 @@ function computeTopologicalOrderUncached<T extends string = string>(
   const dependents = new Map<string, Set<string>>();
   const heap = new MinHeap(declIndex);
 
-  pointers.forEach((pointer, index) => {
+  for (let index = 0, len = pointers.length; index < len; index++) {
+    const pointer = pointers[index] as string;
     const priority = options?.getPointerPriority?.(pointer) ?? 10;
     declIndex.set(pointer, priority * 1_000_000 + index);
 
@@ -166,7 +167,7 @@ function computeTopologicalOrderUncached<T extends string = string>(
       inDegree.set(pointer, 0);
       heap.push(pointer);
     }
-  });
+  }
 
   const emitted = new Set<string>();
   const order: Array<string> = [];
@@ -189,12 +190,20 @@ function computeTopologicalOrderUncached<T extends string = string>(
     }
   }
 
-  // emit remaining nodes (cycles) in declaration order
-  const remaining = pointers.filter((pointer) => !emitted.has(pointer));
-  remaining.sort((a, b) => declIndex.get(a)! - declIndex.get(b)!);
-  for (const pointer of remaining) {
-    emitted.add(pointer);
-    order.push(pointer);
+  // emit remaining nodes (cycles) in declaration order. Cycles are rare, so
+  // skip building/sorting a `remaining` array entirely in the common case
+  // where everything was already emitted by the heap-driven pass above.
+  if (emitted.size < pointers.length) {
+    const remaining: Array<string> = [];
+    for (let i = 0, len = pointers.length; i < len; i++) {
+      const pointer = pointers[i] as string;
+      if (!emitted.has(pointer)) remaining.push(pointer);
+    }
+    remaining.sort((a, b) => declIndex.get(a)! - declIndex.get(b)!);
+    for (const pointer of remaining) {
+      emitted.add(pointer);
+      order.push(pointer);
+    }
   }
 
   // prefer specified groups when safe

--- a/packages/shared/src/ir/graph.ts
+++ b/packages/shared/src/ir/graph.ts
@@ -20,8 +20,8 @@ const irPatterns: Record<IrTopLevelKind, RegExp> = {
   webhook: /^#\/webhooks\/[^/]+\/(get|put|post|delete|options|head|patch|trace)$/,
 };
 
-// Every pattern above requires a fixed literal prefix. Checking the prefix
-// with `startsWith` first lets us skip the regex entirely for the vast
+// Every pattern in `irPatterns` requires a fixed literal prefix. Checking the
+// prefix with `startsWith` first lets us skip the regex entirely for the vast
 // majority of pointers (deeply nested leaf nodes — properties, items, etc.)
 // that can never match any top-level kind, since this runs once per graph
 // node on every walk/priority lookup.

--- a/packages/shared/src/ir/graph.ts
+++ b/packages/shared/src/ir/graph.ts
@@ -20,6 +20,20 @@ const irPatterns: Record<IrTopLevelKind, RegExp> = {
   webhook: /^#\/webhooks\/[^/]+\/(get|put|post|delete|options|head|patch|trace)$/,
 };
 
+// Every pattern above requires a fixed literal prefix. Checking the prefix
+// with `startsWith` first lets us skip the regex entirely for the vast
+// majority of pointers (deeply nested leaf nodes — properties, items, etc.)
+// that can never match any top-level kind, since this runs once per graph
+// node on every walk/priority lookup.
+const irPrefixes: ReadonlyArray<readonly [prefix: string, kind: IrTopLevelKind]> = [
+  ['#/paths/', 'operation'],
+  ['#/components/parameters/', 'parameter'],
+  ['#/components/requestBodies/', 'requestBody'],
+  ['#/components/schemas/', 'schema'],
+  ['#/servers/', 'server'],
+  ['#/webhooks/', 'webhook'],
+];
+
 /**
  * Checks if a pointer matches a known top-level IR component (schema, parameter, etc) and returns match info.
  *
@@ -31,8 +45,9 @@ export const matchIrPointerToGroup: MatchPointerToGroupFn<IrTopLevelKind> = (poi
   if (kind) {
     return irPatterns[kind].test(pointer) ? { kind, matched: true } : { matched: false };
   }
-  for (const key of irTopLevelKinds) {
-    if (irPatterns[key].test(pointer)) {
+  for (let i = 0, len = irPrefixes.length; i < len; i++) {
+    const [prefix, key] = irPrefixes[i]!;
+    if (pointer.startsWith(prefix) && irPatterns[key].test(pointer)) {
       return { kind: key, matched: true };
     }
   }

--- a/packages/shared/src/openApi/shared/transforms/readWrite.ts
+++ b/packages/shared/src/openApi/shared/transforms/readWrite.ts
@@ -660,14 +660,14 @@ export function updateRefsInSpec({
   const event = logger.timeEvent('update-refs-in-spec');
   const schemasPointerNamespace = specToSchemasPointerNamespace(spec);
 
-  const walk = ({
+  function walk({
     context,
     currentPointer,
     inSchema,
     node,
     path,
     visited = new Set(),
-  }: WalkArgs): void => {
+  }: WalkArgs): void {
     if (node instanceof Array) {
       node.forEach((item, index) =>
         walk({
@@ -864,7 +864,7 @@ export function updateRefsInSpec({
         }
       }
     }
-  };
+  }
   walk({
     context: null,
     currentPointer: null,

--- a/packages/shared/src/openApi/shared/utils/graph.ts
+++ b/packages/shared/src/openApi/shared/utils/graph.ts
@@ -43,11 +43,6 @@ type PointerDependenciesResult = {
 
 /**
  * Recursively collects all $ref dependencies in the subtree rooted at `pointer`.
- *
- * `cache`, `graph`, and `visited` are invariant across the whole recursion
- * (only `pointer` changes per call); passing them positionally instead of as
- * a destructured options object avoids allocating a wrapper object on every
- * one of the ~4 recursive calls made per graph node.
  */
 function collectPointerDependencies(
   cache: Cache,
@@ -248,17 +243,16 @@ export function buildGraph(
     transitiveDependencies: new Map(),
   };
 
-  const walk = ({
-    key,
-    node,
-    parentPointer,
-    pointer,
-  }: {
-    key: string | number | null;
-    node: unknown;
-    parentPointer: string | null;
-    pointer: string;
-  }) => {
+  // `key`/`node`/`parentPointer`/`pointer` are passed positionally rather
+  // than as a destructured options object, since this closure runs once per
+  // graph node (hundreds of thousands of times on a large spec) and a
+  // wrapper object would be allocated on every call for no benefit.
+  const walk = (
+    key: string | number | null,
+    node: unknown,
+    parentPointer: string | null,
+    pointer: string,
+  ) => {
     if (typeof node !== 'object' || node === null) {
       return;
     }
@@ -266,54 +260,52 @@ export function buildGraph(
     let deprecated: boolean | undefined;
     let tags: Set<string> | undefined;
 
-    if (typeof node === 'object' && node !== null) {
-      // Check for deprecated property
-      if ('deprecated' in node && typeof node.deprecated === 'boolean') {
-        deprecated = Boolean(node.deprecated);
+    // Check for deprecated property
+    if ('deprecated' in node && typeof node.deprecated === 'boolean') {
+      deprecated = Boolean(node.deprecated);
+    }
+    // If this node has a $ref, record the dependency
+    if ('$ref' in node && typeof node.$ref === 'string') {
+      const refPointer = normalizeJsonPointer(node.$ref);
+      let deps = graph.nodeDependencies.get(pointer);
+      if (!deps) {
+        deps = new Set();
+        graph.nodeDependencies.set(pointer, deps);
       }
-      // If this node has a $ref, record the dependency
-      if ('$ref' in node && typeof node.$ref === 'string') {
-        const refPointer = normalizeJsonPointer(node.$ref);
-        if (!graph.nodeDependencies.has(pointer)) {
-          graph.nodeDependencies.set(pointer, new Set());
+      deps.add(refPointer);
+    }
+    // Check for tags property (should be an array of strings)
+    if ('tags' in node && Array.isArray(node.tags)) {
+      for (let i = 0, len = node.tags.length; i < len; i++) {
+        const tag: unknown = node.tags[i];
+        if (typeof tag === 'string') {
+          (tags ??= new Set()).add(tag);
         }
-        graph.nodeDependencies.get(pointer)!.add(refPointer);
-      }
-      // Check for tags property (should be an array of strings)
-      if ('tags' in node && Array.isArray(node.tags)) {
-        tags = new Set(node.tags.filter((tag) => typeof tag === 'string'));
       }
     }
 
-    graph.nodes.set(pointer, { deprecated, key, node, parentPointer, tags });
+    // `scopes` is included explicitly (even though undefined here) so every
+    // `NodeInfo` object has the same hidden class from creation instead of
+    // one that changes shape later when scope-seeding assigns it.
+    graph.nodes.set(pointer, { deprecated, key, node, parentPointer, scopes: undefined, tags });
 
     if (Array.isArray(node)) {
       for (let index = 0, len = node.length; index < len; index++) {
-        walk({
-          key: index,
-          node: node[index],
-          parentPointer: pointer,
-          pointer: pointer + '/' + encodeJsonPointerSegment(index),
-        });
+        walk(index, node[index], pointer, pointer + '/' + encodeJsonPointerSegment(index));
       }
     } else {
-      for (const [childKey, value] of Object.entries(node)) {
-        walk({
-          key: childKey,
-          node: value,
-          parentPointer: pointer,
-          pointer: pointer + '/' + encodeJsonPointerSegment(childKey),
-        });
+      for (const childKey in node) {
+        walk(
+          childKey,
+          (node as Record<string, unknown>)[childKey],
+          pointer,
+          pointer + '/' + encodeJsonPointerSegment(childKey),
+        );
       }
     }
   };
 
-  walk({
-    key: null,
-    node: root,
-    parentPointer: null,
-    pointer: '#',
-  });
+  walk(null, root, null, '#');
 
   const cache: Cache = {
     parentToChildren: new Map(),

--- a/packages/shared/src/openApi/shared/utils/graph.ts
+++ b/packages/shared/src/openApi/shared/utils/graph.ts
@@ -247,12 +247,12 @@ export function buildGraph(
   // than as a destructured options object, since this closure runs once per
   // graph node (hundreds of thousands of times on a large spec) and a
   // wrapper object would be allocated on every call for no benefit.
-  const walk = (
+  function walk(
     key: string | number | null,
     node: unknown,
     parentPointer: string | null,
     pointer: string,
-  ) => {
+  ): void {
     if (typeof node !== 'object' || node === null) {
       return;
     }
@@ -260,7 +260,7 @@ export function buildGraph(
     let deprecated: boolean | undefined;
     let tags: Set<string> | undefined;
 
-    // Check for deprecated property
+    // Check for deprecated property (should be a boolean)
     if ('deprecated' in node && typeof node.deprecated === 'boolean') {
       deprecated = Boolean(node.deprecated);
     }
@@ -303,7 +303,7 @@ export function buildGraph(
         );
       }
     }
-  };
+  }
 
   walk(null, root, null, '#');
 

--- a/packages/shared/src/openApi/shared/utils/graph.ts
+++ b/packages/shared/src/openApi/shared/utils/graph.ts
@@ -288,14 +288,14 @@ export function buildGraph(
     graph.nodes.set(pointer, { deprecated, key, node, parentPointer, tags });
 
     if (Array.isArray(node)) {
-      node.forEach((item, index) =>
+      for (let index = 0, len = node.length; index < len; index++) {
         walk({
           key: index,
-          node: item,
+          node: node[index],
           parentPointer: pointer,
           pointer: pointer + '/' + encodeJsonPointerSegment(index),
-        }),
-      );
+        });
+      }
     } else {
       for (const [childKey, value] of Object.entries(node)) {
         walk({

--- a/packages/shared/src/openApi/shared/utils/graph.ts
+++ b/packages/shared/src/openApi/shared/utils/graph.ts
@@ -43,18 +43,18 @@ type PointerDependenciesResult = {
 
 /**
  * Recursively collects all $ref dependencies in the subtree rooted at `pointer`.
+ *
+ * `cache`, `graph`, and `visited` are invariant across the whole recursion
+ * (only `pointer` changes per call); passing them positionally instead of as
+ * a destructured options object avoids allocating a wrapper object on every
+ * one of the ~4 recursive calls made per graph node.
  */
-function collectPointerDependencies({
-  cache,
-  graph,
-  pointer,
-  visited,
-}: {
-  cache: Cache;
-  graph: Graph;
-  pointer: string;
-  visited: Set<string>;
-}): PointerDependenciesResult {
+function collectPointerDependencies(
+  cache: Cache,
+  graph: Graph,
+  pointer: string,
+  visited: Set<string>,
+): PointerDependenciesResult {
   if (cache.transitiveDependencies.has(pointer)) {
     return {
       subtreeDependencies: cache.subtreeDependencies.get(pointer) ?? null,
@@ -84,12 +84,7 @@ function collectPointerDependencies({
       (transitiveDependencies ??= new Set()).add(depPointer);
       (subtreeDependencies ??= new Set()).add(depPointer);
       // Recursively collect dependencies of the referenced node
-      const depResult = collectPointerDependencies({
-        cache,
-        graph,
-        pointer: depPointer,
-        visited,
-      });
+      const depResult = collectPointerDependencies(cache, graph, depPointer, visited);
       if (depResult.transitiveDependencies) {
         for (const dependency of depResult.transitiveDependencies) {
           transitiveDependencies.add(dependency);
@@ -101,12 +96,7 @@ function collectPointerDependencies({
   const children = cache.parentToChildren.get(pointer) ?? [];
   for (const childPointer of children) {
     if (!cache.transitiveDependencies.has(childPointer)) {
-      const childResult = collectPointerDependencies({
-        cache,
-        graph,
-        pointer: childPointer,
-        visited,
-      });
+      const childResult = collectPointerDependencies(cache, graph, childPointer, visited);
       cache.transitiveDependencies.set(childPointer, childResult.transitiveDependencies);
       cache.subtreeDependencies.set(childPointer, childResult.subtreeDependencies);
     }
@@ -130,45 +120,70 @@ function collectPointerDependencies({
 }
 
 /**
- * Propagates scopes through the graph using a multi-pass linear scan.
+ * Propagates scopes through the graph using a worklist algorithm.
  *
- * Nodes are visited in reverse DFS-pre-order (bottom-up): children tend to
- * appear before their parents so each node can push its scopes to its parent
- * within the same pass.  For typical OpenAPI specs (components declared after
- * paths) $ref targets also appear before $ref sources in this order, meaning
- * both tree propagation and $ref propagation usually converge in a single pass.
- *
- * The outer `while (changed)` loop guarantees correctness for any ordering:
- * it re-runs until no new scope values were added anywhere.  Because scopes
- * can only grow (at most 3 values: 'normal', 'read', 'write'), the loop
- * terminates in at most a handful of passes even for pathological specs.
+ * A node's scopes only ever flow to two places: its parent (tree edge) and
+ * any node that references it via `$ref` (dependency edge). So instead of
+ * repeatedly re-scanning every node until a full pass makes no changes (which
+ * on a large spec means re-visiting hundreds of thousands of already-settled
+ * nodes on every one of several passes), we seed a queue with the nodes that
+ * start out with scopes and only re-examine a node when one of its actual
+ * scope sources has just changed. Each node is processed once per net scope
+ * change it receives (at most 3 times, since scopes are one of 'normal' /
+ * 'read' / 'write' and can only grow), giving work proportional to the number
+ * of changes rather than (passes × total node count).
  *
  * @param graph - The Graph structure containing nodes and dependencies.
  */
 export function propagateScopes(graph: Graph): void {
-  // Reverse of insertion order (DFS pre-order) ≈ bottom-up: children before parents.
-  const nodesBottomUp = [...graph.nodes].reverse();
-
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const [pointer, nodeInfo] of nodesBottomUp) {
-      // Pull scopes from $ref dependencies into this node.
-      const nodeDeps = graph.nodeDependencies.get(pointer);
-      if (nodeDeps) {
-        for (const depPointer of nodeDeps) {
-          const depInfo = graph.nodes.get(depPointer);
-          if (depInfo?.scopes && propagateScopesToNode(depInfo, nodeInfo)) {
-            changed = true;
-          }
-        }
+  // Reverse index: pointer -> nodes whose `nodeDependencies` reference it, so
+  // that when `pointer`'s scopes change we know which dependents to recheck.
+  const refDependents = new Map<string, Array<string>>();
+  for (const [pointer, deps] of graph.nodeDependencies) {
+    for (const depPointer of deps) {
+      let dependents = refDependents.get(depPointer);
+      if (!dependents) {
+        dependents = [];
+        refDependents.set(depPointer, dependents);
       }
+      dependents.push(pointer);
+    }
+  }
 
-      // Push this node's scopes up to its parent.
-      if (nodeInfo.scopes && nodeInfo.parentPointer) {
-        const parentInfo = graph.nodes.get(nodeInfo.parentPointer);
-        if (parentInfo && propagateScopesToNode(nodeInfo, parentInfo)) {
-          changed = true;
+  const queued = new Set<string>();
+  const queue: Array<string> = [];
+  const enqueue = (pointer: string): void => {
+    if (queued.has(pointer)) return;
+    queued.add(pointer);
+    queue.push(pointer);
+  };
+
+  for (const [pointer, nodeInfo] of graph.nodes) {
+    if (nodeInfo.scopes) enqueue(pointer);
+  }
+
+  let head = 0;
+  while (head < queue.length) {
+    const pointer = queue[head++] as string;
+    queued.delete(pointer);
+    const nodeInfo = graph.nodes.get(pointer);
+    if (!nodeInfo?.scopes) continue;
+
+    // Push this node's scopes up to its parent.
+    if (nodeInfo.parentPointer) {
+      const parentInfo = graph.nodes.get(nodeInfo.parentPointer);
+      if (parentInfo && propagateScopesToNode(nodeInfo, parentInfo)) {
+        enqueue(nodeInfo.parentPointer);
+      }
+    }
+
+    // Push this node's scopes to anything that $ref's it.
+    const dependents = refDependents.get(pointer);
+    if (dependents) {
+      for (const dependentPointer of dependents) {
+        const dependentInfo = graph.nodes.get(dependentPointer);
+        if (dependentInfo && propagateScopesToNode(nodeInfo, dependentInfo)) {
+          enqueue(dependentPointer);
         }
       }
     }
@@ -348,17 +363,24 @@ export function buildGraph(
   annotateChildScopes(graph.nodes);
 
   for (const pointer of graph.nodes.keys()) {
-    const result = collectPointerDependencies({
-      cache,
-      graph,
-      pointer,
-      visited: new Set(),
-    });
-    if (result.transitiveDependencies) {
-      graph.transitiveDependencies.set(pointer, result.transitiveDependencies);
+    // Earlier iterations often already resolved this pointer while walking a
+    // prior sibling's subtree (`children` recursion below), so skip the call
+    // (and the `visited` Set it would allocate) when the answer is cached.
+    let transitiveDependencies: Set<string> | null;
+    let subtreeDependencies: Set<string> | null;
+    if (cache.transitiveDependencies.has(pointer)) {
+      transitiveDependencies = cache.transitiveDependencies.get(pointer) ?? null;
+      subtreeDependencies = cache.subtreeDependencies.get(pointer) ?? null;
+    } else {
+      const result = collectPointerDependencies(cache, graph, pointer, new Set());
+      transitiveDependencies = result.transitiveDependencies;
+      subtreeDependencies = result.subtreeDependencies;
     }
-    if (result.subtreeDependencies) {
-      graph.subtreeDependencies.set(pointer, result.subtreeDependencies);
+    if (transitiveDependencies) {
+      graph.transitiveDependencies.set(pointer, transitiveDependencies);
+    }
+    if (subtreeDependencies) {
+      graph.subtreeDependencies.set(pointer, subtreeDependencies);
     }
   }
 

--- a/packages/shared/src/utils/__tests__/minHeap.test.ts
+++ b/packages/shared/src/utils/__tests__/minHeap.test.ts
@@ -1,16 +1,11 @@
 import { MinHeap } from '../minHeap';
 
 describe('MinHeap', () => {
-  it('pops items in increasing declIndex order', () => {
-    const idx = new Map<string, number>([
-      ['a', 10],
-      ['b', 5],
-      ['c', 20],
-    ]);
-    const h = new MinHeap(idx);
-    h.push('a');
-    h.push('b');
-    h.push('c');
+  it('pops items in increasing priority order', () => {
+    const h = new MinHeap();
+    h.push('a', 10);
+    h.push('b', 5);
+    h.push('c', 20);
 
     expect(h.pop()).toBe('b');
     expect(h.pop()).toBe('a');
@@ -19,26 +14,20 @@ describe('MinHeap', () => {
   });
 
   it('supports interleaved push/pop and maintains order', () => {
-    const idx = new Map<string, number>([
-      ['x', 0],
-      ['y', 1],
-      ['z', 2],
-    ]);
-    const h = new MinHeap(idx);
-    h.push('y');
+    const h = new MinHeap();
+    h.push('y', 1);
     expect(h.pop()).toBe('y');
 
-    h.push('z');
-    h.push('x');
+    h.push('z', 2);
+    h.push('x', 0);
     expect(h.pop()).toBe('x');
     expect(h.pop()).toBe('z');
   });
 
   it('handles duplicates (same id pushed multiple times)', () => {
-    const idx = new Map<string, number>([['dup', 1]]);
-    const h = new MinHeap(idx);
-    h.push('dup');
-    h.push('dup');
+    const h = new MinHeap();
+    h.push('dup', 1);
+    h.push('dup', 1);
     expect(h.pop()).toBe('dup');
     // second duplicate still present
     expect(h.pop()).toBe('dup');
@@ -46,10 +35,9 @@ describe('MinHeap', () => {
   });
 
   it('isEmpty returns true when empty and false when not', () => {
-    const idx = new Map<string, number>([['a', 0]]);
-    const h = new MinHeap(idx);
+    const h = new MinHeap();
     expect(h.isEmpty()).toBe(true);
-    h.push('a');
+    h.push('a', 0);
     expect(h.isEmpty()).toBe(false);
     h.pop();
     expect(h.isEmpty()).toBe(true);

--- a/packages/shared/src/utils/escape.ts
+++ b/packages/shared/src/utils/escape.ts
@@ -1,8 +1,65 @@
 import { EOL } from 'node:os';
 
-export function escapeComment(value: string) {
-  return value
-    .replace(/\*\//g, '*')
-    .replace(/\/\*/g, '*')
-    .replace(/\r?\n(.*)/g, (_l, w) => EOL + w.trim());
+// Matches the first point (if any) that needs rewriting: a comment-terminator
+// pair (`*/` or `/*`) or a line break.
+const commentEscapeNeeded = /\*\/|\/\*|\r?\n/;
+
+/**
+ * Core idea: instead of three separate full-string `.replace` passes (one
+ * per comment-terminator pair, plus one regex+callback pass for line
+ * normalization/trimming), find the index of the first character that
+ * starts any of those patterns. If none is found, the string is returned
+ * untouched. Otherwise walk from that index once: unescaped runs are copied
+ * in bulk via `slice` (tracked with `runStart`), each terminator pair
+ * collapses to a single asterisk (both characters consumed together), and
+ * each line break consumes the rest of that line in one step — normalizing
+ * it to `EOL` and trimming the following line's content — so no line is
+ * scanned twice.
+ */
+export function escapeComment(value: string): string {
+  const match = commentEscapeNeeded.exec(value);
+  if (match === null) return value;
+
+  let result = value.slice(0, match.index);
+  let runStart = match.index;
+  const len = value.length;
+
+  for (let i = match.index; i < len; i++) {
+    const code = value.charCodeAt(i);
+    let replacement: string;
+    let consumed: number;
+
+    // 42 = '*', 47 = '/', 13 = '\r', 10 = '\n'
+    if (code === 42 && value.charCodeAt(i + 1) === 47) {
+      // `*/`
+      replacement = '*';
+      consumed = 2;
+    } else if (code === 47 && value.charCodeAt(i + 1) === 42) {
+      // `/*`
+      replacement = '*';
+      consumed = 2;
+    } else if (code === 13 && value.charCodeAt(i + 1) === 10) {
+      // `\r\n` followed by the rest of that line
+      const lineEnd = value.indexOf('\n', i + 2);
+      const line = lineEnd === -1 ? value.slice(i + 2) : value.slice(i + 2, lineEnd);
+      replacement = EOL + line.trim();
+      consumed = (lineEnd === -1 ? len : lineEnd) - i;
+    } else if (code === 10) {
+      // `\n` followed by the rest of that line
+      const lineEnd = value.indexOf('\n', i + 1);
+      const line = lineEnd === -1 ? value.slice(i + 1) : value.slice(i + 1, lineEnd);
+      replacement = EOL + line.trim();
+      consumed = (lineEnd === -1 ? len : lineEnd) - i;
+    } else {
+      continue;
+    }
+
+    if (runStart !== i) result += value.slice(runStart, i);
+    result += replacement;
+    i += consumed - 1;
+    runStart = i + 1;
+  }
+
+  if (runStart !== len) result += value.slice(runStart);
+  return result;
 }

--- a/packages/shared/src/utils/minHeap.ts
+++ b/packages/shared/src/utils/minHeap.ts
@@ -1,62 +1,84 @@
+/**
+ * Binary min-heap keyed by a numeric priority. Priorities are passed in
+ * alongside each item (rather than looked up from a `Map` on every
+ * comparison) so heap operations do plain number comparisons instead of
+ * string-keyed map lookups — significant on graphs with hundreds of
+ * thousands of nodes, since each push/pop does O(log n) comparisons.
+ */
 export class MinHeap {
   private heap: Array<string> = [];
-
-  constructor(public declIndex: Map<string, number>) {}
+  private priorities: Array<number> = [];
 
   isEmpty(): boolean {
     return !this.heap.length;
   }
 
   pop(): string | undefined {
-    const [top] = this.heap;
+    const top = this.heap[0];
     if (!this.heap.length) return;
     const last = this.heap.pop()!;
+    const lastPriority = this.priorities.pop()!;
     if (!this.heap.length) return top;
     this.heap[0] = last;
+    this.priorities[0] = lastPriority;
     this.sinkDown(0);
     return top;
   }
 
-  push(item: string): void {
+  push(item: string, priority: number): void {
     this.heap.push(item);
+    this.priorities.push(priority);
     this.bubbleUp(this.heap.length - 1);
   }
 
   private bubbleUp(index: number): void {
     const heap = this.heap;
+    const priorities = this.priorities;
+    const curVal = heap[index]!;
+    const curPriority = priorities[index]!;
     while (index > 0) {
-      const parent = Math.floor((index - 1) / 2);
-      const parentVal = heap[parent]!;
-      const curVal = heap[index]!;
-      if (this.declIndex.get(parentVal)! <= this.declIndex.get(curVal)!) break;
-      heap[parent] = curVal;
-      heap[index] = parentVal;
+      const parent = (index - 1) >> 1;
+      const parentPriority = priorities[parent]!;
+      if (parentPriority <= curPriority) break;
+      heap[index] = heap[parent]!;
+      priorities[index] = parentPriority;
       index = parent;
     }
+    heap[index] = curVal;
+    priorities[index] = curPriority;
   }
 
   private sinkDown(index: number): void {
     const heap = this.heap;
+    const priorities = this.priorities;
     const len = heap.length;
+    const curVal = heap[index]!;
+    const curPriority = priorities[index]!;
     while (true) {
       const left = 2 * index + 1;
       const right = 2 * index + 2;
       let smallest = index;
+      let smallestPriority = curPriority;
       if (left < len) {
-        const leftVal = heap[left]!;
-        const smallestVal = heap[smallest]!;
-        if (this.declIndex.get(leftVal)! < this.declIndex.get(smallestVal)!) smallest = left;
+        const leftPriority = priorities[left]!;
+        if (leftPriority < smallestPriority) {
+          smallest = left;
+          smallestPriority = leftPriority;
+        }
       }
       if (right < len) {
-        const rightVal = heap[right]!;
-        const smallestVal = heap[smallest]!;
-        if (this.declIndex.get(rightVal)! < this.declIndex.get(smallestVal)!) smallest = right;
+        const rightPriority = priorities[right]!;
+        if (rightPriority < smallestPriority) {
+          smallest = right;
+          smallestPriority = rightPriority;
+        }
       }
       if (smallest === index) break;
-      const tmp = heap[smallest]!;
-      heap[smallest] = heap[index]!;
-      heap[index] = tmp;
+      heap[index] = heap[smallest]!;
+      priorities[index] = priorities[smallest]!;
       index = smallest;
     }
+    heap[index] = curVal;
+    priorities[index] = curPriority;
   }
 }

--- a/packages/shared/src/utils/ref.ts
+++ b/packages/shared/src/utils/ref.ts
@@ -7,7 +7,6 @@ export function refToName($ref: string): string {
   return name;
 }
 
-// Matches the first character (if any) that needs RFC 6901 escaping.
 const jsonPointerSegmentEscapeNeeded = /[~/]/;
 
 /**
@@ -123,10 +122,10 @@ export function normalizeJsonPointer(pointer: string): string {
 export function pathToJsonPointer(path: ReadonlyArray<string | number>): string {
   const len = path.length;
   if (len === 0) return '#';
-  let segments = encodeJsonPointerSegment(path[0] as string | number);
+  let segments = encodeJsonPointerSegment(path[0]!);
   for (let i = 1; i < len; i++) {
     segments += '/';
-    segments += encodeJsonPointerSegment(path[i] as string | number);
+    segments += encodeJsonPointerSegment(path[i]!);
   }
   return `#/${segments}`;
 }

--- a/packages/shared/src/utils/ref.ts
+++ b/packages/shared/src/utils/ref.ts
@@ -7,6 +7,9 @@ export function refToName($ref: string): string {
   return name;
 }
 
+// Matches the first character (if any) that needs RFC 6901 escaping.
+const jsonPointerSegmentEscapeNeeded = /[~/]/;
+
 /**
  * Encodes a path segment for use in a JSON Pointer (RFC 6901).
  *
@@ -16,11 +19,45 @@ export function refToName($ref: string): string {
  * This ensures that path segments containing these characters are safely
  * represented in JSON Pointer strings.
  *
+ * Core idea: rather than always running two full-string `.replaceAll`
+ * passes, find the index of the first character that needs escaping. If
+ * there is none, the input is returned as-is with zero allocation. If there
+ * is one, only that point onward needs a char-by-char scan — the untouched
+ * prefix is reused verbatim via `slice`, and the loop copies unescaped runs
+ * in bulk (via a pending start index) instead of appending one character at
+ * a time.
+ *
  * @param segment - The path segment (string or number) to encode.
  * @returns The encoded segment as a string.
  */
 export function encodeJsonPointerSegment(segment: string | number): string {
-  return String(segment).replaceAll('~', '~0').replaceAll('/', '~1');
+  const str = typeof segment === 'string' ? segment : String(segment);
+
+  const match = jsonPointerSegmentEscapeNeeded.exec(str);
+  if (match === null) return str;
+
+  let result = str.slice(0, match.index);
+  let runStart = match.index;
+
+  for (let i = match.index, len = str.length; i < len; i++) {
+    let escape: string;
+    switch (str.charCodeAt(i)) {
+      case 126: // ~
+        escape = '~0';
+        break;
+      case 47: // /
+        escape = '~1';
+        break;
+      default:
+        continue;
+    }
+    if (runStart !== i) result += str.slice(runStart, i);
+    result += escape;
+    runStart = i + 1;
+  }
+
+  if (runStart !== str.length) result += str.slice(runStart);
+  return result;
 }
 
 /**

--- a/packages/shared/src/utils/ref.ts
+++ b/packages/shared/src/utils/ref.ts
@@ -84,8 +84,14 @@ export function normalizeJsonPointer(pointer: string): string {
  * @returns
  */
 export function pathToJsonPointer(path: ReadonlyArray<string | number>): string {
-  const segments = path.map(encodeJsonPointerSegment).join('/');
-  return '#' + (segments ? `/${segments}` : '');
+  const len = path.length;
+  if (len === 0) return '#';
+  let segments = encodeJsonPointerSegment(path[0] as string | number);
+  for (let i = 1; i < len; i++) {
+    segments += '/';
+    segments += encodeJsonPointerSegment(path[i] as string | number);
+  }
+  return `#/${segments}`;
 }
 
 /**


### PR DESCRIPTION
The PR follows my previous PR https://github.com/hey-api/hey-api/pull/3823 and https://github.com/hey-api/hey-api/pull/3917

- Reduce `ts-compiler` print GC pressure by reducing object allocation: reduce spread copy, remove context object. Also, some other micro-optimizations like the faster join method.
- Cache graph generation to reduce potential repeated calculations
- Avoid repeated stub key population in Symbol registry
- Improve pointer dependencies collection
- Hoist visitor/walker for validation plugin (zod/valibot) to re-use instances
- Re-use the processor instance for the TypeScript plugin
- Improve walking minHeap implementation
- Some early bailout for regex testing (as regex is expensive)
- Micro optimization for escaping: I learned this technique back when I created [fast-escape-html](https://github.com/SukkaW/fast-escape-html) and [fast-escape-regexp](https://github.com/SukkaW/fast-escape-regexp)
- Other micro-optimizations (replace `forEach` w/ plain loop, reduce closure, and more)

The PR also introduces extra phase timing tracking with debug log level, with detailed generation step time:

<img width="760" height="549" alt="image" src="https://github.com/user-attachments/assets/05ca5da7-fb91-4f9f-8d55-4d87f00af88f" />

The Cloudflare schema generation time reduces from 10-11 seconds to 9-10 (sometimes sub-9 seconds if the download is very fast) seconds.

Also, FlameGraph comparison:

before:

<img width="4658" height="790" alt="image" src="https://github.com/user-attachments/assets/aaf074ae-a1bc-40db-8916-0fddacda1999" />

after:

<img width="1673" height="880" alt="image" src="https://github.com/user-attachments/assets/8144ef9a-f3cf-43db-8275-816570f773eb" />

