### PR TITLE
fix: omit auth for anonymous security alternatives

### DIFF
--- a/.changeset/quiet-security-rules.md
+++ b/.changeset/quiet-security-rules.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/shared": patch
+---
+
+Fix OpenAPI security parsing when an operation allows anonymous access with an empty security requirement.

--- a/packages/shared/src/openApi/2.0.x/parser/__tests__/operation.test.ts
+++ b/packages/shared/src/openApi/2.0.x/parser/__tests__/operation.test.ts
@@ -106,6 +106,29 @@ describe('operation', () => {
     });
   });
 
+  it('omits security when an empty requirement allows anonymous access', () => {
+    const localContext = createContext();
+    const securitySchemesMap = new Map<string, OpenAPIV2.SecuritySchemeObject>([
+      ['apiKeyAuth', { in: 'header', name: 'Auth', type: 'apiKey' }],
+    ]);
+
+    parsePathOperation({
+      ambiguousSecurityKeys: new Set(),
+      context: localContext,
+      method: 'get',
+      operation: {
+        operationId: 'getPublicData',
+        responses: {},
+        security: [{ apiKeyAuth: [] }, {}],
+      },
+      path: '/public-data',
+      securitySchemesMap,
+      state: { ids: new Map<string, string>() },
+    });
+
+    expect(localContext.ir.paths?.['/public-data']?.get?.security).toBeUndefined();
+  });
+
   it('should parse body parameter when consumes is undefined', () => {
     const context = createContext();
     const method = 'post';

--- a/packages/shared/src/openApi/2.0.x/parser/operation.ts
+++ b/packages/shared/src/openApi/2.0.x/parser/operation.ts
@@ -276,7 +276,13 @@ function operationToIrOperation({
     const securitySchemeObjects: Map<string, IR.SecurityObject> = new Map();
 
     for (const securityRequirementObject of operation.security) {
-      for (const name in securityRequirementObject) {
+      const names = Object.keys(securityRequirementObject);
+      if (!names.length) {
+        securitySchemeObjects.clear();
+        break;
+      }
+
+      for (const name of names) {
         const securitySchemeObject = securitySchemesMap.get(name);
 
         if (!securitySchemeObject) {

--- a/packages/shared/src/openApi/3.0.x/parser/__tests__/operation.test.ts
+++ b/packages/shared/src/openApi/3.0.x/parser/__tests__/operation.test.ts
@@ -80,4 +80,30 @@ describe('operation', () => {
       summary: 'Test Operation',
     });
   });
+
+  it('omits security when an empty requirement allows anonymous access', () => {
+    const localContext = {
+      config: { plugins: {} },
+      ir: { paths: {}, servers: [] },
+    } as unknown as Context;
+    const securitySchemesMap = new Map<string, OpenAPIV3.SecuritySchemeObject>([
+      ['apiKeyAuth', { in: 'header', name: 'Auth', type: 'apiKey' }],
+    ]);
+
+    parsePathOperation({
+      ambiguousSecurityKeys: new Set(),
+      context: localContext,
+      method: 'get',
+      operation: {
+        operationId: 'getPublicData',
+        responses: {},
+        security: [{ apiKeyAuth: [] }, {}],
+      },
+      path: '/public-data',
+      securitySchemesMap,
+      state: { ids: new Map<string, string>() },
+    });
+
+    expect(localContext.ir.paths?.['/public-data']?.get?.security).toBeUndefined();
+  });
 });

--- a/packages/shared/src/openApi/3.0.x/parser/operation.ts
+++ b/packages/shared/src/openApi/3.0.x/parser/operation.ts
@@ -208,7 +208,13 @@ function operationToIrOperation({
     const securitySchemeObjects: Map<string, IR.SecurityObject> = new Map();
 
     for (const securityRequirementObject of operation.security) {
-      for (const name in securityRequirementObject) {
+      const names = Object.keys(securityRequirementObject);
+      if (!names.length) {
+        securitySchemeObjects.clear();
+        break;
+      }
+
+      for (const name of names) {
         const securitySchemeObject = securitySchemesMap.get(name);
 
         if (!securitySchemeObject) {

--- a/packages/shared/src/openApi/3.1.x/parser/__tests__/operation.test.ts
+++ b/packages/shared/src/openApi/3.1.x/parser/__tests__/operation.test.ts
@@ -143,4 +143,30 @@ describe('operation', () => {
       { scheme: 'basic', type: 'http' },
     ]);
   });
+
+  it('omits security when an empty requirement allows anonymous access', () => {
+    const localContext = {
+      config: { plugins: {} },
+      ir: { paths: {}, servers: [] },
+    } as unknown as Context;
+    const securitySchemesMap = new Map<string, OpenAPIV3_1.SecuritySchemeObject>([
+      ['apiKeyAuth', { in: 'header', name: 'Auth', type: 'apiKey' }],
+    ]);
+
+    parsePathOperation({
+      ambiguousSecurityKeys: new Set(),
+      context: localContext,
+      method: 'get',
+      operation: {
+        operationId: 'getPublicData',
+        responses: {},
+        security: [{ apiKeyAuth: [] }, {}],
+      },
+      path: '/public-data',
+      securitySchemesMap,
+      state: { ids: new Map<string, string>() },
+    });
+
+    expect(localContext.ir.paths?.['/public-data']?.get?.security).toBeUndefined();
+  });
 });

--- a/packages/shared/src/openApi/3.1.x/parser/operation.ts
+++ b/packages/shared/src/openApi/3.1.x/parser/operation.ts
@@ -192,7 +192,13 @@ function operationToIrOperation({
     const securitySchemeObjects: Map<string, IR.SecurityObject> = new Map();
 
     for (const securityRequirementObject of operation.security) {
-      for (const name in securityRequirementObject) {
+      const names = Object.keys(securityRequirementObject);
+      if (!names.length) {
+        securitySchemeObjects.clear();
+        break;
+      }
+
+      for (const name of names) {
         const securitySchemeObject = securitySchemesMap.get(name);
 
         if (!securitySchemeObject) {


### PR DESCRIPTION
## Summary
- Treat an empty OpenAPI security requirement object as an anonymous access alternative.
- Avoid generating operation auth metadata when API key or anonymous access is allowed.
- Cover the behavior for OpenAPI 2.0, 3.0, and 3.1 parsers.

## Validation
- pnpm exec vitest run packages/shared/src/openApi/2.0.x/parser/__tests__/operation.test.ts packages/shared/src/openApi/3.0.x/parser/__tests__/operation.test.ts packages/shared/src/openApi/3.1.x/parser/__tests__/operation.test.ts
- pnpm exec oxfmt --check packages/shared/src/openApi/2.0.x/parser/operation.ts packages/shared/src/openApi/3.0.x/parser/operation.ts packages/shared/src/openApi/3.1.x/parser/operation.ts packages/shared/src/openApi/2.0.x/parser/__tests__/operation.test.ts packages/shared/src/openApi/3.0.x/parser/__tests__/operation.test.ts packages/shared/src/openApi/3.1.x/parser/__tests__/operation.test.ts
- pnpm exec oxlint packages/shared/src/openApi/2.0.x/parser/operation.ts packages/shared/src/openApi/3.0.x/parser/operation.ts packages/shared/src/openApi/3.1.x/parser/operation.ts packages/shared/src/openApi/2.0.x/parser/__tests__/operation.test.ts packages/shared/src/openApi/3.0.x/parser/__tests__/operation.test.ts packages/shared/src/openApi/3.1.x/parser/__tests__/operation.test.ts
