### PR TITLE
docs: fix horizontal codegen page overflow

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -246,9 +246,9 @@ const isSponsorsPage = currentPath === '/sponsors';
     background: var(--dt-bg-2);
     border-top: 1px solid var(--vp-c-divider);
     box-sizing: border-box;
-    margin-inline: calc(50% - 50vw);
+    margin-inline: calc(50% - 50cqw);
     padding: 56px 0 0;
-    width: 100vw;
+    width: 100cqw;
   }
 
   .site-footer-inner {

--- a/web/src/components/pages/codegen/Features.astro
+++ b/web/src/components/pages/codegen/Features.astro
@@ -240,13 +240,13 @@ const DECK = {
     border-top: 1px solid var(--vp-c-divider);
     display: flex;
     height: 100vh;
-    margin-inline: calc(50% - 50vw);
+    margin-inline: calc(50% - 50cqw);
     overflow: hidden;
     padding-top: calc(var(--sl-nav-height, 0px) + 3rem);
     position: sticky;
     transition: background 200ms linear;
     top: 0;
-    width: 100vw;
+    width: 100cqw;
   }
 
   .features-sticky::after {

--- a/web/src/components/pages/codegen/Hero.astro
+++ b/web/src/components/pages/codegen/Hero.astro
@@ -237,10 +237,10 @@ const scrollTo = announcement?.link?.startsWith('#') ? announcement.link.slice(1
 
 <style>
   .landing-hero {
-    margin-inline: calc(50% - 50vw);
+    margin-inline: calc(50% - 50cqw);
     margin-top: 0;
     padding: calc(80px + var(--announcement-height-budget)) 0 64px;
-    width: 100vw;
+    width: 100cqw;
   }
 
   .hero-inner {

--- a/web/src/components/pages/codegen/HowItWorks.astro
+++ b/web/src/components/pages/codegen/HowItWorks.astro
@@ -449,9 +449,9 @@ const STEPS: Array<Step> = [
       display: flex;
       flex-direction: column;
       gap: 10px;
-      margin-inline: calc(50% - 50vw);
+      margin-inline: calc(50% - 50cqw);
       padding-bottom: 12px;
-      padding-inline: calc(50vw - 50% + var(--sl-content-pad-x, 1rem));
+      padding-inline: calc(50cqw - 50% + var(--sl-content-pad-x, 1rem));
       padding-top: 10px;
       position: sticky;
       top: var(--sl-nav-height, 0px);

--- a/web/src/styles/custom.css
+++ b/web/src/styles/custom.css
@@ -47,6 +47,10 @@
   );
 }
 
+html {
+  container-type: inline-size;
+}
+
 :root[data-theme='light'] {
   --dt-bg: #fff;
   --dt-bg-2: #f6f6f7;


### PR DESCRIPTION
## Summary

before

<img width="3024" height="428" alt="CleanShot 2026-07-06 at 10 25 22@2x" src="https://github.com/user-attachments/assets/9a5eaf30-a577-4b2b-9a44-59e90afa2ada" />

after

<img width="3024" height="392" alt="CleanShot 2026-07-06 at 10 26 39@2x" src="https://github.com/user-attachments/assets/25e5a56a-30a3-423d-aa1d-6093c58d8759" />


- Replace viewport-width full-bleed calculations with container query width units on the codegen splash page and footer.
- Declare the root element as an inline-size query container so full-bleed sections use the layout viewport width instead of the scrollbar-inclusive 100vw width.



## Root Cause
The previous 100vw-based full-bleed layout included the vertical scrollbar width, making sticky sections and the splash footer slightly wider than documentElement.clientWidth and triggering a page-level horizontal scrollbar.

## Validation
- Verified in the in-app browser at the default viewport that documentElement.scrollWidth equals documentElement.clientWidth with overflow-x still visible.
- Verified a narrow 781px viewport matching the reported screenshot: innerWidth 781, clientWidth 766, no page-level horizontal scroll.
- pnpm --filter web build