### PR TITLE
fix(#3805): `client-ky` options respect instance default

### DIFF
--- a/examples/openapi-ts-ky/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-ky/src/client/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/examples/openapi-ts-ky/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-ky/src/client/client/types.gen.ts
@@ -43,6 +43,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/examples/openapi-ts-ky/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-ky/src/client/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -48,6 +48,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -141,14 +144,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -46,6 +46,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -170,6 +170,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/__tests__/client.test.ts
@@ -617,6 +617,224 @@ describe('retry configuration', () => {
       }),
     );
   });
+
+  it('omits retry when unset so ky instance defaults survive', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    await client.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      url: '/test',
+    });
+
+    expect(mockKy.mock.calls[0]![1]).not.toHaveProperty('retry');
+  });
+
+  it('passes kyOptions.retry to ky when top-level retry is unset', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    await client.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      kyOptions: {
+        retry: { limit: 5, retryOnTimeout: true },
+      },
+      url: '/test',
+    });
+
+    expect(mockKy).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        retry: { limit: 5, retryOnTimeout: true },
+      }),
+    );
+  });
+
+  it('prefers top-level retry over kyOptions.retry', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    await client.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      kyOptions: {
+        retry: { limit: 5 },
+      },
+      retry: 3,
+      url: '/test',
+    });
+
+    expect(mockKy).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        retry: 3,
+      }),
+    );
+  });
+
+  it('prefers per-request kyOptions.retry over client-level retry', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    const clientWithRetry = createClient({
+      baseUrl: 'https://example.com',
+      retry: 2,
+    });
+
+    await clientWithRetry.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      kyOptions: {
+        retry: { limit: 5 },
+      },
+      url: '/test',
+    });
+
+    expect(mockKy).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        retry: { limit: 5 },
+      }),
+    );
+  });
+
+  it('falls back to client-level retry when request does not specify one', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    const clientWithRetry = createClient({
+      baseUrl: 'https://example.com',
+      kyOptions: {
+        retry: { limit: 4 },
+      },
+    });
+
+    await clientWithRetry.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      url: '/test',
+    });
+
+    expect(mockKy).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        retry: { limit: 4 },
+      }),
+    );
+  });
+});
+
+describe('redirect configuration', () => {
+  const client = createClient({ baseUrl: 'https://example.com' });
+
+  it('omits redirect when unset so ky instance defaults survive', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    await client.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      url: '/test',
+    });
+
+    expect(mockKy.mock.calls[0]![1]).not.toHaveProperty('redirect');
+  });
+
+  it('passes redirect to ky when set', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    await client.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      redirect: 'error',
+      url: '/test',
+    });
+
+    expect(mockKy).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        redirect: 'error',
+      }),
+    );
+  });
+});
+
+describe('setConfig kyOptions merging', () => {
+  it('merges kyOptions instead of replacing them', async () => {
+    const mockResponse = new Response(JSON.stringify({ success: true }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 200,
+    });
+
+    const mockKy = vi.fn().mockResolvedValue(mockResponse);
+
+    const client = createClient({
+      baseUrl: 'https://example.com',
+      kyOptions: { context: { foo: 'bar' } },
+    });
+
+    client.setConfig({
+      kyOptions: { fetch: globalThis.fetch },
+    });
+
+    expect(client.getConfig().kyOptions).toEqual({
+      context: { foo: 'bar' },
+      fetch: globalThis.fetch,
+    });
+
+    await client.get({
+      ky: mockKy as Partial<KyInstance> as KyInstance,
+      url: '/test',
+    });
+
+    expect(mockKy).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        context: { foo: 'bar' },
+        fetch: globalThis.fetch,
+      }),
+    );
+  });
 });
 
 describe('responseStyle configuration', () => {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/client.ts
@@ -46,6 +46,9 @@ export const createClient = (config: Config = {}): Client => {
         ..._config.kyOptions,
         ...options.kyOptions,
       },
+      // per-request options are more specific than client-level ones, and
+      // within each level top-level `retry` wins over `kyOptions.retry`
+      retry: options.retry ?? options.kyOptions?.retry ?? _config.retry ?? _config.kyOptions?.retry,
       serializedBody: undefined as string | undefined,
     };
 
@@ -139,14 +142,15 @@ export const createClient = (config: Config = {}): Client => {
         ...(opts.keepalive !== undefined ? { keepalive: opts.keepalive } : {}),
         ...(opts.method !== undefined ? { method: opts.method } : {}),
         ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
-        redirect: opts.redirect ?? 'follow',
+        ...(opts.redirect !== undefined ? { redirect: opts.redirect } : {}),
         ...(opts.referrer !== undefined ? { referrer: opts.referrer } : {}),
         ...(opts.referrerPolicy !== undefined ? { referrerPolicy: opts.referrerPolicy } : {}),
         ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
         throwHttpErrors: opts.throwOnError ?? false,
         ...(opts.timeout !== undefined ? { timeout: opts.timeout } : {}),
         ...opts.kyOptions,
-        retry: opts.retry ?? opts.kyOptions?.retry ?? 2,
+        // omit `retry` entirely when unset so ky instance defaults survive
+        ...(opts.retry !== undefined ? { retry: opts.retry } : {}),
       };
 
       request = new Request(url, {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/types.ts
@@ -44,6 +44,11 @@ export interface Config<T extends ClientOptions = ClientOptions>
   /**
    * Additional ky-specific options that will be passed directly to ky.
    * This allows you to use any ky option not explicitly exposed in the config.
+   *
+   * Note that `parseJson` and `stringifyJson` have no effect on the data
+   * returned or sent by this client: request bodies are serialized with
+   * `bodySerializer` before they reach ky, and response bodies are parsed
+   * by the client itself, bypassing ky's JSON handling.
    */
   kyOptions?: Omit<KyOptions, 'method' | 'prefixUrl'>;
   /**

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/utils.ts
@@ -168,6 +168,9 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
     config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1);
   }
   config.headers = mergeHeaders(a.headers, b.headers);
+  if (a.kyOptions && b.kyOptions) {
+    config.kyOptions = { ...a.kyOptions, ...b.kyOptions };
+  }
   return config;
 };
 


### PR DESCRIPTION
## Summary

The PR follows #3806, which is the second part of fixing #3805.

- `redirect` and `retry`, when unset, no longer fall back to the hardcoded default, but instead fall back to the ky instance default (and if you pass your own ky instance, that instance's options will now be respected).
  - There are no breaking changes here, as the current hardcoded default options are the same as ky's default, if we remove the `client-ky` hardcoded default options, ky's same default options will be used, so no changing behavior
- `config.kyOptions` is now also merged when calling `setConfig()`.
- document that `parseJson`/`stringifyJson` in `kyOptions` have no effect on bodies handled by the client

## Linked issues

Related to: #3805 #3806

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
