### PR TITLE
fix(sdk): require `parameters` in flat paramsStructure when `options` is required (TS1016)

### DIFF
--- a/.changeset/sdk-flat-client-false-required-parameters.md
+++ b/.changeset/sdk-flat-client-false-required-parameters.md
@@ -1,0 +1,7 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**fix(sdk)**: keep `parameters` required in `paramsStructure: 'flat'` when `options` is required (e.g. `client: false`)
+
+When the SDK `options` argument is required (for example with `client: false`), an operation whose parameters are all optional generated `(parameters?: ..., options: ...)` — a required parameter following an optional one, which TypeScript rejects with TS1016. `parameters` is now emitted as required whenever `options` is; callers can still pass `{}`.

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/__tests__/operation.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/__tests__/operation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { createClient } from '../../../../index';
+import type { UserConfig as SdkUserConfig } from '../types';
+
+// Generates an SDK for a single operation whose parameters are all optional (an optional request
+// body, no required parameters) and returns the generated `sdk.gen.ts` content.
+async function generateSdk(sdk: SdkUserConfig): Promise<string | undefined> {
+  const [context] = await createClient({
+    dryRun: true,
+    input: {
+      info: { title: 'flat-params', version: '1.0.0' },
+      openapi: '3.1.0',
+      paths: {
+        '/things': {
+          post: {
+            operationId: 'createThing',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    properties: { name: { type: 'string' } },
+                    type: 'object',
+                  },
+                },
+              },
+              required: false,
+            },
+            responses: { 200: { description: 'ok' } },
+          },
+        },
+      },
+    },
+    logs: { level: 'silent' },
+    output: 'out',
+    plugins: ['@hey-api/typescript', '@hey-api/client-fetch', sdk],
+  });
+
+  return Array.from(context!.gen.render()).find((file) => file.path.includes('sdk'))?.content;
+}
+
+describe('sdk flat params', () => {
+  // `client: false` makes `options` required. Since `parameters` is emitted before `options`, it
+  // must also be required — otherwise a required parameter follows an optional one and TypeScript
+  // rejects the signature (TS1016). Callers can still pass `{}`.
+  it('requires `parameters` when `options` is required (client: false)', async () => {
+    const sdk = await generateSdk({
+      client: false,
+      name: '@hey-api/sdk',
+      paramsStructure: 'flat',
+    });
+
+    expect(sdk).toContain('export const createThing');
+    expect(sdk).not.toContain('parameters?:');
+  });
+
+  // Default case: `options` is optional, so all-optional `parameters` must stay optional — the fix
+  // above must not over-require it.
+  it('keeps `parameters` optional when `options` is optional', async () => {
+    const sdk = await generateSdk({
+      name: '@hey-api/sdk',
+      paramsStructure: 'flat',
+    });
+
+    expect(sdk).toContain('export const createThing');
+    expect(sdk).toContain('parameters?:');
+  });
+});

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/shared/operation.ts
@@ -139,7 +139,9 @@ export function operationParameters({
       }
 
       result.parameters.push(
-        $.param('parameters', (p) => p.required(isParametersRequired).type(flatParams)),
+        $.param('parameters', (p) =>
+          p.required(isParametersRequired || isRequiredOptions).type(flatParams),
+        ),
       );
     }
   }


### PR DESCRIPTION
Closes #4249

### Problem

With `@hey-api/sdk` `client: false`, the `options` argument is required. In
`paramsStructure: 'flat'`, `parameters` was only made required when the operation
had a required parameter — so an operation whose parameters are all optional
generated a required `options` after an optional `parameters?`, which TypeScript
rejects with **TS1016** ("A required parameter cannot follow an optional parameter").

Only affects `paramsStructure: 'flat'` + a required `options` (e.g. `client: false`)
with operations that have only-optional parameters. The default nested structure and
the `instance` SDK style are unaffected (`!isInstance` guard in `isOperationOptionsRequired`).

### Root cause

`operationParameters` (flat branch) set `parameters` required from `isParametersRequired`
alone (does any parameter require a value), ignoring `isRequiredOptions` — even though
`options` is emitted right after and can be required.

### Fix

Emit `parameters` as required whenever `options` is required:
`p.required(isParametersRequired || isRequiredOptions)`. Callers can still pass `{}`.

### Tests

Added `sdk/shared/__tests__/operation.test.ts` (flat paramsStructure):
- `client: false` → `parameters` is required (fails before this change);
- default → `parameters` stays optional (guards against over-requiring).


## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.