### PR TITLE
fix(client-angular): forward HttpContext through generated request options

### DIFF
--- a/.changeset/silent-otters-glow.md
+++ b/.changeset/silent-otters-glow.md
@@ -2,4 +2,4 @@
 "@hey-api/openapi-ts": patch
 ---
 
-`@hey-api/client-angular` now accepts `context` (Angular's `HttpContext`) on generated requests. `requestOptions()` already forwarded it into the underlying `HttpRequest` constructor, but the `Config`/`RequestOptions` types were missing the field, so it could not be set from a generated SDK call.
+**plugin(@hey-api/client-angular)**: fix: accept `context` field

--- a/.changeset/silent-otters-glow.md
+++ b/.changeset/silent-otters-glow.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+`@hey-api/client-angular` now accepts `context` (Angular's `HttpContext`) on generated requests. `requestOptions()` already forwarded it into the underlying `HttpRequest` constructor, but the `Config`/`RequestOptions` types were missing the field, so it could not be set from a generated SDK call.

--- a/examples/openapi-ts-angular-common/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -22,6 +23,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/examples/openapi-ts-angular/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-angular/src/client/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -22,6 +23,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -22,6 +23,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/types.gen.ts
@@ -2,6 +2,7 @@
 
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -25,6 +26,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from '@angular/common/http';
-import { HttpHeaders } from '@angular/common/http';
+import { HttpContext, HttpHeaders } from '@angular/common/http';
 
 import { createClient } from '../bundle/client';
 
@@ -108,6 +108,22 @@ describe('unserialized request body handling', () => {
     );
 
     expect(spy).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('context', () => {
+  const client = createClient({ baseUrl: 'https://example.com' });
+
+  it('forwards a provided HttpContext to the resulting HttpRequest', () => {
+    const context = new HttpContext();
+
+    const request = client.requestOptions({
+      context,
+      httpClient: vi.fn() as Partial<HttpClient> as HttpClient,
+      url: '/test',
+    });
+
+    expect(request.context).toBe(context);
   });
 });
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/types.ts
@@ -1,5 +1,6 @@
 import type {
   HttpClient,
+  HttpContext,
   HttpErrorResponse,
   HttpHeaders,
   HttpRequest,
@@ -23,6 +24,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * Base URL for all requests made by this client.
    */
   baseUrl?: T['baseUrl'];
+  /**
+   * Shared and mutable context that can be read and written by
+   * `HttpInterceptorFn`s. Never sent to the server.
+   *
+   * {@link https://angular.dev/api/common/http/HttpContext See more}
+   */
+  context?: HttpContext;
   /**
    * An object containing any HTTP headers that you want to pre-populate your
    * `HttpHeaders` object with.


### PR DESCRIPTION
## Summary

`client-angular` builds every request as an Angular `HttpRequest`, and `HttpRequest`'s constructor already accepts `context: HttpContext`. `requestOptions()` in `bundle/client.ts` spreads the whole resolved options object straight into that constructor, so a `context` value on `opts` was already forwarded correctly at runtime. The gap was purely in the types: `Config`/`RequestOptions` in `bundle/types.ts` never declared `context`, so it couldn't be set from a generated SDK call.

This adds `context?: HttpContext` to `Config`, adds a test asserting it flows through `requestOptions()` into the resulting `HttpRequest`, and regenerates the affected example/snapshot clients.

## Linked issues

Closes: #4268

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.