### PR TITLE
fix: nest dotted pagination params in infinite query options

### DIFF
--- a/.changeset/warm-pandas-nest.md
+++ b/.changeset/warm-pandas-nest.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@tanstack/query-core)**: fix nested pagination parameter paths in infinite query options

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/pagination-ref/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/pagination-ref/@tanstack/react-query.gen.ts
@@ -93,7 +93,9 @@ export const getFooInfiniteOptions = (options: Options<GetFooData>) => {
       // @ts-ignore
       const page: Pick<QueryKey<Options<GetFooData>>[0], 'body' | 'headers' | 'path' | 'query'> = typeof pageParam === 'object' ? pageParam : {
         query: {
-          'foo.page': pageParam
+          foo: {
+            page: pageParam
+          }
         }
       };
       const params = createInfiniteParams(queryKey, page);

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/v5/infinite-query-options.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/v5/infinite-query-options.ts
@@ -193,6 +193,13 @@ export function createInfiniteQueryOptions({
     resource: 'createInfiniteParams',
   });
 
+  const paginationValue = pagination.name
+    .split('.')
+    .reduceRight<TsDsl<any>>(
+      (value, name) => $.object().pretty().prop(name, value),
+      $('pageParam'),
+    );
+
   const statements: Array<TsDsl<any>> = [
     $.const('page')
       .type(typePageObjectParam)
@@ -200,11 +207,7 @@ export function createInfiniteQueryOptions({
       .assign(
         $.ternary($('pageParam').typeofExpr().eq($.literal('object')))
           .do('pageParam')
-          .otherwise(
-            $.object()
-              .pretty()
-              .prop(pagination.in, $.object().pretty().prop(pagination.name, $('pageParam'))),
-          ),
+          .otherwise($.object().pretty().prop(pagination.in, paginationValue)),
       ),
     $.const('params').assign($(symbolCreateInfiniteParams).call('queryKey', 'page')),
   ];


### PR DESCRIPTION
## Summary

- generate nested page parameter objects when pagination metadata contains dotted paths
- update the existing OpenAPI 3.1 `pagination-ref` snapshot to cover the corrected output
- add a patch changeset for `@hey-api/openapi-ts`

## Why

Infinite query generation currently treats a pagination name such as `foo.page` as one literal property. The generated object is therefore incompatible with the generated request type, which expects `{ foo: { page } }`, and downstream TypeScript compilation fails.

This change constructs the page parameter value from right to left, preserving the existing output for non-dotted pagination names while nesting dotted paths correctly.

## Linked issues

Closes:
Related to:

## Validation

- `turbo run build --filter '@hey-api/openapi-ts...'`
- `pnpm --filter @hey-api/openapi-ts typecheck`
- `vitest run packages/openapi-ts-tests/tanstack-query/v5/test/3.1.x.test.ts` (4 tests passed, no type errors)
- repository pre-commit formatting and lint hooks

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
