### PR TITLE
refactor: replace ansi-colors and color-support with native styleText

### DIFF
--- a/.changeset/huge-baboons-vanish.md
+++ b/.changeset/huge-baboons-vanish.md
@@ -1,0 +1,7 @@
+---
+"@hey-api/codegen-core": patch
+"@hey-api/openapi-python": patch
+"@hey-api/openapi-ts": patch
+---
+
+**dependencies**: remove ansi-colors and color-support

--- a/.changeset/long-turtles-bow.md
+++ b/.changeset/long-turtles-bow.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/shared": patch
+---
+
+**dependencies**: remove ansi-colors

--- a/.changeset/native-styletext-colors.md
+++ b/.changeset/native-styletext-colors.md
@@ -1,0 +1,8 @@
+---
+"@hey-api/openapi-python": patch
+"@hey-api/codegen-core": patch
+"@hey-api/openapi-ts": patch
+"@hey-api/shared": patch
+---
+
+Use Node's built-in `node:util` `styleText` for terminal coloring instead of the `ansi-colors` and `color-support` packages.

--- a/.changeset/native-styletext-colors.md
+++ b/.changeset/native-styletext-colors.md
@@ -1,8 +1,0 @@
----
-"@hey-api/openapi-python": patch
-"@hey-api/codegen-core": patch
-"@hey-api/openapi-ts": patch
-"@hey-api/shared": patch
----
-
-Use Node's built-in `node:util` `styleText` for terminal coloring instead of the `ansi-colors` and `color-support` packages.

--- a/packages/codegen-core/package.json
+++ b/packages/codegen-core/package.json
@@ -48,9 +48,7 @@
   },
   "dependencies": {
     "@hey-api/types": "workspace:*",
-    "ansi-colors": "4.1.3",
-    "c12": "3.3.4",
-    "color-support": "1.1.3"
+    "c12": "3.3.4"
   },
   "devDependencies": {
     "typescript": "6.0.3"

--- a/packages/codegen-core/src/log.ts
+++ b/packages/codegen-core/src/log.ts
@@ -1,25 +1,24 @@
-import type { MaybeArray, MaybeFunc } from '@hey-api/types';
-import colors from 'ansi-colors';
-// @ts-expect-error
-import colorSupport from 'color-support';
+import { styleText } from 'node:util';
 
-colors.enabled = colorSupport().hasBasic;
+import type { MaybeArray, MaybeFunc } from '@hey-api/types';
+
+type Format = Parameters<typeof styleText>[0];
 
 const DEBUG_NAMESPACE = 'heyapi';
 
 const NO_WARNINGS = /^(1|true|yes|on)$/i.test(process.env.HEYAPI_DISABLE_WARNINGS ?? '');
 
 const DebugGroups = {
-  analyzer: colors.greenBright,
-  dsl: colors.cyanBright,
-  file: colors.yellowBright,
-  registry: colors.blueBright,
-  symbol: colors.magentaBright,
-} as const;
+  analyzer: 'greenBright',
+  dsl: 'cyanBright',
+  file: 'yellowBright',
+  registry: 'blueBright',
+  symbol: 'magentaBright',
+} as const satisfies Record<string, Format>;
 
 const WarnGroups = {
-  deprecated: colors.magentaBright,
-} as const;
+  deprecated: 'magentaBright',
+} as const satisfies Record<string, Format>;
 
 let cachedDebugGroups: Set<string> | undefined;
 function getDebugGroups(): Set<string> {
@@ -49,8 +48,8 @@ function debug(message: string, group: keyof typeof DebugGroups) {
     return;
   }
 
-  const color = DebugGroups[group] ?? colors.whiteBright;
-  const prefix = color(`${DEBUG_NAMESPACE}:${group}`);
+  const format = DebugGroups[group] ?? 'whiteBright';
+  const prefix = styleText(format, `${DEBUG_NAMESPACE}:${group}`);
 
   console.debug(`${prefix} ${message}`);
 }
@@ -58,9 +57,9 @@ function debug(message: string, group: keyof typeof DebugGroups) {
 function warn(message: string, group?: keyof typeof WarnGroups) {
   if (NO_WARNINGS) return;
 
-  const color = group ? WarnGroups[group] : colors.yellowBright;
+  const format = group ? WarnGroups[group] : 'yellowBright';
 
-  console.warn(color(`${message}`));
+  console.warn(styleText(format, `${message}`));
 }
 
 function warnDeprecated({

--- a/packages/codegen-core/src/logger.ts
+++ b/packages/codegen-core/src/logger.ts
@@ -1,5 +1,6 @@
-import colors from 'ansi-colors';
+import { styleText } from 'node:util';
 
+type Format = Parameters<typeof styleText>[0];
 type PerformanceMarkResult = ReturnType<typeof performance.mark>;
 type PerformanceMeasureResult = ReturnType<typeof performance.measure>;
 
@@ -12,7 +13,7 @@ interface LoggerEvent {
 }
 
 interface Severity {
-  color: colors.StyleFunction;
+  color: Format;
   type: 'duration' | 'percentage';
 }
 
@@ -29,25 +30,25 @@ const idStart = (id: string) => `${id}-start`;
 const getSeverity = (duration: number, percentage: number): Severity | undefined => {
   if (duration > 200) {
     return {
-      color: colors.red,
+      color: 'red',
       type: 'duration',
     };
   }
   if (percentage > 30) {
     return {
-      color: colors.red,
+      color: 'red',
       type: 'percentage',
     };
   }
   if (duration > 50) {
     return {
-      color: colors.yellow,
+      color: 'yellow',
       type: 'duration',
     };
   }
   if (percentage > 10) {
     return {
-      color: colors.yellow,
+      color: 'yellow',
       type: 'percentage',
     };
   }
@@ -129,7 +130,7 @@ export class Logger {
     indent: number;
     measure: PerformanceMeasureResult;
   }): void {
-    const color = !indent ? colors.cyan : colors.gray;
+    const format: Format = !indent ? 'cyan' : 'gray';
     const lastIndex = parent.events.length - 1;
 
     parent.events.forEach((event, index) => {
@@ -142,7 +143,7 @@ export class Logger {
 
         let durationLabel = `${duration.toFixed(2).padStart(8)}ms`;
         if (severity?.type === 'duration') {
-          durationLabel = severity.color(durationLabel);
+          durationLabel = styleText(severity.color, durationLabel);
         }
 
         const branch = index === lastIndex ? '└─ ' : '├─ ';
@@ -153,11 +154,12 @@ export class Logger {
         const percentagePrefix = indent ? ' '.repeat(indent - 1) + percentageBranch : '';
         let percentageLabel = `${percentagePrefix}${percentage.toFixed(2)}%`;
         if (severity?.type === 'percentage') {
-          percentageLabel = severity.color(percentageLabel);
+          percentageLabel = styleText(severity.color, percentageLabel);
         }
-        const jobPrefix = colors.gray('[root] ');
+        const jobPrefix = styleText('gray', '[root] ');
         console.log(
-          `${jobPrefix}${colors.gray(prefix)}${color(
+          `${jobPrefix}${styleText('gray', prefix)}${styleText(
+            format,
             `${event.name.padEnd(maxLength)} ${durationLabel} (${percentageLabel})`,
           )}`,
         );

--- a/packages/openapi-python/package.json
+++ b/packages/openapi-python/package.json
@@ -76,9 +76,7 @@
     "@hey-api/shared": "workspace:*",
     "@hey-api/spec-types": "workspace:*",
     "@hey-api/types": "workspace:*",
-    "@lukeed/ms": "2.0.2",
-    "ansi-colors": "4.1.3",
-    "color-support": "1.1.3"
+    "@lukeed/ms": "2.0.2"
   },
   "devDependencies": {
     "typescript": "6.0.3"

--- a/packages/openapi-python/src/config/expand.ts
+++ b/packages/openapi-python/src/config/expand.ts
@@ -1,5 +1,6 @@
+import { styleText } from 'node:util';
+
 import { getInput } from '@hey-api/shared';
-import colors from 'ansi-colors';
 
 import type { UserConfig } from './types';
 
@@ -28,7 +29,7 @@ export function expandToJobs(configs: ReadonlyArray<UserConfig>): ReadonlyArray<
     } else if (outputs.length > 1 && inputs.length !== outputs.length) {
       // Warn and create job per output (all with same inputs)
       console.warn(
-        `⚙️ ${colors.yellow('Warning:')} You provided ${colors.cyan(String(inputs.length))} ${colors.cyan(inputs.length === 1 ? 'input' : 'inputs')} and ${colors.yellow(String(outputs.length))} ${colors.yellow('outputs')}. This will produce identical output in multiple locations. You likely want to provide a single output or the same number of outputs as inputs.`,
+        `⚙️ ${styleText('yellow', 'Warning:')} You provided ${styleText('cyan', String(inputs.length))} ${styleText('cyan', inputs.length === 1 ? 'input' : 'inputs')} and ${styleText('yellow', String(outputs.length))} ${styleText('yellow', 'outputs')}. This will produce identical output in multiple locations. You likely want to provide a single output or the same number of outputs as inputs.`,
       );
       for (const output of outputs) {
         jobs.push({

--- a/packages/openapi-python/src/config/resolve.ts
+++ b/packages/openapi-python/src/config/resolve.ts
@@ -1,6 +1,7 @@
+import { styleText } from 'node:util';
+
 import { detectInteractiveSession } from '@hey-api/codegen-core';
 import { ConfigError, getInput, getLogs, getParser, resolvePlugins } from '@hey-api/shared';
-import colors from 'ansi-colors';
 
 import { defaultPluginConfigs, defaultPlugins } from '../plugins/config';
 import { getOutput } from './output/config';
@@ -55,8 +56,8 @@ export function resolveConfig(
   };
 
   if (logs.level === 'debug') {
-    const jobPrefix = colors.gray(`[Job ${validated.job.index}] `);
-    console.warn(`${jobPrefix}${colors.cyan('config:')}`, config);
+    const jobPrefix = styleText('gray', `[Job ${validated.job.index}] `);
+    console.warn(`${jobPrefix}${styleText('cyan', 'config:')}`, config);
   }
 
   return {

--- a/packages/openapi-python/src/create-client.ts
+++ b/packages/openapi-python/src/create-client.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { type Logger, Project, Version } from '@hey-api/codegen-core';
 import { $RefParser, ResolverError } from '@hey-api/json-schema-ref-parser';
@@ -17,7 +18,6 @@ import {
   SymbolFactory,
 } from '@hey-api/shared';
 import { format as ms } from '@lukeed/ms';
-import colors from 'ansi-colors';
 
 import { postProcessors } from './config/output/postprocess';
 import type { Config } from './config/types';
@@ -192,7 +192,7 @@ export async function createClient({
 
     const eventPostprocess = logger.timeEvent('postprocess');
     if (!config.dryRun) {
-      const jobPrefix = colors.gray(`[Job ${jobIndex + 1}] `);
+      const jobPrefix = styleText('gray', `[Job ${jobIndex + 1}] `);
       postprocessOutput(config.output, postProcessors, jobPrefix);
 
       if (config.logs.level !== 'silent') {
@@ -200,7 +200,7 @@ export async function createClient({
           ? `./${path.relative(process.env.INIT_CWD, config.output.path)}`
           : config.output.path;
         console.log(
-          `${jobPrefix}${colors.green('✓')} ${colors.cyanBright(outputPath)} ${colors.gray(`· ${fileCount} ${fileCount === 1 ? 'file' : 'files'} · ${ms(totalMs)}`)}`,
+          `${jobPrefix}${styleText('green', '✓')} ${styleText('cyanBright', outputPath)} ${styleText('gray', `· ${fileCount} ${fileCount === 1 ? 'file' : 'files'} · ${ms(totalMs)}`)}`,
         );
       }
     }

--- a/packages/openapi-python/src/index.ts
+++ b/packages/openapi-python/src/index.ts
@@ -54,9 +54,6 @@ declare module '@hey-api/shared' {
 
 import type { Version } from '@hey-api/codegen-core';
 import type { AnyString, LazyOrAsync, MaybeArray } from '@hey-api/types';
-import colors from 'ansi-colors';
-// @ts-expect-error
-import colorSupport from 'color-support';
 
 import type { PythonVersion } from './config/output/types';
 import type { UserConfig } from './config/types';
@@ -68,8 +65,6 @@ import type { HeyApiSdkPlugin } from './plugins/@hey-api/sdk';
 import type { PydanticPlugin, PydanticResolvers } from './plugins/pydantic';
 import type { EnumSymbols } from './symbols/enum';
 import type { TypingSymbols } from './symbols/typing';
-
-colors.enabled = colorSupport().hasBasic;
 
 export { createClient } from './generate';
 

--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -95,8 +95,6 @@
     "@hey-api/spec-types": "workspace:*",
     "@hey-api/types": "workspace:*",
     "@lukeed/ms": "2.0.2",
-    "ansi-colors": "4.1.3",
-    "color-support": "1.1.3",
     "get-tsconfig": "4.14.0"
   },
   "devDependencies": {

--- a/packages/openapi-ts/src/config/expand.ts
+++ b/packages/openapi-ts/src/config/expand.ts
@@ -1,5 +1,6 @@
+import { styleText } from 'node:util';
+
 import { getInput } from '@hey-api/shared';
-import colors from 'ansi-colors';
 
 import type { UserConfig } from './types';
 
@@ -28,7 +29,7 @@ export function expandToJobs(configs: ReadonlyArray<UserConfig>): ReadonlyArray<
     } else if (outputs.length > 1 && inputs.length !== outputs.length) {
       // Warn and create job per output (all with same inputs)
       console.warn(
-        `⚙️ ${colors.yellow('Warning:')} You provided ${colors.cyan(String(inputs.length))} ${colors.cyan(inputs.length === 1 ? 'input' : 'inputs')} and ${colors.yellow(String(outputs.length))} ${colors.yellow('outputs')}. This will produce identical output in multiple locations. You likely want to provide a single output or the same number of outputs as inputs.`,
+        `⚙️ ${styleText('yellow', 'Warning:')} You provided ${styleText('cyan', String(inputs.length))} ${styleText('cyan', inputs.length === 1 ? 'input' : 'inputs')} and ${styleText('yellow', String(outputs.length))} ${styleText('yellow', 'outputs')}. This will produce identical output in multiple locations. You likely want to provide a single output or the same number of outputs as inputs.`,
       );
       for (const output of outputs) {
         jobs.push({

--- a/packages/openapi-ts/src/config/resolve.ts
+++ b/packages/openapi-ts/src/config/resolve.ts
@@ -1,6 +1,7 @@
+import { styleText } from 'node:util';
+
 import { detectInteractiveSession } from '@hey-api/codegen-core';
 import { ConfigError, getInput, getLogs, getParser, resolvePlugins } from '@hey-api/shared';
-import colors from 'ansi-colors';
 
 import { defaultPluginConfigs, defaultPlugins } from '../plugins/config';
 import { getOutput } from './output/config';
@@ -55,8 +56,8 @@ export function resolveConfig(
   };
 
   if (logs.level === 'debug') {
-    const jobPrefix = colors.gray(`[Job ${validated.job.index}] `);
-    console.warn(`${jobPrefix}${colors.cyan('config:')}`, config);
+    const jobPrefix = styleText('gray', `[Job ${validated.job.index}] `);
+    console.warn(`${jobPrefix}${styleText('cyan', 'config:')}`, config);
   }
 
   return {

--- a/packages/openapi-ts/src/create-client.ts
+++ b/packages/openapi-ts/src/create-client.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { type Logger, Project } from '@hey-api/codegen-core';
 import { $RefParser, ResolverError } from '@hey-api/json-schema-ref-parser';
@@ -16,7 +17,6 @@ import {
   postprocessOutput,
 } from '@hey-api/shared';
 import { format as ms } from '@lukeed/ms';
-import colors from 'ansi-colors';
 
 import { postProcessors } from './config/output/postprocess';
 import type { Config } from './config/types';
@@ -178,7 +178,7 @@ export async function createClient({
 
     const eventPostprocess = logger.timeEvent('postprocess');
     if (!config.dryRun) {
-      const jobPrefix = colors.gray(`[Job ${jobIndex + 1}] `);
+      const jobPrefix = styleText('gray', `[Job ${jobIndex + 1}] `);
       postprocessOutput(config.output, postProcessors, jobPrefix);
 
       if (config.logs.level !== 'silent') {
@@ -186,7 +186,7 @@ export async function createClient({
           ? `./${path.relative(process.env.INIT_CWD, config.output.path)}`
           : config.output.path;
         console.log(
-          `${jobPrefix}${colors.green('✓')} ${colors.cyanBright(outputPath)} ${colors.gray(`· ${fileCount} ${fileCount === 1 ? 'file' : 'files'} · ${ms(totalMs)}`)}`,
+          `${jobPrefix}${styleText('green', '✓')} ${styleText('cyanBright', outputPath)} ${styleText('gray', `· ${fileCount} ${fileCount === 1 ? 'file' : 'files'} · ${ms(totalMs)}`)}`,
         );
       }
     }

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -90,9 +90,6 @@ declare module '@hey-api/shared' {
 // END OVERRIDES
 
 import type { AnyString, LazyOrAsync, MaybeArray } from '@hey-api/types';
-import colors from 'ansi-colors';
-// @ts-expect-error
-import colorSupport from 'color-support';
 
 import type { UserConfig } from './config/types';
 import type { AngularCommonPlugin } from './plugins/@angular/common';
@@ -146,8 +143,6 @@ import type { SwrPlugin } from './plugins/swr';
 import type { ValibotPlugin, ValibotResolvers } from './plugins/valibot';
 import type { ZodPlugin, ZodResolvers } from './plugins/zod';
 import type { TsDsl } from './ts-dsl';
-
-colors.enabled = colorSupport().hasBasic;
 
 export { createClient } from './generate';
 

--- a/packages/openapi-ts/src/plugins/@faker-js/faker/config.ts
+++ b/packages/openapi-ts/src/plugins/@faker-js/faker/config.ts
@@ -35,7 +35,7 @@ export const defaultConfig: FakerJsFakerPlugin['Config'] = {
       //   if (!(context as PluginContext).package.satisfies(version, '>=3.25.0 <5.0.0')) {
       //     const compatibleVersion = inferCompatibleVersion();
       //     console.warn(
-      //       `🔌 ${colors.yellow('Warning:')} Installed ${colors.cyan(packageName)} ${colors.cyan(`v${version.version}`)} does not support compatibility version ${colors.yellow(String(value))}, using ${colors.yellow(String(compatibleVersion))}.`,
+      //       `🔌 ${styleText('yellow', 'Warning:')} Installed ${styleText('cyan', packageName)} ${styleText('cyan', `v${version.version}`)} does not support compatibility version ${styleText('yellow', String(value))}, using ${styleText('yellow', String(compatibleVersion))}.`,
       //     );
       //     return compatibleVersion;
       //   }

--- a/packages/openapi-ts/src/plugins/zod/config.ts
+++ b/packages/openapi-ts/src/plugins/zod/config.ts
@@ -1,6 +1,7 @@
+import { styleText } from 'node:util';
+
 import type { PluginContext } from '@hey-api/shared';
 import { coerce, definePluginConfig } from '@hey-api/shared';
-import colors from 'ansi-colors';
 
 import { Api } from './api';
 import { zodImports } from './imports';
@@ -37,7 +38,7 @@ export const defaultConfig: ZodPlugin['Config'] = {
         if (!(context as PluginContext).package.satisfies(version, '>=3.25.0 <5.0.0')) {
           const compatibleVersion = inferCompatibleVersion();
           console.warn(
-            `🔌 ${colors.yellow('Warning:')} Installed ${colors.cyan(packageName)} ${colors.cyan(`v${version.version}`)} does not support compatibility version ${colors.yellow(String(value))}, using ${colors.yellow(String(compatibleVersion))}.`,
+            `🔌 ${styleText('yellow', 'Warning:')} Installed ${styleText('cyan', packageName)} ${styleText('cyan', `v${version.version}`)} does not support compatibility version ${styleText('yellow', String(value))}, using ${styleText('yellow', String(compatibleVersion))}.`,
           );
           return compatibleVersion;
         }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,7 +44,6 @@
     "@hey-api/json-schema-ref-parser": "workspace:*",
     "@hey-api/spec-types": "workspace:*",
     "@hey-api/types": "workspace:*",
-    "ansi-colors": "4.1.3",
     "cross-spawn": "7.0.6",
     "open": "11.0.0",
     "semver": "7.8.5"

--- a/packages/shared/src/cli.ts
+++ b/packages/shared/src/cli.ts
@@ -1,4 +1,4 @@
-import colors from 'ansi-colors';
+import { styleText } from 'node:util';
 
 import { loadPackageJson } from './tsConfig';
 
@@ -52,13 +52,13 @@ export function printCliIntro(initialDir: string, showLogo: boolean = false): vo
     if (showLogo) {
       const text = asciiToLines(textAscii, { padding: 1 });
       for (const line of text.lines) {
-        console.log(colors.cyan(line));
+        console.log(styleText('cyan', line));
       }
     }
     const versionString = isEnvironment('development')
       ? '[DEVELOPMENT]'
       : `v${packageJson.version}`;
-    console.log(colors.gray(`${packageJson.name} ${versionString}`));
+    console.log(styleText('gray', `${packageJson.name} ${versionString}`));
   }
   console.log('');
 }

--- a/packages/shared/src/config/input/path.ts
+++ b/packages/shared/src/config/input/path.ts
@@ -1,4 +1,4 @@
-import colors from 'ansi-colors';
+import { styleText } from 'node:util';
 
 import type { LogLevel } from '../../types/logs';
 import type { Input } from './types';
@@ -106,13 +106,13 @@ export function logInputPaths(
 
   const lines: Array<string> = [];
 
-  const jobPrefix = colors.gray(`[Job ${jobIndex + 1}] `);
-  const baseString = colors.cyan(`Generating...`);
-  lines.push(`${jobPrefix}${colors.gray('~')} ${baseString}`);
+  const jobPrefix = styleText('gray', `[Job ${jobIndex + 1}] `);
+  const baseString = styleText('cyan', `Generating...`);
+  lines.push(`${jobPrefix}${styleText('gray', '~')} ${baseString}`);
 
   inputPaths.forEach((inputPath, index) => {
     const itemPrefixStr = `  [${index + 1}] `;
-    const itemPrefix = colors.cyan(itemPrefixStr);
+    const itemPrefix = styleText('cyan', itemPrefixStr);
     const detailIndent = ' '.repeat(itemPrefixStr.length);
 
     if (typeof inputPath.path !== 'string') {
@@ -126,39 +126,43 @@ export function logInputPaths(
         lines.push(`${jobPrefix}${itemPrefix}${baseInput}`);
         if (inputPath.branch) {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('branch:')} ${colors.green(
+            `${jobPrefix}${detailIndent}${styleText('gray', 'branch:')} ${styleText(
+              'green',
               inputPath.branch,
             )}`,
           );
         }
         if (inputPath.commit_sha) {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('commit:')} ${colors.green(
+            `${jobPrefix}${detailIndent}${styleText('gray', 'commit:')} ${styleText(
+              'green',
               inputPath.commit_sha,
             )}`,
           );
         }
         if (inputPath.tags?.length) {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('tags:')} ${colors.green(
+            `${jobPrefix}${detailIndent}${styleText('gray', 'tags:')} ${styleText(
+              'green',
               inputPath.tags.join(', '),
             )}`,
           );
         }
         if (inputPath.version) {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('version:')} ${colors.green(
+            `${jobPrefix}${detailIndent}${styleText('gray', 'version:')} ${styleText(
+              'green',
               inputPath.version,
             )}`,
           );
         }
         if (logLevel === 'debug') {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('url:')} ${colors.green(inputPath.path)}`,
+            `${jobPrefix}${detailIndent}${styleText('gray', 'url:')} ${styleText('green', inputPath.path)}`,
           );
         }
         lines.push(
-          `${jobPrefix}${detailIndent}${colors.gray('registry:')} ${colors.green('Hey API')}`,
+          `${jobPrefix}${detailIndent}${styleText('gray', 'registry:')} ${styleText('green', 'Hey API')}`,
         );
         break;
       }
@@ -171,16 +175,16 @@ export function logInputPaths(
         }
         if (inputPath.uuid) {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('uuid:')} ${colors.green(inputPath.uuid)}`,
+            `${jobPrefix}${detailIndent}${styleText('gray', 'uuid:')} ${styleText('green', inputPath.uuid)}`,
           );
         }
         if (logLevel === 'debug' && baseInput) {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('url:')} ${colors.green(inputPath.path)}`,
+            `${jobPrefix}${detailIndent}${styleText('gray', 'url:')} ${styleText('green', inputPath.path)}`,
           );
         }
         lines.push(
-          `${jobPrefix}${detailIndent}${colors.gray('registry:')} ${colors.green('ReadMe')}`,
+          `${jobPrefix}${detailIndent}${styleText('gray', 'registry:')} ${styleText('green', 'ReadMe')}`,
         );
         break;
       }
@@ -189,11 +193,11 @@ export function logInputPaths(
         lines.push(`${jobPrefix}${itemPrefix}${baseInput}`);
         if (logLevel === 'debug') {
           lines.push(
-            `${jobPrefix}${detailIndent}${colors.gray('url:')} ${colors.green(inputPath.path)}`,
+            `${jobPrefix}${detailIndent}${styleText('gray', 'url:')} ${styleText('green', inputPath.path)}`,
           );
         }
         lines.push(
-          `${jobPrefix}${detailIndent}${colors.gray('registry:')} ${colors.green('Scalar')}`,
+          `${jobPrefix}${detailIndent}${styleText('gray', 'registry:')} ${styleText('green', 'Scalar')}`,
         );
         break;
       }

--- a/packages/shared/src/config/output/postprocess.ts
+++ b/packages/shared/src/config/output/postprocess.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
+import { styleText } from 'node:util';
 
-import colors from 'ansi-colors';
 import { sync } from 'cross-spawn';
 
 import { ConfigError } from '../../error';
@@ -67,7 +67,7 @@ export function postprocessOutput(
     const name = resolved.name ?? resolved.command;
     const args = resolved.args.map((arg) => arg.replace('{{path}}', config.path));
 
-    console.log(`${jobPrefix}🧹 Running ${colors.cyanBright(name)}`);
+    console.log(`${jobPrefix}🧹 Running ${styleText('cyanBright', name)}`);
     const result = sync(resolved.command, args);
 
     if (result.error) {

--- a/packages/shared/src/debug/ir.ts
+++ b/packages/shared/src/debug/ir.ts
@@ -1,4 +1,4 @@
-import colors from 'ansi-colors';
+import { styleText } from 'node:util';
 
 import type { IR } from '../ir/types';
 import { httpMethods } from '../openApi/shared/utils/operation';
@@ -43,7 +43,7 @@ const print = (ir: IR.Model, options: PrintOptions = {}) => {
       if (kind === 'responses') {
         const count = Object.keys(obj).length;
         const noun = count === 1 ? 'code' : 'codes';
-        log(`responses: ${colors.yellow(`${count} ${noun}`)}`, level);
+        log(`responses: ${styleText('yellow', `${count} ${noun}`)}`, level);
       } else if (kind === 'requestBody') {
         log(`requestBody: ${Object.keys(obj).join(', ')}`, level);
       } else if (kind === 'schema') {
@@ -62,7 +62,7 @@ const print = (ir: IR.Model, options: PrintOptions = {}) => {
     base: number = 1,
   ) => {
     if ('$ref' in item) {
-      log(`${colors.cyan(key)} is a $ref → ${colors.yellow(item.$ref)}`, base);
+      log(`${styleText('cyan', key)} is a $ref → ${styleText('yellow', item.$ref)}`, base);
       return;
     }
 
@@ -71,7 +71,7 @@ const print = (ir: IR.Model, options: PrintOptions = {}) => {
 
       const operation = item[method]!;
       log(
-        `${colors.green(method.toUpperCase())} ${colors.cyan(key)} (${colors.magenta(operation.operationId ?? '')})`,
+        `${styleText('green', method.toUpperCase())} ${styleText('cyan', key)} (${styleText('magenta', operation.operationId ?? '')})`,
         base,
       );
 

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
-import colors from 'ansi-colors';
 import open from 'open';
 
 import { ensureDirSync } from './fs';
@@ -202,22 +202,23 @@ export function printCrashReport({
     }
 
     for (const [jobIndex, errors] of groupByJob.entries()) {
-      const jobPrefix = colors.gray(`[Job ${jobIndex + 1}] `);
+      const jobPrefix = styleText('gray', `[Job ${jobIndex + 1}] `);
       const count = errors.length;
-      const baseString = colors.red(
+      const baseString = styleText(
+        'red',
         `Found ${count} configuration ${count === 1 ? 'error' : 'errors'}:`,
       );
       console.error(`${jobPrefix}❗️ ${baseString}`);
       errors.forEach((err, index) => {
         const itemPrefixStr = `  [${index + 1}] `;
-        const itemPrefix = colors.red(itemPrefixStr);
-        console.error(`${jobPrefix}${itemPrefix}${colors.white(err.message)}`);
+        const itemPrefix = styleText('red', itemPrefixStr);
+        console.error(`${jobPrefix}${itemPrefix}${styleText('white', err.message)}`);
       });
     }
   } else {
-    let jobPrefix = colors.gray('[root] ');
+    let jobPrefix = styleText('gray', '[root] ');
     if (error instanceof JobError) {
-      jobPrefix = colors.gray(`[Job ${error.originalError.jobIndex + 1}] `);
+      jobPrefix = styleText('gray', `[Job ${error.originalError.jobIndex + 1}] `);
       error = error.originalError.error;
     }
 
@@ -227,36 +228,38 @@ export function printCrashReport({
 
       const isNetworkError = error.message.startsWith('Input request failed');
       if (isNetworkError) {
-        console.error(`${jobPrefix}${colors.red(`❌ ${error.message}`)}`);
-        if (source) console.error(colors.gray(source));
-        console.error(colors.gray('\nPlease verify that:'));
-        console.error(colors.gray(`${itemPrefixStr}• The URL is correct`));
-        console.error(colors.gray(`${itemPrefixStr}• Your API key is valid`));
-        console.error(colors.gray(`${itemPrefixStr}• You have network access`));
+        console.error(`${jobPrefix}${styleText('red', `❌ ${error.message}`)}`);
+        if (source) console.error(styleText('gray', source));
+        console.error(styleText('gray', '\nPlease verify that:'));
+        console.error(styleText('gray', `${itemPrefixStr}• The URL is correct`));
+        console.error(styleText('gray', `${itemPrefixStr}• Your API key is valid`));
+        console.error(styleText('gray', `${itemPrefixStr}• You have network access`));
         return;
       }
 
-      console.error(`${jobPrefix}${colors.red('❌ Input file not found:')}`);
-      if (source) console.error(colors.gray(source));
-      console.error(colors.gray('\nPlease verify that:'));
-      console.error(colors.gray(`${itemPrefixStr}• The file exists`));
-      console.error(colors.gray(`${itemPrefixStr}• The path is correct`));
-      console.error(colors.gray(`${itemPrefixStr}• You have read permissions`));
+      console.error(`${jobPrefix}${styleText('red', '❌ Input file not found:')}`);
+      if (source) console.error(styleText('gray', source));
+      console.error(styleText('gray', '\nPlease verify that:'));
+      console.error(styleText('gray', `${itemPrefixStr}• The file exists`));
+      console.error(styleText('gray', `${itemPrefixStr}• The path is correct`));
+      console.error(styleText('gray', `${itemPrefixStr}• You have read permissions`));
       return;
     }
 
-    const baseString = colors.red('Failed with the message:');
+    const baseString = styleText('red', 'Failed with the message:');
     console.error(`${jobPrefix}❌ ${baseString}`);
     const itemPrefixStr = `  `;
-    const itemPrefix = colors.red(itemPrefixStr);
+    const itemPrefix = styleText('red', itemPrefixStr);
     console.error(
       `${jobPrefix}${itemPrefix}${typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error'}`,
     );
   }
 
   if (logPath) {
-    const jobPrefix = colors.gray('[root] ');
-    console.error(`${jobPrefix}${colors.cyan('📄 Crash log saved to:')} ${colors.gray(logPath)}`);
+    const jobPrefix = styleText('gray', '[root] ');
+    console.error(
+      `${jobPrefix}${styleText('cyan', '📄 Crash log saved to:')} ${styleText('gray', logPath)}`,
+    );
   }
 }
 
@@ -277,9 +280,9 @@ export async function shouldReportCrash({
   }
 
   return new Promise((resolve) => {
-    const jobPrefix = colors.gray('[root] ');
+    const jobPrefix = styleText('gray', '[root] ');
     console.log(
-      `${jobPrefix}${colors.yellow('📢 Open a GitHub issue with crash details? (y/N):')}`,
+      `${jobPrefix}${styleText('yellow', '📢 Open a GitHub issue with crash details? (y/N):')}`,
     );
     process.stdin.setEncoding('utf8');
     process.stdin.once('data', (data: string) => {

--- a/packages/shared/src/openApi/shared/utils/validator.ts
+++ b/packages/shared/src/openApi/shared/utils/validator.ts
@@ -1,4 +1,4 @@
-import colors from 'ansi-colors';
+import { styleText } from 'node:util';
 
 import type { Context } from '../../../ir/context';
 
@@ -56,13 +56,16 @@ const formatPath = (path: ReadonlyArray<string | number>): string =>
 
 const formatValidatorIssue = (issue: ValidatorIssue): string => {
   const pathStr = formatPath(issue.path);
-  const level = issue.severity === 'error' ? colors.bold.red : colors.bold.yellow;
+  const level =
+    issue.severity === 'error'
+      ? (text: string) => styleText(['bold', 'red'], text)
+      : (text: string) => styleText(['bold', 'yellow'], text);
 
   const highlightedMessage = issue.message.replace(/`([^`]+)`/g, (_, code) =>
-    colors.yellow(`\`${code}\``),
+    styleText('yellow', `\`${code}\``),
   );
 
-  return `${level(`[${issue.severity.toUpperCase()}]`)} ${colors.cyan(pathStr)}: ${highlightedMessage}`;
+  return `${level(`[${issue.severity.toUpperCase()}]`)} ${styleText('cyan', pathStr)}: ${highlightedMessage}`;
 };
 
 const shouldPrint = ({ context, issue }: { context: Context; issue: ValidatorIssue }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,15 +1075,9 @@ importers:
       '@hey-api/types':
         specifier: workspace:*
         version: link:../types
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
       c12:
         specifier: 3.3.4
         version: 3.3.4(magicast@0.5.2)
-      color-support:
-        specifier: 1.1.3
-        version: 1.1.3
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -1177,12 +1171,6 @@ importers:
       '@lukeed/ms':
         specifier: 2.0.2
         version: 2.0.2
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
-      color-support:
-        specifier: 1.1.3
-        version: 1.1.3
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -1229,12 +1217,6 @@ importers:
       '@lukeed/ms':
         specifier: 2.0.2
         version: 2.0.2
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
-      color-support:
-        specifier: 1.1.3
-        version: 1.1.3
       get-tsconfig:
         specifier: 4.14.0
         version: 4.14.0
@@ -1530,9 +1512,6 @@ importers:
       '@hey-api/types':
         specifier: workspace:*
         version: link:../types
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
       cross-spawn:
         specifier: 7.0.6
         version: 7.0.6
@@ -8329,10 +8308,6 @@ packages:
 
   color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
 
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
@@ -21447,8 +21422,6 @@ snapshots:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
     optional: true
-
-  color-support@1.1.3: {}
 
   color@4.2.3:
     dependencies:


### PR DESCRIPTION
## Summary

<!-- What does this change, and why? -->

Use Node's built-in `node:util` `styleText` for terminal coloring instead of the `ansi-colors` and `color-support` packages. Behavior is unchanged.

This should reduce monthly ecosystem traffic by ~ 42GB, source: [1](https://dependents.dev/?package=color-support), [2](https://dependents.dev/?package=ansi-colors)

## Linked issues

<!--
  Link at least one issue. Formats: #123, owner/repo#123, or full URL.
  - Closes / Fixes / Resolves: auto-closes the issue when this merges. Repeat
    the keyword per issue, e.g. "Closes #12, Closes #34".
  - Related to: links without closing. Separate multiple with commas.
  Fill whichever applies, you don't need both.
-->

Related to: https://github.com/hey-api/hey-api/issues/4288

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
