### PR TITLE
refactor: replace semver with verkit

### DIFF
--- a/.changeset/replace-semver-with-verkit.md
+++ b/.changeset/replace-semver-with-verkit.md
@@ -2,4 +2,4 @@
 "@hey-api/shared": patch
 ---
 
-Replace semver with verkit and expose verkit-compatible dependency version helpers
+**dependencies**: replace semver with verkit

--- a/.changeset/replace-semver-with-verkit.md
+++ b/.changeset/replace-semver-with-verkit.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/shared": patch
+---
+
+Replace semver with verkit and expose verkit-compatible dependency version helpers

--- a/packages/openapi-ts/src/plugins/zod/config.ts
+++ b/packages/openapi-ts/src/plugins/zod/config.ts
@@ -1,7 +1,7 @@
 import { styleText } from 'node:util';
 
 import type { PluginContext } from '@hey-api/shared';
-import { coerce, definePluginConfig } from '@hey-api/shared';
+import { coerce, definePluginConfig, normalizeFull } from '@hey-api/shared';
 
 import { Api } from './api';
 import { zodImports } from './imports';
@@ -38,7 +38,7 @@ export const defaultConfig: ZodPlugin['Config'] = {
         if (!(context as PluginContext).package.satisfies(version, '>=3.25.0 <5.0.0')) {
           const compatibleVersion = inferCompatibleVersion();
           console.warn(
-            `🔌 ${styleText('yellow', 'Warning:')} Installed ${styleText('cyan', packageName)} ${styleText('cyan', `v${version.version}`)} does not support compatibility version ${styleText('yellow', String(value))}, using ${styleText('yellow', String(compatibleVersion))}.`,
+            `🔌 ${styleText('yellow', 'Warning:')} Installed ${styleText('cyan', packageName)} ${styleText('cyan', `v${normalizeFull(version)}`)} does not support compatibility version ${styleText('yellow', String(value))}, using ${styleText('yellow', String(compatibleVersion))}.`,
           );
           return compatibleVersion;
         }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,7 +46,7 @@
     "@hey-api/types": "workspace:*",
     "cross-spawn": "7.0.6",
     "open": "11.0.0",
-    "verkit": "0.2.0"
+    "verkit": "0.3.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,13 +46,12 @@
     "@hey-api/types": "workspace:*",
     "cross-spawn": "7.0.6",
     "open": "11.0.0",
-    "semver": "7.8.5"
+    "verkit": "0.2.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
     "@types/cross-spawn": "6.0.6",
     "@types/js-yaml": "4.0.9",
-    "@types/semver": "7.7.1",
     "js-yaml": "5.2.0",
     "typescript": "6.0.3"
   },

--- a/packages/shared/src/config/utils/dependencies.ts
+++ b/packages/shared/src/config/utils/dependencies.ts
@@ -1,5 +1,5 @@
-import type { RangeOptions, SemVer } from 'semver';
-import * as semver from 'semver';
+import type { RangeInput, RangeOptions, SemVer } from 'verkit';
+import { coerce, findMinimumForRange, satisfies, tryParse } from 'verkit';
 
 export type Dependency = {
   /**
@@ -20,39 +20,37 @@ export type Dependency = {
    * @param range The semver range to check against.
    * @returns True if the version satisfies the range, false otherwise.
    */
-  satisfies: (
-    nameOrVersion: string | SemVer,
-    range: string,
-    optionsOrLoose?: boolean | RangeOptions,
-  ) => boolean;
+  satisfies: (nameOrVersion: string | SemVer, range: RangeInput, options?: RangeOptions) => boolean;
 };
 
-export const satisfies: typeof semver.satisfies = (...args) => semver.satisfies(...args);
+export { normalizeFull, satisfies } from 'verkit';
 
 export function dependencyFactory(dependencies: Record<string, string>): Dependency {
   return {
     getVersion: (name) => {
       const version = dependencies[name];
       if (!version) return;
+
+      let parsed = tryParse(version);
+      if (parsed) return parsed;
+
       try {
-        let parsed = semver.parse(version);
-        if (parsed) return parsed;
-
-        const min = semver.minVersion(version);
-        if (min) return min;
-
-        parsed = semver.coerce(version);
-        if (parsed) return parsed;
+        const min = findMinimumForRange(version);
+        if (min) return tryParse(min) ?? undefined;
       } catch {
         // noop
       }
+
+      const coerced = coerce(version);
+      parsed = coerced ? tryParse(coerced) : null;
+      if (parsed) return parsed;
       return;
     },
     isInstalled: (name) => Boolean(dependencies[name]),
-    satisfies: (nameOrVersion, range, optionsOrLoose) => {
+    satisfies: (nameOrVersion, range, options) => {
       const version =
         typeof nameOrVersion === 'string' ? dependencies[nameOrVersion] : nameOrVersion;
-      return version ? satisfies(version, range, optionsOrLoose) : false;
+      return version ? satisfies(version, range, options) : false;
     },
   };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,7 +29,7 @@ export type {
   UserIndexExportOption,
 } from './config/shared';
 export type { Dependency } from './config/utils/dependencies';
-export { dependencyFactory, satisfies } from './config/utils/dependencies';
+export { dependencyFactory, normalizeFull, satisfies } from './config/utils/dependencies';
 export { debugTools } from './debug';
 export {
   ConfigError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1519,8 +1519,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       verkit:
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.3.0
+        version: 0.3.0
     devDependencies:
       '@types/bun':
         specifier: 1.3.14
@@ -13314,8 +13314,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  verkit@0.2.0:
-    resolution: {integrity: sha512-6M8R2xSKplkQ+0mAm07IMh548GLLPUnRQZJCCe/W4rfk/SXW2bs8ZJSWa5kjdIdsx3hLG5oLWROJ4+N5hpX08g==}
+  verkit@0.3.0:
+    resolution: {integrity: sha512-Njrh4U8UODGajoZ44QS2C/BsoEM9DTI/aCqY5swsizb+/ap0FamvnCMcZAxrR5+aoC0ZqkawEfpC/N2SBc+xeA==}
     engines: {node: '>=18.12.0'}
 
   vfile-location@5.0.3:
@@ -28157,7 +28157,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  verkit@0.2.0: {}
+  verkit@0.3.0: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1518,9 +1518,9 @@ importers:
       open:
         specifier: 11.0.0
         version: 11.0.0
-      semver:
-        specifier: 7.8.5
-        version: 7.8.5
+      verkit:
+        specifier: 0.2.0
+        version: 0.2.0
     devDependencies:
       '@types/bun':
         specifier: 1.3.14
@@ -1531,9 +1531,6 @@ importers:
       '@types/js-yaml':
         specifier: 4.0.9
         version: 4.0.9
-      '@types/semver':
-        specifier: 7.7.1
-        version: 7.7.1
       js-yaml:
         specifier: 5.2.0
         version: 5.2.0
@@ -13316,6 +13313,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verkit@0.2.0:
+    resolution: {integrity: sha512-6M8R2xSKplkQ+0mAm07IMh548GLLPUnRQZJCCe/W4rfk/SXW2bs8ZJSWa5kjdIdsx3hLG5oLWROJ4+N5hpX08g==}
+    engines: {node: '>=18.12.0'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -28155,6 +28156,8 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  verkit@0.2.0: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION


## Summary

<!-- What does this change, and why? -->

Use verkit for semantic version parsing and range checks instead of semver.

## Linked issues

<!--
  Link at least one issue. Formats: #123, owner/repo#123, or full URL.
  - Closes / Fixes / Resolves: auto-closes the issue when this merges. Repeat
    the keyword per issue, e.g. "Closes #12, Closes #34".
  - Related to: links without closing. Separate multiple with commas.
  Fill whichever applies, you don't need both.
-->


Related to: #4288

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
