### PR TITLE
feat(orpc): typesafe error handling

### DIFF
--- a/.changeset/gold-fans-lie.md
+++ b/.changeset/gold-fans-lie.md
@@ -1,0 +1,9 @@
+---
+"@hey-api/openapi-ts": minor
+---
+
+**plugin(orpc)**: provide typesafety to error responses by generating the contract according to https://orpc.dev/docs/error-handling#type-safe-error-handling
+
+**plugin(zod)**: generate schemas for error responses
+
+**plugin(valibot)**: generate schemas for error responses

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/custom-names/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/custom-names/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as v from 'valibot';
 
-import { vCreatePostBody, vCreatePostHeaders, vCreatePostResponse, vCreateUserBody, vCreateUserResponse, vDeleteUserHeaders, vDeleteUserPath, vDeleteUserResponse, vGetPostByIdPath, vGetPostByIdQuery, vGetPostByIdResponse, vGetPostsQuery, vGetPostsResponse, vGetUserByIdPath, vGetUserByIdResponse, vGetUsersQuery, vGetUsersResponse, vUpdateUserBody, vUpdateUserPath, vUpdateUserResponse } from './valibot.gen';
+import { vCreatePostBody, vCreatePostHeaders, vCreatePostResponse, vCreateUserBody, vCreateUserResponse, vDeleteUserHeaders, vDeleteUserPath, vDeleteUserResponse, vGetPostById500Response, vGetPostByIdPath, vGetPostByIdQuery, vGetPostByIdResponse, vGetPostsQuery, vGetPostsResponse, vGetUserByIdPath, vGetUserByIdResponse, vGetUsersQuery, vGetUsersResponse, vUpdateUserBody, vUpdateUserPath, vUpdateUserResponse } from './valibot.gen';
 
 /**
  * Get all users
@@ -102,7 +102,11 @@ export const getPostByIdRpc = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(v.object({ params: vGetPostByIdPath, query: v.optional(vGetPostByIdQuery) })).output(vGetPostByIdResponse);
+}).input(v.object({ params: vGetPostByIdPath, query: v.optional(vGetPostByIdQuery) })).output(vGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: vGetPostById500Response
+  } });
 
 export const rpcContract = {
   getUsersRpc,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/custom-names/valibot.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/custom-names/valibot.gen.ts
@@ -39,6 +39,11 @@ export const vCreatePostInput = v.object({
   status: v.optional(v.picklist(['draft', 'published']), 'draft')
 });
 
+export const vError = v.object({
+  type: v.pipe(v.string(), v.url()),
+  title: v.string()
+});
+
 export const vGetUsersQuery = v.object({
   limit: v.optional(v.pipe(v.number(), v.integer()), 10),
   offset: v.optional(v.pipe(v.number(), v.integer()), 0)
@@ -126,3 +131,8 @@ export const vGetPostByIdQuery = v.object({
  * Post found
  */
 export const vGetPostByIdResponse = vPost;
+
+/**
+ * Internal server error
+ */
+export const vGetPostById500Response = vError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/default/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/default/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as z from 'zod';
 
-import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
+import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostById500Response, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
 
 /**
  * Get all users
@@ -102,7 +102,11 @@ export const getPostById = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse);
+}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: zGetPostById500Response
+  } });
 
 export const contract = {
   getUsers,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.0.x/default/zod.gen.ts
@@ -39,6 +39,11 @@ export const zCreatePostInput = z.object({
   status: z.enum(['draft', 'published']).optional().default('draft')
 });
 
+export const zError = z.object({
+  type: z.url(),
+  title: z.string()
+});
+
 export const zGetUsersQuery = z.object({
   limit: z.int().optional().default(10),
   offset: z.int().optional().default(0)
@@ -126,3 +131,8 @@ export const zGetPostByIdQuery = z.object({
  * Post found
  */
 export const zGetPostByIdResponse = zPost;
+
+/**
+ * Internal server error
+ */
+export const zGetPostById500Response = zError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-custom-naming/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-custom-naming/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as z from 'zod';
 
-import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
+import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostById500Response, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
 
 /**
  * Get all users
@@ -110,7 +110,11 @@ export const GetPostById = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse);
+}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: zGetPostById500Response
+  } });
 
 export const postsContracts = {
   GetPosts,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-custom-naming/zod.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-custom-naming/zod.gen.ts
@@ -39,6 +39,11 @@ export const zCreatePostInput = z.object({
   status: z.enum(['draft', 'published']).optional().default('draft')
 });
 
+export const zError = z.object({
+  type: z.url(),
+  title: z.string()
+});
+
 export const zGetUsersQuery = z.object({
   limit: z.int().optional().default(10),
   offset: z.int().optional().default(0)
@@ -126,3 +131,8 @@ export const zGetPostByIdQuery = z.object({
  * Post found
  */
 export const zGetPostByIdResponse = zPost;
+
+/**
+ * Internal server error
+ */
+export const zGetPostById500Response = zError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-nesting-id/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-nesting-id/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as z from 'zod';
 
-import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
+import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostById500Response, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
 
 /**
  * Get all users
@@ -110,7 +110,11 @@ export const getPostById = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse);
+}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: zGetPostById500Response
+  } });
 
 export const posts = {
   getPosts,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-nesting-id/zod.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-nesting-id/zod.gen.ts
@@ -39,6 +39,11 @@ export const zCreatePostInput = z.object({
   status: z.enum(['draft', 'published']).optional().default('draft')
 });
 
+export const zError = z.object({
+  type: z.url(),
+  title: z.string()
+});
+
 export const zGetUsersQuery = z.object({
   limit: z.int().optional().default(10),
   offset: z.int().optional().default(0)
@@ -126,3 +131,8 @@ export const zGetPostByIdQuery = z.object({
  * Post found
  */
 export const zGetPostByIdResponse = zPost;
+
+/**
+ * Internal server error
+ */
+export const zGetPostById500Response = zError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-by-tags/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-by-tags/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as z from 'zod';
 
-import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
+import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostById500Response, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
 
 /**
  * Get all users
@@ -110,7 +110,11 @@ export const getPostById = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse);
+}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: zGetPostById500Response
+  } });
 
 export const posts = {
   getPosts,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-by-tags/zod.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-by-tags/zod.gen.ts
@@ -39,6 +39,11 @@ export const zCreatePostInput = z.object({
   status: z.enum(['draft', 'published']).optional().default('draft')
 });
 
+export const zError = z.object({
+  type: z.url(),
+  title: z.string()
+});
+
 export const zGetUsersQuery = z.object({
   limit: z.int().optional().default(10),
   offset: z.int().optional().default(0)
@@ -126,3 +131,8 @@ export const zGetPostByIdQuery = z.object({
  * Post found
  */
 export const zGetPostByIdResponse = zPost;
+
+/**
+ * Internal server error
+ */
+export const zGetPostById500Response = zError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-single/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-single/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as z from 'zod';
 
-import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
+import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostById500Response, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
 
 /**
  * Get all users
@@ -102,7 +102,11 @@ export const getPostById = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse);
+}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: zGetPostById500Response
+  } });
 
 export const api = {
   getUsers,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-single/zod.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/contracts-strategy-single/zod.gen.ts
@@ -39,6 +39,11 @@ export const zCreatePostInput = z.object({
   status: z.enum(['draft', 'published']).optional().default('draft')
 });
 
+export const zError = z.object({
+  type: z.url(),
+  title: z.string()
+});
+
 export const zGetUsersQuery = z.object({
   limit: z.int().optional().default(10),
   offset: z.int().optional().default(0)
@@ -126,3 +131,8 @@ export const zGetPostByIdQuery = z.object({
  * Post found
  */
 export const zGetPostByIdResponse = zPost;
+
+/**
+ * Internal server error
+ */
+export const zGetPostById500Response = zError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/custom-names/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/custom-names/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as v from 'valibot';
 
-import { vCreatePostBody, vCreatePostHeaders, vCreatePostResponse, vCreateUserBody, vCreateUserResponse, vDeleteUserHeaders, vDeleteUserPath, vDeleteUserResponse, vGetPostByIdPath, vGetPostByIdQuery, vGetPostByIdResponse, vGetPostsQuery, vGetPostsResponse, vGetUserByIdPath, vGetUserByIdResponse, vGetUsersQuery, vGetUsersResponse, vUpdateUserBody, vUpdateUserPath, vUpdateUserResponse } from './valibot.gen';
+import { vCreatePostBody, vCreatePostHeaders, vCreatePostResponse, vCreateUserBody, vCreateUserResponse, vDeleteUserHeaders, vDeleteUserPath, vDeleteUserResponse, vGetPostById500Response, vGetPostByIdPath, vGetPostByIdQuery, vGetPostByIdResponse, vGetPostsQuery, vGetPostsResponse, vGetUserByIdPath, vGetUserByIdResponse, vGetUsersQuery, vGetUsersResponse, vUpdateUserBody, vUpdateUserPath, vUpdateUserResponse } from './valibot.gen';
 
 /**
  * Get all users
@@ -102,7 +102,11 @@ export const getPostByIdRpc = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(v.object({ params: vGetPostByIdPath, query: v.optional(vGetPostByIdQuery) })).output(vGetPostByIdResponse);
+}).input(v.object({ params: vGetPostByIdPath, query: v.optional(vGetPostByIdQuery) })).output(vGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: vGetPostById500Response
+  } });
 
 export const rpcContract = {
   getUsersRpc,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/custom-names/valibot.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/custom-names/valibot.gen.ts
@@ -39,6 +39,11 @@ export const vCreatePostInput = v.object({
   status: v.optional(v.picklist(['draft', 'published']), 'draft')
 });
 
+export const vError = v.object({
+  type: v.pipe(v.string(), v.url()),
+  title: v.string()
+});
+
 export const vGetUsersQuery = v.object({
   limit: v.optional(v.pipe(v.number(), v.integer()), 10),
   offset: v.optional(v.pipe(v.number(), v.integer()), 0)
@@ -126,3 +131,8 @@ export const vGetPostByIdQuery = v.object({
  * Post found
  */
 export const vGetPostByIdResponse = vPost;
+
+/**
+ * Internal server error
+ */
+export const vGetPostById500Response = vError;

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/default/orpc.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/default/orpc.gen.ts
@@ -3,7 +3,7 @@
 import { oc } from '@orpc/contract';
 import * as z from 'zod';
 
-import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
+import { zCreatePostBody, zCreatePostHeaders, zCreatePostResponse, zCreateUserBody, zCreateUserResponse, zDeleteUserHeaders, zDeleteUserPath, zDeleteUserResponse, zGetPostById500Response, zGetPostByIdPath, zGetPostByIdQuery, zGetPostByIdResponse, zGetPostsQuery, zGetPostsResponse, zGetUserByIdPath, zGetUserByIdResponse, zGetUsersQuery, zGetUsersResponse, zUpdateUserBody, zUpdateUserPath, zUpdateUserResponse } from './zod.gen';
 
 /**
  * Get all users
@@ -102,7 +102,11 @@ export const getPostById = oc.route({
   path: '/posts/{postId}',
   summary: 'Get a post by ID',
   tags: ['posts']
-}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse);
+}).input(z.object({ params: zGetPostByIdPath, query: zGetPostByIdQuery.optional() })).output(zGetPostByIdResponse).errors({ POST_NOT_FOUND: { status: 404, message: 'Post not found' } }).errors({ INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: 'Internal server error',
+    data: zGetPostById500Response
+  } });
 
 export const contract = {
   getUsers,

--- a/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/orpc/v1/__snapshots__/3.1.x/default/zod.gen.ts
@@ -39,6 +39,11 @@ export const zCreatePostInput = z.object({
   status: z.enum(['draft', 'published']).optional().default('draft')
 });
 
+export const zError = z.object({
+  type: z.url(),
+  title: z.string()
+});
+
 export const zGetUsersQuery = z.object({
   limit: z.int().optional().default(10),
   offset: z.int().optional().default(0)
@@ -126,3 +131,8 @@ export const zGetPostByIdQuery = z.object({
  * Post found
  */
 export const zGetPostByIdResponse = zPost;
+
+/**
+ * Internal server error
+ */
+export const zGetPostById500Response = zError;

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/2.0.x/mini/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/2.0.x/mini/default/zod.gen.ts
@@ -546,6 +546,21 @@ export const zCallWithResponseResponse = zModelWithString;
  */
 export const zCallWithDuplicateResponsesResponse = zModelWithString;
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.optional(z.readonly(z.string())),
@@ -555,6 +570,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()),
@@ -628,3 +658,13 @@ export const zPostApiVbyApiVersionBodyBody = zParameterActivityParams;
  * OK
  */
 export const zPostApiVbyApiVersionBodyResponse = zResponsePostActivityResponse;
+
+/**
+ * Bad Request
+ */
+export const zPostApiVbyApiVersionBody400Response = zFailureFailure;
+
+/**
+ * Internal Server Error
+ */
+export const zPostApiVbyApiVersionBody500Response = zFailureFailure;

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/2.0.x/v3/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/2.0.x/v3/default/zod.gen.ts
@@ -546,6 +546,21 @@ export const zCallWithResponseResponse = zModelWithString;
  */
 export const zCallWithDuplicateResponsesResponse = zModelWithString;
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -555,6 +570,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()),
@@ -628,3 +658,13 @@ export const zPostApiVbyApiVersionBodyBody = zParameterActivityParams;
  * OK
  */
 export const zPostApiVbyApiVersionBodyResponse = zResponsePostActivityResponse;
+
+/**
+ * Bad Request
+ */
+export const zPostApiVbyApiVersionBody400Response = zFailureFailure;
+
+/**
+ * Internal Server Error
+ */
+export const zPostApiVbyApiVersionBody500Response = zFailureFailure;

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/2.0.x/v4/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/2.0.x/v4/default/zod.gen.ts
@@ -546,6 +546,21 @@ export const zCallWithResponseResponse = zModelWithString;
  */
 export const zCallWithDuplicateResponsesResponse = zModelWithString;
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -555,6 +570,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()),
@@ -628,3 +658,13 @@ export const zPostApiVbyApiVersionBodyBody = zParameterActivityParams;
  * OK
  */
 export const zPostApiVbyApiVersionBodyResponse = zResponsePostActivityResponse;
+
+/**
+ * Bad Request
+ */
+export const zPostApiVbyApiVersionBody400Response = zFailureFailure;
+
+/**
+ * Internal Server Error
+ */
+export const zPostApiVbyApiVersionBody500Response = zFailureFailure;

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/3.0.x/mini/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/3.0.x/mini/default/zod.gen.ts
@@ -1266,6 +1266,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.optional(z.readonly(z.string())),
@@ -1275,6 +1295,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.nullable(z.array(z.string())),

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/3.0.x/v3/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/3.0.x/v3/default/zod.gen.ts
@@ -1266,6 +1266,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1275,6 +1295,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/3.0.x/v4/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/3.0.x/v4/default/zod.gen.ts
@@ -1266,6 +1266,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1275,6 +1295,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/3.1.x/mini/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/3.1.x/mini/default/zod.gen.ts
@@ -1284,6 +1284,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.optional(z.readonly(z.string())),
@@ -1293,6 +1313,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.nullable(z.array(z.string())),

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/3.1.x/v3/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/3.1.x/v3/default/zod.gen.ts
@@ -1284,6 +1284,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1293,6 +1313,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v3/__snapshots__/3.1.x/v4/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v3/__snapshots__/3.1.x/v4/default/zod.gen.ts
@@ -1284,6 +1284,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1293,6 +1313,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/default/zod.gen.ts
@@ -546,6 +546,21 @@ export const zCallWithResponseResponse = zModelWithString;
  */
 export const zCallWithDuplicateResponsesResponse = zModelWithString;
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.optional(z.readonly(z.string())),
@@ -555,6 +570,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()),
@@ -628,3 +658,13 @@ export const zPostApiVbyApiVersionBodyBody = zParameterActivityParams;
  * OK
  */
 export const zPostApiVbyApiVersionBodyResponse = zResponsePostActivityResponse;
+
+/**
+ * Bad Request
+ */
+export const zPostApiVbyApiVersionBody400Response = zFailureFailure;
+
+/**
+ * Internal Server Error
+ */
+export const zPostApiVbyApiVersionBody500Response = zFailureFailure;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/default/zod.gen.ts
@@ -546,6 +546,21 @@ export const zCallWithResponseResponse = zModelWithString;
  */
 export const zCallWithDuplicateResponsesResponse = zModelWithString;
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -555,6 +570,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()),
@@ -628,3 +658,13 @@ export const zPostApiVbyApiVersionBodyBody = zParameterActivityParams;
  * OK
  */
 export const zPostApiVbyApiVersionBodyResponse = zResponsePostActivityResponse;
+
+/**
+ * Bad Request
+ */
+export const zPostApiVbyApiVersionBody400Response = zFailureFailure;
+
+/**
+ * Internal Server Error
+ */
+export const zPostApiVbyApiVersionBody500Response = zFailureFailure;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/default/zod.gen.ts
@@ -546,6 +546,21 @@ export const zCallWithResponseResponse = zModelWithString;
  */
 export const zCallWithDuplicateResponsesResponse = zModelWithString;
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -555,6 +570,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()),
@@ -628,3 +658,13 @@ export const zPostApiVbyApiVersionBodyBody = zParameterActivityParams;
  * OK
  */
 export const zPostApiVbyApiVersionBodyResponse = zResponsePostActivityResponse;
+
+/**
+ * Bad Request
+ */
+export const zPostApiVbyApiVersionBody400Response = zFailureFailure;
+
+/**
+ * Internal Server Error
+ */
+export const zPostApiVbyApiVersionBody500Response = zFailureFailure;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/default/zod.gen.ts
@@ -1266,6 +1266,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.optional(z.readonly(z.string())),
@@ -1275,6 +1295,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.nullable(z.array(z.string())),

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/default/zod.gen.ts
@@ -1266,6 +1266,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1275,6 +1295,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/default/zod.gen.ts
@@ -1266,6 +1266,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1275,6 +1295,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/default/zod.gen.ts
@@ -1284,6 +1284,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.optional(z.readonly(z.string())),
@@ -1293,6 +1313,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.nullable(z.array(z.string())),

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/default/zod.gen.ts
@@ -1284,6 +1284,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1293,6 +1313,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/default/zod.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/default/zod.gen.ts
@@ -1284,6 +1284,26 @@ export const zCallWithDuplicateResponsesResponse = z.union([
   zModelWithString
 ]);
 
+/**
+ * Message for 500 error
+ */
+export const zCallWithDuplicateResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithDuplicateResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithDuplicateResponses502Response = zModelWithStringError;
+
+/**
+ * Message for 4XX errors
+ */
+export const zCallWithDuplicateResponses4XxResponse = zDictionaryWithArray;
+
 export const zCallWithResponsesResponse = z.union([
   z.object({
     '@namespace.string': z.string().readonly().optional(),
@@ -1293,6 +1313,21 @@ export const zCallWithResponsesResponse = z.union([
   zModelThatExtends,
   zModelThatExtendsExtends
 ]);
+
+/**
+ * Message for 500 error
+ */
+export const zCallWithResponses500Response = zModelWithStringError;
+
+/**
+ * Message for 501 error
+ */
+export const zCallWithResponses501Response = zModelWithStringError;
+
+/**
+ * Message for 502 error
+ */
+export const zCallWithResponses502Response = zModelWithStringError;
 
 export const zCollectionFormatQuery = z.object({
   parameterArrayCSV: z.array(z.string()).nullable(),

--- a/packages/openapi-ts/src/plugins/orpc/contracts/node.ts
+++ b/packages/openapi-ts/src/plugins/orpc/contracts/node.ts
@@ -209,6 +209,32 @@ function createContractExpression(
     }
   }
 
+  if (operation.responses) {
+    for (const [status, response] of Object.entries(operation.responses)) {
+      if (!response) continue;
+      const statusInt = parseInt(status, 10);
+      if (statusInt < 400 || statusInt >= 600) continue;
+
+      let errorObject = $.object()
+        .prop('status', $.literal(statusInt))
+        .prop('message', $.literal(response.schema.description ?? status));
+
+      if (plugin.config.validator.output) {
+        const schema = plugin.referenceSymbol({
+          artifact: plugin.config.validator.output,
+          category: 'schema',
+          resource: 'operation',
+          resourceId: operation.id,
+          role: 'error' + status,
+        });
+        errorObject = errorObject.$if(schema.name, (o) => o.prop('data', schema));
+      }
+
+      const code = response.schema.description?.replaceAll(' ', '_').toUpperCase() ?? status;
+      expression = expression.attr('errors').call($.object().prop(code, errorObject));
+    }
+  }
+
   return expression;
 }
 

--- a/packages/openapi-ts/src/plugins/valibot/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/valibot/shared/operation.ts
@@ -86,7 +86,7 @@ export function irOperationToAst({
 
   if (plugin.config.responses.enabled) {
     if (operation.responses) {
-      const { response } = operationResponsesMap(operation);
+      const { errors, response } = operationResponsesMap(operation);
 
       if (response) {
         processor.process({
@@ -102,6 +102,27 @@ export function irOperationToAst({
           schema: response,
           tags,
         });
+      }
+
+      if (errors && errors.properties) {
+        for (const [status, error] of Object.entries(errors.properties)) {
+          if (['never', 'null', 'undefined', 'unknown', 'void'].includes(error.type!)) continue;
+          if (status === 'default') continue;
+
+          processor.process({
+            meta: {
+              resource: 'operation',
+              resourceId: operation.id,
+              role: 'error' + status,
+            },
+            naming: plugin.config.responses,
+            namingAnchor: operation.id + status,
+            path: [...path, 'error', status],
+            plugin,
+            schema: error,
+            tags,
+          });
+        }
       }
     }
   }

--- a/packages/openapi-ts/src/plugins/zod/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/zod/shared/operation.ts
@@ -86,7 +86,7 @@ export function irOperationToAst({
 
   if (plugin.config.responses.enabled) {
     if (operation.responses) {
-      const { response } = operationResponsesMap(operation);
+      const { errors, response } = operationResponsesMap(operation);
 
       if (response) {
         processor.process({
@@ -102,6 +102,27 @@ export function irOperationToAst({
           schema: response,
           tags,
         });
+      }
+
+      if (errors && errors.properties) {
+        for (const [status, error] of Object.entries(errors.properties)) {
+          if (['never', 'null', 'undefined', 'unknown', 'void'].includes(error.type!)) continue;
+          if (status === 'default') continue;
+
+          processor.process({
+            meta: {
+              resource: 'operation',
+              resourceId: operation.id,
+              role: 'error' + status,
+            },
+            naming: plugin.config.responses,
+            namingAnchor: operation.id + status,
+            path: [...path, 'error', status],
+            plugin,
+            schema: error,
+            tags,
+          });
+        }
       }
     }
   }

--- a/specs/3.0.x/rpc.yaml
+++ b/specs/3.0.x/rpc.yaml
@@ -201,6 +201,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Post'
+        '404':
+          description: Post not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     User:
@@ -283,3 +291,16 @@ components:
             - draft
             - published
           default: draft
+    Error:
+      type: object
+      required:
+        - type
+        - title
+      properties:
+        type:
+          type: string
+          format: uri
+          example: https://example.net/INTERNAL_SERVER_ERROR
+        title:
+          type: string
+          example: 'Unexpected error occurred'

--- a/specs/3.1.x/rpc.yaml
+++ b/specs/3.1.x/rpc.yaml
@@ -201,6 +201,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Post'
+        '404':
+          description: Post not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     User:
@@ -283,3 +291,16 @@ components:
             - draft
             - published
           default: draft
+    Error:
+      type: object
+      required:
+        - type
+        - title
+      properties:
+        type:
+          type: string
+          format: uri
+          example: https://example.net/INTERNAL_SERVER_ERROR
+        title:
+          type: string
+          example: 'Unexpected error occurred'

--- a/web/src/content/docs/docs/openapi/typescript/plugins/orpc/v1.mdx
+++ b/web/src/content/docs/docs/openapi/typescript/plugins/orpc/v1.mdx
@@ -99,7 +99,7 @@ For a more granular approach, manually add a validator plugin and set `validator
 ```ts {15,16} title="orpc.gen.ts"
 import { oc } from '@orpc/contract';
 
-import { vAddPetBody, vAddPetResponse } from './valibot.gen';
+import { vAddPetBody, vAddPetResponse, vAddPet409Response } from './valibot.gen';
 
 const addPet = oc
   .route({
@@ -112,7 +112,8 @@ const addPet = oc
     tags: ['pet'],
   })
   .input(v.object({ body: vAddPetBody }))
-  .output(vAddPetResponse);
+  .output(vAddPetResponse)
+  .errors({ PET_ALREADY_EXISTS: { status: 409, message: 'Pet already exists', data: vAddPet409Response } });
 ```
   </TabItem>
   <TabItem label="config">

--- a/web/src/content/docs/docs/openapi/typescript/plugins/orpc/v2.mdx
+++ b/web/src/content/docs/docs/openapi/typescript/plugins/orpc/v2.mdx
@@ -149,7 +149,7 @@ For a more granular approach, manually add a validator plugin and set `validator
 import { oc } from '@orpc/contract';
 import { openapi } from '@orpc/openapi';
 
-import { vAddPetBody, vAddPetResponse } from './valibot.gen';
+import { vAddPetBody, vAddPetResponse, vAddPet409Response } from './valibot.gen';
 
 const addPet = oc
   .meta(
@@ -164,7 +164,8 @@ const addPet = oc
     }),
   )
   .input(v.object({ body: vAddPetBody }))
-  .output(vAddPetResponse);
+  .output(vAddPetResponse)
+  .errors({ PET_ALREADY_EXISTS: { status: 409, message: 'Pet already exists', data: vAddPet409Response } });
 ```
   </TabItem>
   <TabItem label="config">


### PR DESCRIPTION
## Summary

<!-- What does this change, and why? -->

This PR solves the issue of previously missing typesafety in error responses. Users had to a) either manually type out errors in a oRPC server implementation, or b) deal with throwing raw `ORPCError`s living without the typesafety.

As proposed via https://github.com/hey-api/hey-api/issues/3771, it would be nice if contract generation respected error responses and automatically registered them. By doing so, errors can be thrown in a typesafe way from the oRPC server implementation while also having the benefit of output validation without having to maintain extra boilerplate / redundant error response definitions.


## Linked issues

<!--
  Link at least one issue. Formats: #123, owner/repo#123, or full URL.
  - Closes / Fixes / Resolves: auto-closes the issue when this merges. Repeat
    the keyword per issue, e.g. "Closes #12, Closes #34".
  - Related to: links without closing. Separate multiple with commas.
  Fill whichever applies, you don't need both.
-->

Closes https://github.com/hey-api/hey-api/issues/3771

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
