### PR TITLE
fix: chain zod allOf intersections

### DIFF
--- a/packages/openapi-ts/src/__tests__/index.test.ts
+++ b/packages/openapi-ts/src/__tests__/index.test.ts
@@ -3,6 +3,80 @@ import { createClient } from '../index';
 type Config = Parameters<typeof createClient>[0];
 
 describe('createClient', () => {
+  it('chains zod intersections for allOf with more than two members', async () => {
+    const input = {
+      components: {
+        schemas: {
+          MySchema: {
+            allOf: [
+              { description: 'annotation-only member' },
+              {
+                oneOf: [
+                  {
+                    properties: {
+                      enable: { type: 'boolean' },
+                    },
+                    required: ['enable'],
+                    type: 'object',
+                  },
+                ],
+              },
+              {
+                properties: {
+                  a: { type: 'string' },
+                },
+                type: 'object',
+              },
+              {
+                properties: {
+                  b: { type: 'string' },
+                },
+                type: 'object',
+              },
+            ],
+          },
+        },
+      },
+      info: { title: 'zod-intersection-test', version: '1.0.0' },
+      openapi: '3.0.3',
+      paths: {},
+    } as const;
+
+    for (const compatibilityVersion of [3, 4, 'mini'] as const) {
+      const results = await createClient({
+        dryRun: true,
+        input,
+        logs: {
+          level: 'silent',
+        },
+        output: 'output',
+        plugins: [
+          '@hey-api/typescript',
+          {
+            compatibilityVersion,
+            name: 'zod',
+          },
+        ],
+      });
+
+      const zodFile = results[0]!.gen
+        .render()
+        .find((file: { path: string }) => file.path.endsWith('/zod.gen.ts'))!;
+
+      expect(zodFile.content).toContain('z.intersection(');
+      expect(zodFile.content).not.toContain('}), z.object({');
+      expect(zodFile.content).toContain('b:');
+
+      if (compatibilityVersion === 'mini') {
+        expect(zodFile.content).toContain('z.intersection(z.intersection(');
+        expect(zodFile.content).toContain('z.optional(z.string())');
+      } else {
+        expect(zodFile.content).toContain('.and(z.object({');
+        expect(zodFile.content).toContain('b: z.string().optional()');
+      }
+    }
+  });
+
   it('handles deep path $ref without errors', async () => {
     // This test verifies that deep path refs like
     // #/components/schemas/Foo/properties/bar/items are inlined

--- a/packages/openapi-ts/src/__tests__/index.test.ts
+++ b/packages/openapi-ts/src/__tests__/index.test.ts
@@ -61,7 +61,7 @@ describe('createClient', () => {
 
       const zodFile = results[0]!.gen
         .render()
-        .find((file: { path: string }) => file.path.endsWith('/zod.gen.ts'))!;
+        .find((file: { path: string }) => file.path.endsWith('zod.gen.ts'))!;
 
       expect(zodFile.content).toContain('z.intersection(');
       expect(zodFile.content).not.toContain('}), z.object({');

--- a/packages/openapi-ts/src/plugins/zod/v3/toAst/intersection.ts
+++ b/packages/openapi-ts/src/plugins/zod/v3/toAst/intersection.ts
@@ -8,6 +8,11 @@ function baseNode(ctx: IntersectionResolverContext): Chain {
   const { childResults, schemas } = ctx;
   const { z } = ctx.plugin.imports;
 
+  const chainOrLazy = (item: ZodResult): Chain =>
+    item.meta.hasLazy && !item.meta.isLazy
+      ? $(z).attr(identifiers.lazy).call($.func().do(item.chain.return()))
+      : item.chain;
+
   if (!childResults.length) {
     return $(z).attr(identifiers.never).call();
   }
@@ -18,20 +23,22 @@ function baseNode(ctx: IntersectionResolverContext): Chain {
     firstSchema?.logicalOperator === 'or' ||
     (firstSchema?.type && firstSchema.type !== 'object')
   ) {
-    return $(z)
-      .attr(identifiers.intersection)
-      .call(...childResults.map((result) => result.chain));
+    let chain = childResults[0]!.chain;
+
+    if (childResults[1]) {
+      chain = $(z).attr(identifiers.intersection).call(chain, chainOrLazy(childResults[1]));
+    }
+
+    childResults.slice(2).forEach((item) => {
+      chain = chain.attr(identifiers.and).call(chainOrLazy(item));
+    });
+
+    return chain;
   }
 
   let chain = childResults[0]!.chain;
   childResults.slice(1).forEach((item) => {
-    chain = chain
-      .attr(identifiers.and)
-      .call(
-        item.meta.hasLazy && !item.meta.isLazy
-          ? $(z).attr(identifiers.lazy).call($.func().do(item.chain.return()))
-          : item.chain,
-      );
+    chain = chain.attr(identifiers.and).call(chainOrLazy(item));
   });
 
   return chain;

--- a/packages/openapi-ts/src/plugins/zod/v4/toAst/intersection.ts
+++ b/packages/openapi-ts/src/plugins/zod/v4/toAst/intersection.ts
@@ -8,6 +8,11 @@ function baseNode(ctx: IntersectionResolverContext): Chain {
   const { childResults, schemas } = ctx;
   const { z } = ctx.plugin.imports;
 
+  const chainOrLazy = (item: ZodResult): Chain =>
+    item.meta.hasLazy
+      ? $(z).attr(identifiers.lazy).call($.func().do(item.chain.return()))
+      : item.chain;
+
   if (!childResults.length) {
     return $(z).attr(identifiers.never).call();
   }
@@ -18,20 +23,22 @@ function baseNode(ctx: IntersectionResolverContext): Chain {
     firstSchema?.logicalOperator === 'or' ||
     (firstSchema?.type && firstSchema.type !== 'object')
   ) {
-    return $(z)
-      .attr(identifiers.intersection)
-      .call(...childResults.map((result) => result.chain));
+    let chain = childResults[0]!.chain;
+
+    if (childResults[1]) {
+      chain = $(z).attr(identifiers.intersection).call(chain, chainOrLazy(childResults[1]));
+    }
+
+    childResults.slice(2).forEach((item) => {
+      chain = chain.attr(identifiers.and).call(chainOrLazy(item));
+    });
+
+    return chain;
   }
 
   let chain = childResults[0]!.chain;
   childResults.slice(1).forEach((item) => {
-    chain = chain
-      .attr(identifiers.and)
-      .call(
-        item.meta.hasLazy
-          ? $(z).attr(identifiers.lazy).call($.func().do(item.chain.return()))
-          : item.chain,
-      );
+    chain = chain.attr(identifiers.and).call(chainOrLazy(item));
   });
 
   return chain;


### PR DESCRIPTION
## Summary

Chains generated Zod v3/v4 intersections when `allOf` has more than two members and starts with a non-object/`oneOf` schema, so generated validators keep every member instead of emitting a variadic `z.intersection(...)` call.

Adds regression coverage for Zod v3, Zod v4, and Zod Mini output.

Tests:
- `pnpm --filter @hey-api/openapi-ts... build`
- `pnpm exec vitest run --project @hey-api/openapi-ts src/__tests__/index.test.ts -t 'chains zod intersections'`
- `pnpm exec oxfmt --check packages/openapi-ts/src/plugins/zod/v3/toAst/intersection.ts packages/openapi-ts/src/plugins/zod/v4/toAst/intersection.ts packages/openapi-ts/src/__tests__/index.test.ts`
- `pnpm exec oxlint packages/openapi-ts/src/plugins/zod/v3/toAst/intersection.ts packages/openapi-ts/src/plugins/zod/v4/toAst/intersection.ts packages/openapi-ts/src/__tests__/index.test.ts`
- `pnpm --filter @hey-api/openapi-ts typecheck`
- `git diff --check`

## Linked issues

Closes: #4297
Related to:

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
