### PR TITLE
fix(client-angular): support AbortSignal cancellation

### DIFF
--- a/.changeset/tidy-cats-cancel.md
+++ b/.changeset/tidy-cats-cancel.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+**plugin(@hey-api/client-angular)**: abort HTTP requests when their `AbortSignal` is aborted

--- a/examples/openapi-ts-angular-common/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/examples/openapi-ts-angular/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-angular/src/client/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen.ts';
 import type { HttpMethod } from '../core/types.gen.ts';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen.js';
 import type { HttpMethod } from '../core/types.gen.js';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen.js';
 import type { HttpMethod } from '../core/types.gen.js';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/client.gen.ts
@@ -8,8 +8,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
@@ -143,11 +143,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
@@ -1,7 +1,83 @@
 import type { HttpClient } from '@angular/common/http';
-import { HttpContext, HttpHeaders } from '@angular/common/http';
+import { HttpContext, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
 
 import { createClient } from '../bundle/client';
+
+describe('AbortSignal', () => {
+  it('does not start an HTTP request when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = new DOMException('The operation was aborted', 'AbortError');
+    const transformedError = { message: 'Request was aborted', type: 'abort' };
+    controller.abort(reason);
+    const request = vi.fn();
+    const errorInterceptor = vi.fn(() => transformedError);
+    const client = createClient({
+      baseUrl: 'https://example.com',
+      httpClient: { request } as unknown as HttpClient,
+      signal: controller.signal,
+    });
+    client.interceptors.error.use(errorInterceptor);
+
+    const result = await client.get({ url: '/test' });
+
+    expect(request).not.toHaveBeenCalled();
+    expect(errorInterceptor).toHaveBeenCalledWith(
+      reason,
+      undefined,
+      expect.anything(),
+      expect.objectContaining({ url: '/test' }),
+    );
+    expect(result).toMatchObject({ error: transformedError });
+  });
+
+  it('unsubscribes from an in-flight HTTP request when the signal is aborted', async () => {
+    const controller = new AbortController();
+    const reason = new DOMException('The operation was aborted', 'AbortError');
+    const subscribed = vi.fn();
+    const teardown = vi.fn();
+    const request = vi.fn(
+      () =>
+        new Observable(() => {
+          subscribed();
+          return teardown;
+        }),
+    );
+    const client = createClient({ baseUrl: 'https://example.com' });
+
+    const result = client.get({
+      httpClient: { request } as unknown as HttpClient,
+      signal: controller.signal,
+      throwOnError: true,
+      url: '/test',
+    });
+    await vi.waitFor(() => expect(subscribed).toHaveBeenCalledOnce());
+
+    controller.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+    expect(teardown).toHaveBeenCalledOnce();
+  });
+
+  it('does not react when the signal is aborted after a successful response', async () => {
+    const controller = new AbortController();
+    const errorInterceptor = vi.fn((error) => error);
+    const request = vi.fn(() => of(new HttpResponse({ body: { success: true } })));
+    const client = createClient({ baseUrl: 'https://example.com' });
+    client.interceptors.error.use(errorInterceptor);
+
+    const result = await client.get({
+      httpClient: { request } as unknown as HttpClient,
+      signal: controller.signal,
+      throwOnError: true,
+      url: '/test',
+    });
+    controller.abort();
+
+    expect(result.data).toEqual({ success: true });
+    expect(errorInterceptor).not.toHaveBeenCalled();
+  });
+});
 
 describe('buildUrl', () => {
   const client = createClient();

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from '@angular/common/http';
-import { HttpContext, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { HttpContext, HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 
 import { createClient } from '../bundle/client';
@@ -56,6 +56,40 @@ describe('AbortSignal', () => {
     controller.abort(reason);
 
     await expect(result).rejects.toBe(reason);
+    expect(teardown).toHaveBeenCalledOnce();
+  });
+
+  it('preserves a regular HTTP error when the signal is not aborted', async () => {
+    const controller = new AbortController();
+    const error = { message: 'Request failed', type: 'http' };
+    const response = new HttpErrorResponse({ error, status: 500 });
+    const teardown = vi.fn();
+    const request = vi.fn(
+      () =>
+        new Observable((subscriber) => {
+          subscriber.error(response);
+          return teardown;
+        }),
+    );
+    const errorInterceptor = vi.fn(() => ({ message: 'Transformed request error', type: 'http' }));
+    const client = createClient({ baseUrl: 'https://example.com' });
+    client.interceptors.error.use(errorInterceptor);
+
+    const result = client.get({
+      httpClient: { request } as unknown as HttpClient,
+      signal: controller.signal,
+      throwOnError: true,
+      url: '/test',
+    });
+
+    await expect(result).rejects.toEqual({ message: 'Transformed request error', type: 'http' });
+    expect(controller.signal.aborted).toBe(false);
+    expect(errorInterceptor).toHaveBeenCalledWith(
+      error,
+      response,
+      expect.anything(),
+      expect.objectContaining({ url: '/test' }),
+    );
     expect(teardown).toHaveBeenCalledOnce();
   });
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
@@ -6,8 +6,8 @@ import {
   provideAppInitializer,
   runInInjectionContext,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { firstValueFrom, fromEvent } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { createSseClient } from '../../client-core/bundle/serverSentEvents';
 import type { HttpMethod } from '../../client-core/bundle/types';
@@ -141,11 +141,24 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
-      );
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason;
+      }
+
+      const response$ = opts
+        .httpClient!.request(req)
+        .pipe(filter((event) => event.type === HttpEventType.Response));
+
+      try {
+        result.response = await firstValueFrom(
+          opts.signal ? response$.pipe(takeUntil(fromEvent(opts.signal, 'abort'))) : response$,
+        );
+      } catch (error) {
+        if (opts.signal?.aborted) {
+          throw opts.signal.reason;
+        }
+        throw error;
+      }
 
       for (const fn of interceptors.response.fns) {
         if (fn) {


### PR DESCRIPTION
## Summary

- connect `AbortSignal` to the Angular `HttpClient` observable
- avoid starting requests whose signal is already aborted
- unsubscribe from in-flight requests when the signal aborts
- preserve existing error interceptor, `throwOnError`, success, and no-signal behavior
- cover the normal `HttpClient` error path with an active signal: it remains a normal error, preserves the external signal, and tears down once
- add focused tests and refresh generated Angular examples and snapshots

`@hey-api/client-angular` already exposes `signal` through its shared request options, but its runtime awaited the `HttpClient` observable without observing that signal. This left generated Angular SDK requests running after cancellation.

## Linked issues

Closes: #4303
Related to:

## Validation

- `pnpm exec vitest run packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts` (21 passed)
- `pnpm exec vitest run --coverage packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts` (21 passed; exercises the normal-error rethrow branch)
- `pnpm ty @hey-api/openapi-ts`
- `oxfmt --check` and `oxlint` for the changed test
- Previous full validation on the original patch:
  - `pnpm exec vitest run --project @test/openapi-ts` (323 passed, 1 skipped)
  - `pnpm lint`
  - `pnpm examples:check`
  - `pnpm build --filter="@hey-api/**"`

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.