### PR TITLE
feat(client-angular): support onUploadProgress/onDownloadProgress request options

### DIFF
--- a/.changeset/wise-otters-dance.md
+++ b/.changeset/wise-otters-dance.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": minor
+---
+
+**feat(client-angular)**: support `onUploadProgress`/`onDownloadProgress` request options for upload/download progress tracking

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import type { HttpClient } from '@angular/common/http';
-import { HttpContext, HttpHeaders } from '@angular/common/http';
+import { HttpContext, HttpEventType, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { of } from 'rxjs';
 
 import { createClient } from '../bundle/client';
 
@@ -124,6 +125,54 @@ describe('context', () => {
     });
 
     expect(request.context).toBe(context);
+  });
+});
+
+describe('progress', () => {
+  const client = createClient({ baseUrl: 'https://example.com' });
+
+  it('does not enable reportProgress by default', () => {
+    const request = client.requestOptions({
+      httpClient: vi.fn() as Partial<HttpClient> as HttpClient,
+      url: '/test',
+    });
+
+    expect(request.reportProgress).toBe(false);
+  });
+
+  it('enables reportProgress when onUploadProgress or onDownloadProgress is provided', () => {
+    const request = client.requestOptions({
+      httpClient: vi.fn() as Partial<HttpClient> as HttpClient,
+      onUploadProgress: () => {},
+      url: '/test',
+    });
+
+    expect(request.reportProgress).toBe(true);
+  });
+
+  it('forwards upload and download progress events to their callbacks', async () => {
+    const onUploadProgress = vi.fn();
+    const onDownloadProgress = vi.fn();
+
+    const uploadEvent = { loaded: 50, total: 100, type: HttpEventType.UploadProgress };
+    const downloadEvent = { loaded: 75, total: 100, type: HttpEventType.DownloadProgress };
+    const responseEvent = new HttpResponse({ body: { ok: true }, status: 200 });
+
+    const httpClient = {
+      request: vi.fn(() => of(uploadEvent, downloadEvent, responseEvent)),
+    } as unknown as HttpClient;
+
+    const result = await client.request({
+      httpClient,
+      method: 'GET',
+      onDownloadProgress,
+      onUploadProgress,
+      url: '/test',
+    });
+
+    expect(onUploadProgress).toHaveBeenCalledWith(uploadEvent);
+    expect(onDownloadProgress).toHaveBeenCalledWith(downloadEvent);
+    expect(result.response).toBe(responseEvent);
   });
 });
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
@@ -7,7 +7,7 @@ import {
   runInInjectionContext,
 } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, tap } from 'rxjs/operators';
 
 import { createSseClient } from '../../client-core/bundle/serverSentEvents';
 import type { HttpMethod } from '../../client-core/bundle/types';
@@ -87,9 +87,13 @@ export const createClient = (config: Config = {}): Client => {
 
     const url = buildUrl(opts as Config & RequestOptions);
 
+    const reportProgress =
+      opts.reportProgress ?? Boolean(opts.onUploadProgress || opts.onDownloadProgress);
+
     const req = new HttpRequest<unknown>(opts.method ?? 'GET', url, getValidRequestBody(opts), {
       redirect: 'follow',
       ...opts,
+      reportProgress,
     });
 
     return { opts, req, url };
@@ -142,9 +146,16 @@ export const createClient = (config: Config = {}): Client => {
       }
 
       result.response = await firstValueFrom(
-        opts
-          .httpClient!.request(req)
-          .pipe(filter((event) => event.type === HttpEventType.Response)),
+        opts.httpClient!.request(req).pipe(
+          tap((event) => {
+            if (event.type === HttpEventType.UploadProgress) {
+              opts.onUploadProgress?.(event);
+            } else if (event.type === HttpEventType.DownloadProgress) {
+              opts.onDownloadProgress?.(event);
+            }
+          }),
+          filter((event) => event.type === HttpEventType.Response),
+        ),
       );
 
       for (const fn of interceptors.response.fns) {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/types.ts
@@ -3,6 +3,7 @@ import type {
   HttpContext,
   HttpErrorResponse,
   HttpHeaders,
+  HttpProgressEvent,
   HttpRequest,
   HttpResponse,
 } from '@angular/common/http';
@@ -92,8 +93,31 @@ export interface RequestOptions<
    * Optional custom injector for dependency resolution if you don't implicitly or explicitly provide one.
    */
   injector?: Injector;
+  /**
+   * Callback invoked with `HttpEventType.DownloadProgress` events. Setting
+   * this (or {@link onUploadProgress}) automatically enables `reportProgress`
+   * on the underlying `HttpRequest`.
+   *
+   * {@link https://angular.dev/api/common/http/HttpProgressEvent See more}
+   */
+  onDownloadProgress?: (event: HttpProgressEvent) => void;
+  /**
+   * Callback invoked with `HttpEventType.UploadProgress` events. Setting
+   * this (or {@link onDownloadProgress}) automatically enables
+   * `reportProgress` on the underlying `HttpRequest`.
+   *
+   * {@link https://angular.dev/api/common/http/HttpProgressEvent See more}
+   */
+  onUploadProgress?: (event: HttpProgressEvent) => void;
   path?: Record<string, unknown>;
   query?: Record<string, unknown>;
+  /**
+   * Whether the underlying `HttpRequest` should report progress events.
+   * Automatically enabled when {@link onUploadProgress} or
+   * {@link onDownloadProgress} is provided, but can be set explicitly to
+   * request progress events without a callback.
+   */
+  reportProgress?: boolean;
   /**
    * Security mechanism(s) to use for the request.
    */

--- a/web/src/content/docs/docs/openapi/typescript/clients/angular/v19.mdx
+++ b/web/src/content/docs/docs/openapi/typescript/clients/angular/v19.mdx
@@ -199,6 +199,21 @@ This section is under construction. We appreciate your patience.
 This section is under construction. We appreciate your patience.
 :::
 
+## Progress Events
+
+If you need upload or download progress, pass `onUploadProgress` and/or `onDownloadProgress` callbacks to your request. This automatically enables `reportProgress` on the underlying `HttpRequest`, so you no longer need to clone the request yourself to opt into Angular's `reportProgress`/`observe: 'events'` behavior.
+
+```js title="src/index.ts"
+const response = await getFoo({
+  onDownloadProgress: (event) => {
+    console.log(event.loaded, event.total);
+  },
+  onUploadProgress: (event) => {
+    console.log(event.loaded, event.total);
+  },
+});
+```
+
 ## Build URL
 
 If you need to access the compiled URL, you can use the `buildUrl()` method. It's loosely typed by default to accept almost any value; in practice, you will want to pass a type hint.

--- a/web/src/content/docs/docs/openapi/typescript/clients/angular/v20.mdx
+++ b/web/src/content/docs/docs/openapi/typescript/clients/angular/v20.mdx
@@ -201,6 +201,21 @@ This section is under construction. We appreciate your patience.
 This section is under construction. We appreciate your patience.
 :::
 
+## Progress Events
+
+If you need upload or download progress, pass `onUploadProgress` and/or `onDownloadProgress` callbacks to your request. This automatically enables `reportProgress` on the underlying `HttpRequest`, so you no longer need to clone the request yourself to opt into Angular's `reportProgress`/`observe: 'events'` behavior.
+
+```js title="src/index.ts"
+const response = await getFoo({
+  onDownloadProgress: (event) => {
+    console.log(event.loaded, event.total);
+  },
+  onUploadProgress: (event) => {
+    console.log(event.loaded, event.total);
+  },
+});
+```
+
 ## Build URL
 
 If you need to access the compiled URL, you can use the `buildUrl()` method. It's loosely typed by default to accept almost any value; in practice, you will want to pass a type hint.


### PR DESCRIPTION
## Summary
- Resolves #2065 — adds `onUploadProgress`/`onDownloadProgress` request options to the Angular client, so upload/download progress tracking no longer requires cloning the generated `HttpRequest` and manually setting `reportProgress`/`observe`.
- `reportProgress` is auto-enabled on the underlying `HttpRequest` when either callback is provided; progress events are forwarded via the callbacks while the final `Response` event still resolves the request as before.

## Test plan
- [x] Added unit tests covering d`, auto-enabling on callbackpresence, and progress events reaching the correct callbacks
- [x] `pnpm typecheck` and `pnpm
- [x] Added a changeset and docs section (v19/v20 Angular client pages)