### PR TITLE
fix(tanstack): skip useMutation for SSE operations

### DIFF
--- a/.changeset/swift-hares-guard.md
+++ b/.changeset/swift-hares-guard.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@tanstack/query)**: skip `useMutation` for SSE operations

--- a/packages/openapi-ts-tests/tanstack-query/v5/test/3.1.x.test.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/test/3.1.x.test.ts
@@ -47,7 +47,13 @@ describe(`OpenAPI ${version}`, () => {
       config: createConfig({
         input: 'sse-post.yaml',
         output: 'sse-react-query',
-        plugins: ['@hey-api/client-fetch', '@tanstack/react-query'],
+        plugins: [
+          '@hey-api/client-fetch',
+          {
+            name: '@tanstack/react-query',
+            useMutation: true,
+          },
+        ],
       }),
       description: 'SSE POST endpoint is excluded from TanStack React Query mutations',
     },

--- a/packages/openapi-ts/src/__tests__/index.test.ts
+++ b/packages/openapi-ts/src/__tests__/index.test.ts
@@ -380,7 +380,7 @@ describe('createClient', () => {
 
     const queryFile = context?.gen
       .render()
-      .find((file) => file.path.endsWith('@tanstack/react-query.gen.ts'));
+      .find((file) => file.path.replaceAll('\\', '/').endsWith('@tanstack/react-query.gen.ts'));
 
     expect(queryFile).toBeDefined();
     expect(queryFile!.content).not.toContain('useSubscribeToEventStreamMutation');

--- a/packages/openapi-ts/src/__tests__/index.test.ts
+++ b/packages/openapi-ts/src/__tests__/index.test.ts
@@ -325,4 +325,64 @@ describe('createClient', () => {
 
     expect(results.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('excludes SSE POST operations from TanStack Query mutations', async () => {
+    const [context] = await createClient({
+      dryRun: true,
+      input: {
+        info: { title: 'sse-post-test', version: '1.0.0' },
+        openapi: '3.1.0',
+        paths: {
+          '/events': {
+            get: {
+              operationId: 'listEvents',
+              responses: {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: { items: { type: 'string' }, type: 'array' },
+                    },
+                  },
+                  description: 'Events',
+                },
+              },
+            },
+          },
+          '/events/subscribe': {
+            post: {
+              operationId: 'subscribeToEventStream',
+              responses: {
+                200: {
+                  content: {
+                    'text/event-stream': {
+                      schema: { type: 'object' },
+                    },
+                  },
+                  description: 'Event stream',
+                },
+              },
+            },
+          },
+        },
+      },
+      logs: { level: 'silent' },
+      output: 'output',
+      plugins: [
+        '@hey-api/typescript',
+        '@hey-api/sdk',
+        '@hey-api/client-fetch',
+        {
+          name: '@tanstack/react-query',
+          useMutation: true,
+        },
+      ],
+    });
+
+    const queryFile = context?.gen
+      .render()
+      .find((file) => file.path.endsWith('@tanstack/react-query.gen.ts'));
+
+    expect(queryFile).toBeDefined();
+    expect(queryFile!.content).not.toContain('useSubscribeToEventStreamMutation');
+  });
 });

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/v5/use-mutation.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/v5/use-mutation.ts
@@ -2,7 +2,7 @@ import type { IR } from '@hey-api/shared';
 import { applyNaming } from '@hey-api/shared';
 
 import { $ } from '../../../../ts-dsl';
-import { createOperationComment } from '../../../shared/utils/operation';
+import { createOperationComment, hasOperationSse } from '../../../shared/utils/operation';
 import { useTypeData, useTypeError, useTypeResponse } from '../shared/use-type';
 import type { PluginInstance } from '../types';
 
@@ -15,6 +15,8 @@ export function createUseMutation({
   operation: IR.OperationObject;
   plugin: PluginInstance;
 }): void {
+  if (hasOperationSse({ operation })) return;
+
   if (!('useMutation' in plugin.config)) return;
 
   const symbolUseMutationFn = plugin.symbol(applyNaming(operation.id, plugin.config.useMutation));


### PR DESCRIPTION
## Summary

TanStack `useMutation` generation referenced a mutation-options symbol that is intentionally absent for SSE operations, causing the planner failure. The generator now skips the wrapper for SSE operations. The existing SSE scenario enables `useMutation` as a regression test. Ordinary mutation generation is unchanged.

## Validation

- `pnpm tt packages/openapi-ts-tests/tanstack-query/v5/test/3.1.x.test.ts @test/openapi-ts-tanstack-query-v5`
- `pnpm ty @hey-api/openapi-ts`
- touched-file format and lint checks

## Linked issues

Closes: #4330
Related to:

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
