### PR TITLE
fix: Dates shouldn't get unwrapped

### DIFF
--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
@@ -144,9 +144,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/utils.gen.ts
@@ -348,7 +348,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
@@ -142,9 +142,10 @@ export const createClient = (config: Config = {}): Client => {
       watch(bodyParams, (changed) => {
         body.value = serializeBody(changed);
       });
+      const {url, baseURL, query, ...cleanedOpts} = opts;
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
-        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
+        ? useLazyFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...cleanedOpts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/utils.ts
@@ -346,7 +346,8 @@ export const unwrapRefs = <T>(value: T): UnwrapRefs<T> => {
     value instanceof Blob ||
     value instanceof FormData ||
     value instanceof ReadableStream ||
-    value instanceof AbortSignal
+    value instanceof AbortSignal ||
+    value instanceof Date
   ) {
     return value as UnwrapRefs<T>;
   }


### PR DESCRIPTION
## Summary

The unwrap function in `utils.gen.ts` try to unwrap Date objects, but create empty objects instead.

<!-- What does this change, and why? -->

## Linked issues

Closes: https://github.com/hey-api/hey-api/issues/4334
Related to:

## Certification

<!-- Do not remove the line below. -->

- [ ] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
