### PR TITLE
fix(examples): iterate only HTTP methods over path item members

### DIFF
--- a/.changeset/eleven-hoops-smile.md
+++ b/.changeset/eleven-hoops-smile.md
@@ -1,5 +1,6 @@
 ---
 "@hey-api/openapi-ts": patch
+"@hey-api/shared": patch
 ---
 
 **plugin(examples)**: fix crash on non-object path item members (e.g. `x-internal: true`, path-level `summary`) and stop skipping operations that define `summary`, `description`, or `parameters`

--- a/.changeset/eleven-hoops-smile.md
+++ b/.changeset/eleven-hoops-smile.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(examples)**: fix crash on non-object path item members (e.g. `x-internal: true`, path-level `summary`) and stop skipping operations that define `summary`, `description`, or `parameters`

--- a/packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts
@@ -3,6 +3,8 @@ import { toCase } from '@hey-api/shared';
 import { $ } from '../../../ts-dsl';
 import type { HeyApiExamplesPlugin } from './types';
 
+const httpMethods = new Set(['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace']);
+
 export const handler: HeyApiExamplesPlugin['Handler'] = ({ plugin }) => {
   const spec = plugin.context.spec as {
     components?: {
@@ -65,14 +67,14 @@ export const handler: HeyApiExamplesPlugin['Handler'] = ({ plugin }) => {
 
   for (const [, pathItem] of Object.entries(spec.paths)) {
     for (const [key, operation] of Object.entries(pathItem)) {
-      if (key.startsWith('x-')) {
-        continue;
-      }
-      if ('parameters' in operation || 'summary' in operation || 'description' in operation) {
+      // path items contain non-operation members (`parameters`, `summary`,
+      // `servers`, `x-` extensions, ...) whose values may be primitives —
+      // only iterate HTTP methods so property checks below are safe
+      if (!httpMethods.has(key)) {
         continue;
       }
 
-      if (!('responses' in operation) || !operation.responses) {
+      if (!operation.responses) {
         continue;
       }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/examples/plugin.ts
@@ -1,9 +1,7 @@
-import { toCase } from '@hey-api/shared';
+import { httpMethods, toCase } from '@hey-api/shared';
 
 import { $ } from '../../../ts-dsl';
 import type { HeyApiExamplesPlugin } from './types';
-
-const httpMethods = new Set(['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace']);
 
 export const handler: HeyApiExamplesPlugin['Handler'] = ({ plugin }) => {
   const spec = plugin.context.spec as {
@@ -70,7 +68,7 @@ export const handler: HeyApiExamplesPlugin['Handler'] = ({ plugin }) => {
       // path items contain non-operation members (`parameters`, `summary`,
       // `servers`, `x-` extensions, ...) whose values may be primitives —
       // only iterate HTTP methods so property checks below are safe
-      if (!httpMethods.has(key)) {
+      if (!httpMethods.includes(key as (typeof httpMethods)[number])) {
         continue;
       }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -103,6 +103,7 @@ export {
   discriminatorValues,
 } from './openApi/shared/utils/discriminator';
 export { buildGraph } from './openApi/shared/utils/graph';
+export { httpMethods } from './openApi/shared/utils/operation';
 export { patchOpenApiSpec } from './openApi/shared/utils/patch';
 export type {
   OpenApi,

--- a/specs/3.0.x/response-example.yaml
+++ b/specs/3.0.x/response-example.yaml
@@ -4,7 +4,12 @@ info:
   version: 1
 paths:
   /foo:
+    summary: Foo operations
+    description: Path-level description
+    x-internal: true
     post:
+      summary: Create a foo
+      description: Creates a foo and returns it.
       requestBody:
         content:
           'text/plain':

--- a/specs/3.1.x/response-example.yaml
+++ b/specs/3.1.x/response-example.yaml
@@ -4,7 +4,12 @@ info:
   version: 1
 paths:
   /foo:
+    summary: Foo operations
+    description: Path-level description
+    x-internal: true
     post:
+      summary: Create a foo
+      description: Creates a foo and returns it.
       requestBody:
         content:
           'text/plain':


### PR DESCRIPTION
## Summary

The `@hey-api/examples` plugin handler iterates every member of every path item and immediately uses the `in` operator on the value. Path items may legally contain members whose values are primitives, which crashes generation:

- `x-internal: true` (boolean vendor extension) → `Cannot use 'in' operator to search for 'parameters' in true` — fixed on `main` by the recent `key.startsWith('x-')` guard, but:
- path-level `summary` / `description` (strings, per the OpenAPI 3.0/3.1 Path Item Object) still crash the same way: `Cannot use 'in' operator to search for 'parameters' in Path-level summary`.

Additionally, the guard `'parameters' in operation || 'summary' in operation || 'description' in operation` tests the *operation object's own keys* — but operations routinely define `summary`, `description`, and `parameters`, so any operation carrying one of them was skipped entirely and operation example factories were rarely generated for real-world specs.

This PR replaces the key-name guards with an HTTP-method allowlist: only `delete/get/head/options/patch/post/put/trace` entries are treated as operations, which makes the downstream property checks safe and stops skipping legitimate operations.

Verified against the repro spec in the linked issue: generation no longer crashes on `x-internal: true` + path-level `summary`, and the operation example factory is now generated for an operation that defines a `summary`.

## Linked issues

Closes #4343

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)