### PR TITLE
fix(client): don't call Headers.forEach in a detached realm

### DIFF
--- a/.changeset/smooth-pots-jump.md
+++ b/.changeset/smooth-pots-jump.md
@@ -1,0 +1,7 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: avoid `Headers.forEach` in `mergeHeaders` so requests don't fail in a detached realm
+
+`Headers.forEach` is a Web IDL callback, so Blink refuses to invoke it once the owning realm is detached and throws `Failed to execute 'forEach' on 'Headers': The provided callback is no longer runnable.` `mergeHeaders` now iterates `Headers.entries()` and only falls back to `forEach` when `entries` is missing.

--- a/examples/openapi-ts-fastify/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-fetch/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-ky/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-ky/src/client/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-nestjs/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-next/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-next/src/client/client/utils.gen.ts
@@ -282,6 +282,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-ofetch/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-ofetch/src/client/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-openai/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-pinia-colada/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer-duplicate/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer-duplicate/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-false/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-number/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-strict/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-string/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/clean-false/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/default/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/import-file-extension-ts/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-optional/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-required/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-node16-sdk/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer-duplicate/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer-duplicate/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/utils.gen.ts
@@ -285,6 +285,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/utils.gen.ts
@@ -253,6 +253,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/client/utils.gen.ts
@@ -207,6 +207,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-temporal-global/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-temporal-global/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-temporal-polyfill/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-temporal-polyfill/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/asClass/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/full-config/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/full-config/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/2.0.x/plugins/name-builder/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/internal-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/internal-name-conflict/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/asClass/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/full-config/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/full-config/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.0.x/plugins/name-builder/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/internal-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/internal-name-conflict/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/angular-query-experimental/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/angular-query-experimental/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/preact-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/preact-query/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/react-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/react-query/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/solid-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/solid-query/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/svelte-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/svelte-query/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/vue-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/meta-function/vue-query/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/pagination-ref/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/pagination-ref/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/asClass/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/fetch/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/full-config/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/full-config/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/plugins/name-builder/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/query-options-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/query-options-name-conflict/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/sse-react-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/sse-react-query/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/transformer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/transformer/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/transformer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/transformer/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/transformer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/transformer/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/utils.gen.ts
@@ -176,6 +176,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/utils.ts
@@ -174,6 +174,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/utils.ts
@@ -172,6 +172,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/utils.ts
@@ -283,6 +283,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/utils.ts
@@ -251,6 +251,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ofetch/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ofetch/bundle/utils.ts
@@ -205,6 +205,12 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
 };
 
 const headersEntries = (headers: Headers): Array<[string, string]> => {
+  // `forEach` is a Web IDL callback: Blink refuses to invoke it in a detached
+  // realm ("The provided callback is no longer runnable"). Iterate instead, and
+  // keep `forEach` for runtimes that don't expose `Headers.entries`.
+  if (typeof headers.entries === 'function') {
+    return Array.from(headers.entries());
+  }
   const entries: Array<[string, string]> = [];
   headers.forEach((value, key) => {
     entries.push([key, value]);


### PR DESCRIPTION
## Summary

`mergeHeaders` reads an incoming `Headers` via `headersEntries`, which uses `Headers.forEach`. That's a Web IDL callback, so Blink checks `IsCallbackFunctionRunnable()` before invoking it and throws once the callback's realm is detached:

> Failed to execute 'forEach' on 'Headers': The provided callback is no longer runnable.

`mergeHeaders` runs from `resolveOptions` on every request, so the request fails before it ever reaches the network and the app sees an opaque `Headers` error instead of a normal request failure. We hit this in production on Android WebView, where the document is torn down while a file upload is in flight.

Iterate `Headers.entries()` instead — an iterator, not a Web IDL callback, so it has no runnable-callback check.

```ts
const headersEntries = (headers: Headers): Array<[string, string]> => {
  if (typeof headers.entries === 'function') {
    return Array.from(headers.entries());
  }
  const entries: Array<[string, string]> = [];
  headers.forEach((value, key) => {
    entries.push([key, value]);
  });
  return entries;
};
```

`forEach` stays as a fallback behind a `typeof headers.entries === 'function'` guard, so the Node compatibility fix from 39feae97 is preserved. The guard tests `entries` rather than `Symbol.iterator` to avoid referencing `Symbol` in ES5 targets.

Applied to all five client bundles (`fetch`, `ky`, `next`, `nuxt`, `ofetch`) plus regenerated snapshots — the bulk of the diff is snapshots; the substantive change is 5 files plus the changeset.

Left `packages/shared/src/getSpec.ts` alone — same helper, but it runs in the CLI where detached realms don't exist. Happy to align it if you'd rather keep the two identical.

Verified in Chrome 148 that `forEach` throws and `entries()` does not under the same conditions; the snippet is in the linked issue.

## Linked issues

Closes: #4377

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
