### PR TITLE
fix: bump js-yaml to 5.3.0

### DIFF
--- a/.changeset/tall-yaks-guard.md
+++ b/.changeset/tall-yaks-guard.md
@@ -1,0 +1,6 @@
+---
+"@hey-api/json-schema-ref-parser": patch
+"@hey-api/shared": patch
+---
+
+**fix**: bump js-yaml to 5.3.0 to resolve GHSA-724g-mxrg-4qvm

--- a/packages/json-schema-ref-parser/package.json
+++ b/packages/json-schema-ref-parser/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@jsdevtools/ono": "7.1.3",
     "@types/json-schema": "7.0.15",
-    "js-yaml": "5.2.0"
+    "js-yaml": "5.3.0"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/bun": "1.3.14",
     "@types/js-yaml": "4.0.9",
-    "js-yaml": "5.2.0",
+    "js-yaml": "5.3.0",
     "typescript": "6.0.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1107,8 +1107,8 @@ importers:
         specifier: 7.0.15
         version: 7.0.15
       js-yaml:
-        specifier: 5.2.0
-        version: 5.2.0
+        specifier: 5.3.0
+        version: 5.3.0
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
@@ -1526,8 +1526,8 @@ importers:
         specifier: 4.0.9
         version: 4.0.9
       js-yaml:
-        specifier: 5.2.0
-        version: 5.2.0
+        specifier: 5.3.0
+        version: 5.3.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -10035,8 +10035,8 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -23560,7 +23560,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.0:
+  js-yaml@5.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

Bumps the direct js-yaml dependency from 5.2.0 to 5.3.0 in @hey-api/shared and @hey-api/json-schema-ref-parser, resolving GHSA-724g-mxrg-4qvm. Includes a minimal lockfile update (verified with pnpm install --frozen-lockfile) and a changeset releasing both packages as a patch. Builds, typechecks, and the openapi-ts test suite (2407 tests) pass.

## Linked issues

Closes: #4274


## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
