### PR TITLE
fix(shared): strip apostrophe from generated method/type names

### DIFF
--- a/packages/shared/src/utils/naming/__tests__/naming.test.ts
+++ b/packages/shared/src/utils/naming/__tests__/naming.test.ts
@@ -199,6 +199,13 @@ const scenarios: ReadonlyArray<{
     snake_case: 'z3e_num_1_период',
     value: 'z3e-num_1Период',
   },
+  {
+    PascalCase: 'ShowTheDogSTail',
+    SCREAMING_SNAKE_CASE: 'SHOW_THE_DOG_S_TAIL',
+    camelCase: 'showTheDogSTail',
+    snake_case: 'show_the_dog_s_tail',
+    value: "show the dog's tail",
+  },
 ];
 
 describe('toCase', () => {

--- a/packages/shared/src/utils/naming/naming.ts
+++ b/packages/shared/src/utils/naming/naming.ts
@@ -3,7 +3,7 @@ import type { Casing, NamingConfig, NamingRule } from './types';
 const uppercaseRegExp = /[\p{Lu}]/u;
 const lowercaseRegExp = /[\p{Ll}]/u;
 const identifierRegExp = /([\p{Alpha}\p{N}_]|$)/u;
-const separatorsRegExp = /[_.$+:\- `\\[\](){}\\/]+/;
+const separatorsRegExp = /[_.$+:\- `\\[\](){}\\/']+/;
 
 const leadingSeparatorsRegExp = new RegExp(`^${separatorsRegExp.source}`);
 const separatorsAndIdentifierRegExp = new RegExp(


### PR DESCRIPTION
Closes #4296

## Summary

Add `'` to `separatorsRegExp` in `packages/shared/src/utils/naming/naming.ts`. Apostrophes are now stripped (like `-`, `_`, spaces), so `"show the dog's tail"` → `showTheDogSTail` instead of the broken `showTheDog'sTail`.

## Verification

- `packages/shared` naming tests: 125 pass (added a scenario for `"show the dog's tail"`).
- The invalid `showTheDog'sTail` no longer generates — `toCase` produces `showTheDogSTail`.

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.