### PR TITLE
fix(web): improve floating bar contrast on mobile

### DIFF
--- a/web/src/components/FloatingPill.astro
+++ b/web/src/components/FloatingPill.astro
@@ -46,7 +46,7 @@ const { items } = Astro.props;
 <style>
   .floating-pill-group {
     align-items: center;
-    background: rgba(255, 255, 255, 0.12);
+    background: rgba(30, 30, 46, 0.5);
     backdrop-filter: blur(12px) saturate(160%);
     -webkit-backdrop-filter: blur(12px) saturate(160%);
     border-radius: 999px;

--- a/web/src/components/FloatingPill.astro
+++ b/web/src/components/FloatingPill.astro
@@ -46,7 +46,7 @@ const { items } = Astro.props;
 <style>
   .floating-pill-group {
     align-items: center;
-    background: rgba(30, 30, 46, 0.5);
+    background: rgba(30, 30, 46, 0.4);
     backdrop-filter: blur(12px) saturate(160%);
     -webkit-backdrop-filter: blur(12px) saturate(160%);
     border-radius: 999px;


### PR DESCRIPTION
## Summary

- Fixes the floating navigation bar on mobile, where its transparent background allows underlying page content to show through and reduces the visibility of the controls.
- Improves the navigation bar's visual contrast while preserving the existing design.
- Attached screenshots demonstrate the visual difference before and after the change.

<img width="300" height="700" alt="Before" src="https://github.com/user-attachments/assets/bd3c215b-8bb2-44ad-9d88-fab63ce70bd3" />

<img width="300" height="700" alt="After" src="https://github.com/user-attachments/assets/27a4c3d1-bb38-45d2-b50d-c65e8a557353" />

## Linked issues

Closes : #4411
Related to: 

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
