### PR TITLE
fix: emit populate_by_name on a Pydantic model that has an aliased field

### DIFF
--- a/.changeset/pydantic-populate-by-name.md
+++ b/.changeset/pydantic-populate-by-name.md
@@ -1,0 +1,7 @@
+---
+"@hey-api/openapi-python": patch
+---
+
+**plugin(pydantic)**: emit `populate_by_name` on a model that has an aliased field
+
+The config was computed from the fields and then discarded, because its emission was gated on a separate flag that only an explicit `additionalProperties` config sets. A model with an alias but no other config rendered no `model_config` at all, so populating it by the generated field name was silently ignored: `Thing(class_="c").class_` returned `None`.

--- a/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-allof-inline/pydantic_gen.py
+++ b/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-allof-inline/pydantic_gen.py
@@ -2,15 +2,17 @@
 
 from typing import Any, Literal, Optional, TypeAlias, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class Foo(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     type: str = Field(..., alias="$type")
     foo: Optional[str] = None
 
 
 class Bar_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     type: Literal["FooBar"] = Field(..., alias="$type")
     bar: Optional[str] = None
 
@@ -19,6 +21,7 @@ Bar: TypeAlias = Any
 
 
 class Baz_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     baz: Optional[str] = None
     type: Literal["FooBaz"] = Field(..., alias="$type")
 
@@ -27,6 +30,7 @@ Baz: TypeAlias = Any
 
 
 class Qux_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     qux: Optional[str] = None
     type: Literal["BarQux"] = Field(..., alias="$type")
 

--- a/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-allof-member/pydantic_gen.py
+++ b/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-allof-member/pydantic_gen.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, TypeAlias, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class UserNotificationDeleteContentBase(BaseModel):
@@ -11,6 +11,7 @@ class UserNotificationDeleteContentBase(BaseModel):
 
 
 class UserNotificationDeleteContentError_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     finished_at: datetime = Field(..., alias="finishedAt")
     error: str
 
@@ -19,6 +20,7 @@ UserNotificationDeleteContentError: TypeAlias = Any
 
 
 class UserNotificationDeleteContentRunning_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     started_at: datetime = Field(..., alias="startedAt")
 
 
@@ -26,6 +28,7 @@ UserNotificationDeleteContentRunning: TypeAlias = Any
 
 
 class UserNotificationDeleteContentSuccess_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     finished_at: datetime = Field(..., alias="finishedAt")
 
 

--- a/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-allof-nested/pydantic_gen.py
+++ b/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-allof-nested/pydantic_gen.py
@@ -2,15 +2,17 @@
 
 from typing import Any, Literal, TypeAlias, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class VehicleDto(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     type: str = Field(..., alias="$type")
     id: int
 
 
 class CarDto_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     model_name: str = Field(..., alias="modelName")
     type: Literal["Car"] = Field(..., alias="$type")
 
@@ -19,6 +21,7 @@ CarDto: TypeAlias = Any
 
 
 class VolvoDto_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     seatbelt_count: int = Field(..., alias="seatbeltCount")
     type: Literal["Volvo"] = Field(..., alias="$type")
 

--- a/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-object-self-mapped/pydantic_gen.py
+++ b/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-object-self-mapped/pydantic_gen.py
@@ -2,16 +2,18 @@
 
 from typing import Any, Literal, TypeAlias, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class BlogPostDto(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     type: Literal["BlogPost"] = Field(..., alias="$type")
     id: int
     title: str
 
 
 class BlogPostWithImageDto_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     image_url: str = Field(..., alias="imageUrl")
     type: Literal["BlogPostWithImage"] = Field(..., alias="$type")
 

--- a/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-one-of-read-write/pydantic_gen.py
+++ b/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/discriminator-one-of-read-write/pydantic_gen.py
@@ -2,14 +2,16 @@
 
 from typing import Annotated, Any, Literal, TypeAlias, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class AnimalPayload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     type_discriminator: str = Field(..., alias="typeDiscriminator")
 
 
 class DogPayload_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     breed: str
     can_fetch: bool = Field(..., alias="canFetch")
     display_breed: str = Field(..., alias="displayBreed")
@@ -20,6 +22,7 @@ DogPayload: TypeAlias = Any
 
 
 class CatPayload_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     breed: str
     lives_remaining: int = Field(..., alias="livesRemaining")
     display_breed: str = Field(..., alias="displayBreed")
@@ -41,10 +44,12 @@ class CreatePetResponse(BaseModel):
 
 
 class AnimalPayloadWritable(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     type_discriminator: str = Field(..., alias="typeDiscriminator")
 
 
 class DogPayloadWritable_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     breed: str
     can_fetch: bool = Field(..., alias="canFetch")
     type_discriminator: Literal["dog"] = Field(..., alias="typeDiscriminator")
@@ -54,6 +59,7 @@ DogPayloadWritable: TypeAlias = Any
 
 
 class CatPayloadWritable_(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     breed: str
     lives_remaining: int = Field(..., alias="livesRemaining")
     type_discriminator: Literal["cat"] = Field(..., alias="typeDiscriminator")

--- a/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/opencode/pydantic_gen.py
+++ b/packages/openapi-python-tests/pydantic/v2/__snapshots__/3.1.x/opencode/pydantic_gen.py
@@ -7421,6 +7421,7 @@ class BadRequestError(BaseModel):
 
 
 class AuthRemovePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -7435,6 +7436,7 @@ class AuthSetBody(RootModel[Auth]):
 
 
 class AuthSetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -8212,6 +8214,7 @@ class ProjectUpdateBody(BaseModel):
 
 
 class ProjectUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     project_id: str = Field(..., alias="projectID")
 
 
@@ -8276,6 +8279,7 @@ class PtyCreateResponse(RootModel[Pty]):
 
 
 class PtyRemovePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8291,6 +8295,7 @@ class PtyRemoveResponse(RootModel[bool]):
 
 
 class PtyGetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8318,6 +8323,7 @@ class PtyUpdateBody(BaseModel):
 
 
 class PtyUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8333,6 +8339,7 @@ class PtyUpdateResponse(RootModel[Pty]):
 
 
 class PtyConnectTokenPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8366,6 +8373,7 @@ class QuestionReplyBody(BaseModel):
 
 
 class QuestionReplyPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     request_id: Annotated[str, Field(pattern=r"^que")] = Field(..., alias="requestID")
 
 
@@ -8381,6 +8389,7 @@ class QuestionReplyResponse(RootModel[bool]):
 
 
 class QuestionRejectPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     request_id: Annotated[str, Field(pattern=r"^que")] = Field(..., alias="requestID")
 
 
@@ -8419,6 +8428,7 @@ class PermissionReplyBody(BaseModel):
 
 
 class PermissionReplyPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     request_id: Annotated[str, Field(pattern=r"^per")] = Field(..., alias="requestID")
 
 
@@ -8465,6 +8475,7 @@ class ProviderOauthAuthorizeBody(BaseModel):
 
 
 class ProviderOauthAuthorizePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -8486,6 +8497,7 @@ class ProviderOauthCallbackBody(BaseModel):
 
 
 class ProviderOauthCallbackPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -8567,6 +8579,7 @@ class SessionStatusResponse(RootModel[dict[str, SessionStatus]]):
 
 
 class SessionDeletePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8582,6 +8595,7 @@ class SessionDeleteResponse(RootModel[bool]):
 
 
 class SessionGetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8610,6 +8624,7 @@ class SessionUpdateBody(BaseModel):
 
 
 class SessionUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8625,6 +8640,7 @@ class SessionUpdateResponse(RootModel[Session]):
 
 
 class SessionChildrenPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8640,6 +8656,7 @@ class SessionChildrenResponse(RootModel[list[Session]]):
 
 
 class SessionTodoPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8655,10 +8672,12 @@ class SessionTodoResponse(RootModel[list[Todo]]):
 
 
 class SessionDiffPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
 class SessionDiffQuery(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     directory: Optional[str] = None
     workspace: Optional[str] = None
     message_id: Optional[Annotated[str, Field(pattern=r"^msg")]] = Field(default=None, alias="messageID")
@@ -8671,6 +8690,7 @@ class SessionDiffResponse(RootModel[list[SnapshotFileDiff]]):
 
 
 class SessionMessagesPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8713,6 +8733,7 @@ class SessionPromptBody(BaseModel):
 
 
 class SessionPromptPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8729,6 +8750,7 @@ class SessionPromptResponse(BaseModel):
 
 
 class SessionDeleteMessagePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
 
@@ -8745,6 +8767,7 @@ class SessionDeleteMessageResponse(RootModel[bool]):
 
 
 class SessionMessagePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
 
@@ -8768,6 +8791,7 @@ class SessionForkBody(BaseModel):
 
 
 class SessionForkPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8783,6 +8807,7 @@ class SessionForkResponse(RootModel[Session]):
 
 
 class SessionAbortPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8805,6 +8830,7 @@ class SessionInitBody(BaseModel):
 
 
 class SessionInitPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8820,6 +8846,7 @@ class SessionInitResponse(RootModel[bool]):
 
 
 class SessionUnsharePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8835,6 +8862,7 @@ class SessionUnshareResponse(RootModel[Session]):
 
 
 class SessionSharePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8857,6 +8885,7 @@ class SessionSummarizeBody(BaseModel):
 
 
 class SessionSummarizePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8891,6 +8920,7 @@ class SessionPromptAsyncBody(BaseModel):
 
 
 class SessionPromptAsyncPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8931,6 +8961,7 @@ class SessionCommandBody(BaseModel):
 
 
 class SessionCommandPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8961,6 +8992,7 @@ class SessionShellBody(BaseModel):
 
 
 class SessionShellPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8984,6 +9016,7 @@ class SessionRevertBody(BaseModel):
 
 
 class SessionRevertPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8999,6 +9032,7 @@ class SessionRevertResponse(RootModel[Session]):
 
 
 class SessionUnrevertPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9025,6 +9059,7 @@ class PermissionRespondBody(BaseModel):
 
 
 class PermissionRespondPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     permission_id: Annotated[str, Field(pattern=r"^per")] = Field(..., alias="permissionID")
 
@@ -9041,6 +9076,7 @@ class PermissionRespondResponse(RootModel[bool]):
 
 
 class PartDeletePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
     part_id: Annotated[str, Field(pattern=r"^prt")] = Field(..., alias="partID")
@@ -9062,6 +9098,7 @@ class PartUpdateBody(RootModel[Part]):
 
 
 class PartUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
     part_id: Annotated[str, Field(pattern=r"^prt")] = Field(..., alias="partID")
@@ -9192,6 +9229,7 @@ class V2SessionPromptBody(BaseModel):
 
 
 class V2SessionPromptPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9207,6 +9245,7 @@ class V2SessionPromptResponse(RootModel[SessionMessage]):
 
 
 class V2SessionCompactPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9222,6 +9261,7 @@ class V2SessionCompactResponse(RootModel[None]):
 
 
 class V2SessionWaitPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9237,6 +9277,7 @@ class V2SessionWaitResponse(RootModel[None]):
 
 
 class V2SessionContextPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9252,6 +9293,7 @@ class V2SessionContextResponse(RootModel[list[SessionMessage]]):
 
 
 class V2SessionMessagesPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9307,6 +9349,7 @@ class V2ProviderListResponse(RootModel[list[ProviderV2Info]]):
 
 
 class V2ProviderGetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -9626,6 +9669,7 @@ class ExperimentalWorkspaceWarpResponse(RootModel[None]):
 
 
 class PtyConnectPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 

--- a/packages/openapi-python-tests/sdks/__snapshots__/opencode/default/pydantic_gen.py
+++ b/packages/openapi-python-tests/sdks/__snapshots__/opencode/default/pydantic_gen.py
@@ -7421,6 +7421,7 @@ class BadRequestError(BaseModel):
 
 
 class AuthRemovePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -7435,6 +7436,7 @@ class AuthSetBody(RootModel[Auth]):
 
 
 class AuthSetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -8212,6 +8214,7 @@ class ProjectUpdateBody(BaseModel):
 
 
 class ProjectUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     project_id: str = Field(..., alias="projectID")
 
 
@@ -8276,6 +8279,7 @@ class PtyCreateResponse(RootModel[Pty]):
 
 
 class PtyRemovePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8291,6 +8295,7 @@ class PtyRemoveResponse(RootModel[bool]):
 
 
 class PtyGetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8318,6 +8323,7 @@ class PtyUpdateBody(BaseModel):
 
 
 class PtyUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8333,6 +8339,7 @@ class PtyUpdateResponse(RootModel[Pty]):
 
 
 class PtyConnectTokenPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 
@@ -8366,6 +8373,7 @@ class QuestionReplyBody(BaseModel):
 
 
 class QuestionReplyPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     request_id: Annotated[str, Field(pattern=r"^que")] = Field(..., alias="requestID")
 
 
@@ -8381,6 +8389,7 @@ class QuestionReplyResponse(RootModel[bool]):
 
 
 class QuestionRejectPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     request_id: Annotated[str, Field(pattern=r"^que")] = Field(..., alias="requestID")
 
 
@@ -8419,6 +8428,7 @@ class PermissionReplyBody(BaseModel):
 
 
 class PermissionReplyPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     request_id: Annotated[str, Field(pattern=r"^per")] = Field(..., alias="requestID")
 
 
@@ -8465,6 +8475,7 @@ class ProviderOauthAuthorizeBody(BaseModel):
 
 
 class ProviderOauthAuthorizePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -8486,6 +8497,7 @@ class ProviderOauthCallbackBody(BaseModel):
 
 
 class ProviderOauthCallbackPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -8567,6 +8579,7 @@ class SessionStatusResponse(RootModel[dict[str, SessionStatus]]):
 
 
 class SessionDeletePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8582,6 +8595,7 @@ class SessionDeleteResponse(RootModel[bool]):
 
 
 class SessionGetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8610,6 +8624,7 @@ class SessionUpdateBody(BaseModel):
 
 
 class SessionUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8625,6 +8640,7 @@ class SessionUpdateResponse(RootModel[Session]):
 
 
 class SessionChildrenPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8640,6 +8656,7 @@ class SessionChildrenResponse(RootModel[list[Session]]):
 
 
 class SessionTodoPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8655,10 +8672,12 @@ class SessionTodoResponse(RootModel[list[Todo]]):
 
 
 class SessionDiffPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
 class SessionDiffQuery(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     directory: Optional[str] = None
     workspace: Optional[str] = None
     message_id: Optional[Annotated[str, Field(pattern=r"^msg")]] = Field(default=None, alias="messageID")
@@ -8671,6 +8690,7 @@ class SessionDiffResponse(RootModel[list[SnapshotFileDiff]]):
 
 
 class SessionMessagesPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8713,6 +8733,7 @@ class SessionPromptBody(BaseModel):
 
 
 class SessionPromptPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8729,6 +8750,7 @@ class SessionPromptResponse(BaseModel):
 
 
 class SessionDeleteMessagePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
 
@@ -8745,6 +8767,7 @@ class SessionDeleteMessageResponse(RootModel[bool]):
 
 
 class SessionMessagePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
 
@@ -8768,6 +8791,7 @@ class SessionForkBody(BaseModel):
 
 
 class SessionForkPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8783,6 +8807,7 @@ class SessionForkResponse(RootModel[Session]):
 
 
 class SessionAbortPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8805,6 +8830,7 @@ class SessionInitBody(BaseModel):
 
 
 class SessionInitPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8820,6 +8846,7 @@ class SessionInitResponse(RootModel[bool]):
 
 
 class SessionUnsharePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8835,6 +8862,7 @@ class SessionUnshareResponse(RootModel[Session]):
 
 
 class SessionSharePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8857,6 +8885,7 @@ class SessionSummarizeBody(BaseModel):
 
 
 class SessionSummarizePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8891,6 +8920,7 @@ class SessionPromptAsyncBody(BaseModel):
 
 
 class SessionPromptAsyncPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8931,6 +8961,7 @@ class SessionCommandBody(BaseModel):
 
 
 class SessionCommandPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8961,6 +8992,7 @@ class SessionShellBody(BaseModel):
 
 
 class SessionShellPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8984,6 +9016,7 @@ class SessionRevertBody(BaseModel):
 
 
 class SessionRevertPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -8999,6 +9032,7 @@ class SessionRevertResponse(RootModel[Session]):
 
 
 class SessionUnrevertPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9025,6 +9059,7 @@ class PermissionRespondBody(BaseModel):
 
 
 class PermissionRespondPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     permission_id: Annotated[str, Field(pattern=r"^per")] = Field(..., alias="permissionID")
 
@@ -9041,6 +9076,7 @@ class PermissionRespondResponse(RootModel[bool]):
 
 
 class PartDeletePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
     part_id: Annotated[str, Field(pattern=r"^prt")] = Field(..., alias="partID")
@@ -9062,6 +9098,7 @@ class PartUpdateBody(RootModel[Part]):
 
 
 class PartUpdatePath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
     message_id: Annotated[str, Field(pattern=r"^msg")] = Field(..., alias="messageID")
     part_id: Annotated[str, Field(pattern=r"^prt")] = Field(..., alias="partID")
@@ -9192,6 +9229,7 @@ class V2SessionPromptBody(BaseModel):
 
 
 class V2SessionPromptPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9207,6 +9245,7 @@ class V2SessionPromptResponse(RootModel[SessionMessage]):
 
 
 class V2SessionCompactPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9222,6 +9261,7 @@ class V2SessionCompactResponse(RootModel[None]):
 
 
 class V2SessionWaitPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9237,6 +9277,7 @@ class V2SessionWaitResponse(RootModel[None]):
 
 
 class V2SessionContextPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9252,6 +9293,7 @@ class V2SessionContextResponse(RootModel[list[SessionMessage]]):
 
 
 class V2SessionMessagesPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     session_id: Annotated[str, Field(pattern=r"^ses")] = Field(..., alias="sessionID")
 
 
@@ -9307,6 +9349,7 @@ class V2ProviderListResponse(RootModel[list[ProviderV2Info]]):
 
 
 class V2ProviderGetPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     provider_id: str = Field(..., alias="providerID")
 
 
@@ -9626,6 +9669,7 @@ class ExperimentalWorkspaceWarpResponse(RootModel[None]):
 
 
 class PtyConnectPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     pty_id: Annotated[str, Field(pattern=r"^pty")] = Field(..., alias="ptyID")
 
 

--- a/packages/openapi-python/src/plugins/pydantic/dsl/decl/model.ts
+++ b/packages/openapi-python/src/plugins/pydantic/dsl/decl/model.ts
@@ -69,7 +69,10 @@ export class PydanticModelDsl extends Mixed {
       // plugin.querySymbol(BASE_MODEL_META)!
       .extends(plugin.imports.BaseModel, ...this._bases)
       .$if(this.$docs(), (c, v) => c.doc(v))
-      .$if(this._configKwargs.length, (c) =>
+      // Every kwarg, not only the explicitly configured ones. `populate_by_name`
+      // is derived from the fields, so gating on `_configKwargs` dropped it
+      // from any aliased model that had no other config.
+      .$if(mergedKwargs.length, (c) =>
         c.do(
           $.field(identifiers.model_config).assign(
             $(plugin.imports.ConfigDict).call(...mergedKwargs),


### PR DESCRIPTION
Closes #4401

### Description

`populate_by_name` is derived from a model's fields and merged into the config kwargs correctly, but the `model_config` statement is only rendered when `_configKwargs` is non-empty, and that is set only by an explicit `.config()` call such as the one for `additionalProperties`. A model with an aliased field and no other config renders no `model_config` at all, and the computed kwarg is discarded.

Because Pydantic defaults to `extra="ignore"`, populating such a model by its generated field name is accepted and the value silently dropped:

```py
class Thing(BaseModel):
    class_: str | None = Field(default=None, alias="class")

>>> Thing(class_="c").class_
None
>>> Thing.model_validate({"class_": "c"}).class_
None
>>> Thing.model_config
{}
```

Only the wire alias works, even though the field name is what `model_fields` and editor completion show. This affects any property name that needs sanitising, which is most of the awkward ones: Python keywords, hyphens, dots, spaces, and names that collide with a `BaseModel` member.

### Fix

Gate the emission on the merged kwargs rather than on `_configKwargs`, so the config reaches every model that has an alias.

### After

```py
class Thing(BaseModel):
    model_config = ConfigDict(populate_by_name=True)
    class_: str | None = Field(default=None, alias="class")
    some_name: str | None = Field(default=None, alias="some-name")
```

Verified by running the generated module:

```
by field name : c s p
by wire alias : c s p
```

### Snapshot

The only change to the committed snapshots is 44 added `model_config = ConfigDict(populate_by_name=True)` lines, each on a model that has an aliased field. Nothing else moved.

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
