### PR TITLE
feat(output): generate `.gitattributes` for committed clients

### DIFF
--- a/.changeset/output-gitattributes.md
+++ b/.changeset/output-gitattributes.md
@@ -1,0 +1,9 @@
+---
+"@hey-api/openapi-python": minor
+"@hey-api/openapi-ts": minor
+"@hey-api/shared": minor
+---
+
+feat(output): generate `.gitattributes` for committed clients
+
+Generated output now includes a `.gitattributes` file that marks suffixed generated files and entry files with `linguist-generated` and `-diff`. Disable with `output.gitAttributes: false`.

--- a/examples/openapi-ts-angular-common/src/client/.gitattributes
+++ b/examples/openapi-ts-angular-common/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-angular/src/client/.gitattributes
+++ b/examples/openapi-ts-angular/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-axios/src/client/.gitattributes
+++ b/examples/openapi-ts-axios/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-fastify/src/client/.gitattributes
+++ b/examples/openapi-ts-fastify/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-fetch/src/client/.gitattributes
+++ b/examples/openapi-ts-fetch/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-ky/src/client/.gitattributes
+++ b/examples/openapi-ts-ky/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-nestjs/src/client/.gitattributes
+++ b/examples/openapi-ts-nestjs/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-next/src/client/.gitattributes
+++ b/examples/openapi-ts-next/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-ofetch/src/client/.gitattributes
+++ b/examples/openapi-ts-ofetch/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-openai/src/client/.gitattributes
+++ b/examples/openapi-ts-openai/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-pinia-colada/src/client/.gitattributes
+++ b/examples/openapi-ts-pinia-colada/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/.gitattributes
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-tanstack-react-query/src/client/.gitattributes
+++ b/examples/openapi-ts-tanstack-react-query/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/.gitattributes
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/examples/openapi-ts-tanstack-vue-query/src/client/.gitattributes
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/.gitattributes
@@ -1,0 +1,6 @@
+# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff

--- a/packages/openapi-python-tests/utils.ts
+++ b/packages/openapi-python-tests/utils.ts
@@ -11,7 +11,7 @@ export function getFilePaths(dirPath: string): Array<string> {
 
     if (stat.isDirectory()) {
       filePaths = filePaths.concat(getFilePaths(filePath));
-    } else {
+    } else if (path.basename(filePath) !== '.gitattributes') {
       filePaths.push(filePath);
     }
   }

--- a/packages/openapi-python/src/config/output/config.ts
+++ b/packages/openapi-python/src/config/output/config.ts
@@ -41,6 +41,7 @@ export const outputConfig = defineConfig<UserOutput, Output>({
     name: '{{name}}',
     suffix: '_gen',
   },
+  gitAttributes: true,
   module: {},
   path: '',
   postProcess: coerce((value) => (Array.isArray(value) ? value.map(normalizePostProcessItem) : [])),

--- a/packages/openapi-python/src/generate/output.ts
+++ b/packages/openapi-python/src/generate/output.ts
@@ -2,7 +2,7 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
 import type { Context } from '@hey-api/shared';
-import { IntentContext } from '@hey-api/shared';
+import { IntentContext, writeOutputGitAttributes } from '@hey-api/shared';
 
 import { getTypedConfig } from '../config/utils';
 import { getClientPlugin } from '../plugins/@hey-api/client-core/utils';
@@ -92,6 +92,18 @@ export async function generateOutput(context: Context): Promise<{ fileCount: num
       await source.callback(serialized);
     }
   }
+
+  fileCount += await writeOutputGitAttributes({
+    dryRun: config.dryRun,
+    entryGlobs: ['**/__init__.py'],
+    fileExtension: '.py',
+    fileSuffix: context.config.output.fileName.suffix,
+    generator: '@hey-api/openapi-python',
+    gitAttributes: context.config.output.gitAttributes,
+    moduleExtension: context.config.output.module.extension ?? null,
+    outputPath,
+    source,
+  });
 
   return { fileCount };
 }

--- a/packages/openapi-ts-tests/utils.ts
+++ b/packages/openapi-ts-tests/utils.ts
@@ -11,7 +11,7 @@ export function getFilePaths(dirPath: string): Array<string> {
 
     if (stat.isDirectory()) {
       filePaths = filePaths.concat(getFilePaths(filePath));
-    } else {
+    } else if (path.basename(filePath) !== '.gitattributes') {
       filePaths.push(filePath);
     }
   }

--- a/packages/openapi-ts/src/config/output/__tests__/config.test.ts
+++ b/packages/openapi-ts/src/config/output/__tests__/config.test.ts
@@ -178,5 +178,26 @@ describe('getOutput', () => {
 
       expect(output.module.extension).toBeUndefined();
     });
+
+    it('should enable gitAttributes by default', () => {
+      const output = getOutput({
+        output: {
+          path: tmpDir,
+        },
+      });
+
+      expect(output.gitAttributes).toBe(true);
+    });
+
+    it('should allow disabling gitAttributes', () => {
+      const output = getOutput({
+        output: {
+          gitAttributes: false,
+          path: tmpDir,
+        },
+      });
+
+      expect(output.gitAttributes).toBe(false);
+    });
   });
 });

--- a/packages/openapi-ts/src/config/output/config.ts
+++ b/packages/openapi-ts/src/config/output/config.ts
@@ -123,6 +123,7 @@ export const outputConfig = defineConfig<UserOutput, Output>({
     name: '{{name}}',
     suffix: '.gen',
   },
+  gitAttributes: true,
   module: {},
   path: '',
   postProcess: coerce((value) => (Array.isArray(value) ? value.map(normalizePostProcessItem) : [])),

--- a/packages/openapi-ts/src/generate/output.ts
+++ b/packages/openapi-ts/src/generate/output.ts
@@ -3,7 +3,7 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
 import type { Context } from '@hey-api/shared';
-import { IntentContext } from '@hey-api/shared';
+import { IntentContext, writeOutputGitAttributes } from '@hey-api/shared';
 
 import { getTypedConfig } from '../config/utils';
 import { getClientPlugin } from '../plugins/@hey-api/client-core/utils';
@@ -101,6 +101,18 @@ export async function generateOutput(context: Context): Promise<{ fileCount: num
     }
   }
   eventSource.timeEnd();
+
+  fileCount += await writeOutputGitAttributes({
+    dryRun: config.dryRun,
+    entryGlobs: ['**/index.ts', '**/index.js'],
+    fileExtension: '.ts',
+    fileSuffix: context.config.output.fileName.suffix,
+    generator: '@hey-api/openapi-ts',
+    gitAttributes: context.config.output.gitAttributes,
+    moduleExtension: context.config.output.module.extension ?? null,
+    outputPath,
+    source,
+  });
 
   return { fileCount };
 }

--- a/packages/shared/src/config/output/__tests__/gitAttributes.test.ts
+++ b/packages/shared/src/config/output/__tests__/gitAttributes.test.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { renderGitAttributes, writeOutputGitAttributes } from '../gitAttributes';
+import { sourceConfig } from '../source/config';
+
+describe('writeOutputGitAttributes', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitattributes-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { force: true, recursive: true });
+  });
+
+  it('returns 0 when gitAttributes is disabled', async () => {
+    await expect(
+      writeOutputGitAttributes({
+        dryRun: false,
+        entryGlobs: ['**/index.ts'],
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        gitAttributes: false,
+        moduleExtension: '.ts',
+        outputPath: tmpDir,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).resolves.toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, '.gitattributes'))).toBe(false);
+  });
+
+  it('does not write a file during dry run', async () => {
+    await expect(
+      writeOutputGitAttributes({
+        dryRun: true,
+        entryGlobs: ['**/index.ts'],
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        gitAttributes: true,
+        moduleExtension: '.ts',
+        outputPath: tmpDir,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).resolves.toBe(1);
+    expect(fs.existsSync(path.join(tmpDir, '.gitattributes'))).toBe(false);
+  });
+
+  it('writes a gitattributes file to the output folder', async () => {
+    await expect(
+      writeOutputGitAttributes({
+        dryRun: false,
+        entryGlobs: ['**/index.ts'],
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        gitAttributes: true,
+        moduleExtension: '.ts',
+        outputPath: tmpDir,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).resolves.toBe(1);
+
+    expect(fs.readFileSync(path.join(tmpDir, '.gitattributes'), 'utf8')).toBe(
+      renderGitAttributes({
+        entryGlobs: ['**/index.ts'],
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.ts',
+        outputPath: tmpDir,
+        source: sourceConfig({ enabled: false }),
+      }),
+    );
+  });
+
+  it('creates the output folder when it does not exist', async () => {
+    const nestedOutputPath = path.join(tmpDir, 'nested', 'client');
+
+    await expect(
+      writeOutputGitAttributes({
+        dryRun: false,
+        entryGlobs: ['**/index.ts'],
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        gitAttributes: true,
+        moduleExtension: '.ts',
+        outputPath: nestedOutputPath,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).resolves.toBe(1);
+
+    expect(fs.existsSync(path.join(nestedOutputPath, '.gitattributes'))).toBe(true);
+  });
+});
+
+describe('renderGitAttributes', () => {
+  const outputPath = path.resolve('/project/src/api');
+  const tsEntryGlobs = ['**/index.ts', '**/index.js'] as const;
+
+  it('marks generated TypeScript output without a source file', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: tsEntryGlobs,
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.ts',
+        outputPath,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff
+`);
+  });
+
+  it('marks emitted TypeScript files when import specifiers use .js', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: tsEntryGlobs,
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.js',
+        outputPath,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff
+`);
+  });
+
+  it('includes a source file in the output folder', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: tsEntryGlobs,
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.ts',
+        outputPath,
+        source: sourceConfig({
+          enabled: true,
+          extension: 'json',
+          fileName: 'openapi',
+        }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+openapi.json linguist-generated=true
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff
+`);
+  });
+
+  it('marks generated Python output', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: ['**/__init__.py'],
+        fileExtension: '.py',
+        fileSuffix: '_gen',
+        generator: '@hey-api/openapi-python',
+        moduleExtension: '.py',
+        outputPath,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-python generated client
+.gitattributes -linguist-generated -diff
+**/*_gen.py linguist-generated=true -diff
+**/__init__.py linguist-generated=true -diff
+`);
+  });
+
+  it('includes a nested source file relative to the output folder', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: ['**/__init__.py'],
+        fileExtension: '.py',
+        fileSuffix: '_gen',
+        generator: '@hey-api/openapi-python',
+        moduleExtension: '.py',
+        outputPath,
+        source: sourceConfig({
+          enabled: true,
+          extension: 'json',
+          fileName: 'openapi',
+          path: 'spec',
+        }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-python generated client
+.gitattributes -linguist-generated -diff
+**/*_gen.py linguist-generated=true -diff
+spec/openapi.json linguist-generated=true
+**/__init__.py linguist-generated=true -diff
+`);
+  });
+
+  it('falls back to all files when the suffix is disabled', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: tsEntryGlobs,
+        fileExtension: '.ts',
+        fileSuffix: null,
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.ts',
+        outputPath,
+        source: sourceConfig({ enabled: false }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+** linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff
+`);
+  });
+
+  it('keeps the source file visible when the suffix is disabled', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: tsEntryGlobs,
+        fileExtension: '.ts',
+        fileSuffix: null,
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.ts',
+        outputPath,
+        source: sourceConfig({
+          enabled: true,
+          extension: 'json',
+          fileName: 'openapi',
+        }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+** linguist-generated=true -diff
+openapi.json linguist-generated=true
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff
+`);
+  });
+
+  it('skips source files written outside the output folder', () => {
+    expect(
+      renderGitAttributes({
+        entryGlobs: tsEntryGlobs,
+        fileExtension: '.ts',
+        fileSuffix: '.gen',
+        generator: '@hey-api/openapi-ts',
+        moduleExtension: '.ts',
+        outputPath,
+        source: sourceConfig({
+          enabled: true,
+          extension: 'json',
+          fileName: 'openapi',
+          path: '../',
+        }),
+      }),
+    ).toBe(`# OpenAPI spec and @hey-api/openapi-ts generated client
+.gitattributes -linguist-generated -diff
+**/*.gen.ts linguist-generated=true -diff
+**/*.gen.js linguist-generated=true -diff
+**/index.ts linguist-generated=true -diff
+**/index.js linguist-generated=true -diff
+`);
+  });
+});

--- a/packages/shared/src/config/output/gitAttributes.ts
+++ b/packages/shared/src/config/output/gitAttributes.ts
@@ -1,0 +1,135 @@
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+
+import type { SourceConfig } from './source/types';
+
+export type GitAttributesOptions = {
+  /** Globs for generated entry files that omit the configured suffix. */
+  entryGlobs: ReadonlyArray<string>;
+  /** Extension used for emitted generated files (e.g. `.ts`, `.py`). */
+  fileExtension: string;
+  /** Suffix appended to generated file names (before the extension). */
+  fileSuffix: string | null;
+  /** Package name shown in the generated comment header. */
+  generator: string;
+  /** Import-specifier extension from `output.module.extension`. */
+  moduleExtension: string | null;
+  /** Absolute path to the output folder. */
+  outputPath: string;
+  source: SourceConfig;
+};
+
+export type WriteOutputGitAttributesOptions = {
+  dryRun: boolean;
+  entryGlobs: ReadonlyArray<string>;
+  fileExtension: string;
+  fileSuffix: string | null;
+  generator: string;
+  gitAttributes: boolean;
+  moduleExtension: string | null;
+  outputPath: string;
+  source: SourceConfig;
+};
+
+function getSourcePattern(outputPath: string, source: SourceConfig): string | null {
+  if (!source.enabled || source.path === null) {
+    return null;
+  }
+
+  const sourceDir = path.resolve(outputPath, source.path);
+  const sourceFile = `${source.fileName}.${source.extension}`;
+  const sourcePath = path.resolve(sourceDir, sourceFile);
+  const relativePath = path.relative(outputPath, sourcePath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return relativePath.split(path.sep).join('/');
+}
+
+function getGeneratedPatterns(
+  fileSuffix: string | null,
+  fileExtension: string,
+  moduleExtension: string | null,
+): ReadonlyArray<string> {
+  if (!fileSuffix) {
+    return ['** linguist-generated=true -diff'];
+  }
+
+  const patterns: Array<string> = [
+    `**/*${fileSuffix}${fileExtension} linguist-generated=true -diff`,
+  ];
+  const moduleExt = moduleExtension ?? '.ts';
+
+  if (fileExtension === '.ts' && (moduleExt === '.js' || moduleExt === '.ts')) {
+    patterns.push(`**/*${fileSuffix}.js linguist-generated=true -diff`);
+  }
+
+  return patterns;
+}
+
+export function renderGitAttributes({
+  entryGlobs,
+  fileExtension,
+  fileSuffix,
+  generator,
+  moduleExtension,
+  outputPath,
+  source,
+}: GitAttributesOptions): string {
+  const lines = [
+    `# OpenAPI spec and ${generator} generated client`,
+    '.gitattributes -linguist-generated -diff',
+  ];
+
+  for (const pattern of getGeneratedPatterns(fileSuffix, fileExtension, moduleExtension)) {
+    lines.push(pattern);
+  }
+
+  const sourcePattern = getSourcePattern(outputPath, source);
+  if (sourcePattern) {
+    lines.push(`${sourcePattern} linguist-generated=true`);
+  }
+
+  for (const entryGlob of entryGlobs) {
+    lines.push(`${entryGlob} linguist-generated=true -diff`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export async function writeOutputGitAttributes({
+  dryRun,
+  entryGlobs,
+  fileExtension,
+  fileSuffix,
+  generator,
+  gitAttributes,
+  moduleExtension,
+  outputPath,
+  source,
+}: WriteOutputGitAttributesOptions): Promise<number> {
+  if (!gitAttributes) {
+    return 0;
+  }
+
+  const gitAttributesContent = renderGitAttributes({
+    entryGlobs,
+    fileExtension,
+    fileSuffix,
+    generator,
+    moduleExtension,
+    outputPath,
+    source,
+  });
+
+  if (!dryRun) {
+    await fsPromises.mkdir(outputPath, { recursive: true });
+    await fsPromises.writeFile(path.resolve(outputPath, '.gitattributes'), gitAttributesContent, {
+      encoding: 'utf8',
+    });
+  }
+
+  return 1;
+}

--- a/packages/shared/src/config/shared.ts
+++ b/packages/shared/src/config/shared.ts
@@ -144,6 +144,14 @@ export interface BaseUserOutput<TModuleExtension extends string = string> {
         suffix?: string | null;
       };
   /**
+   * Whether to generate a `.gitattributes` file in the output folder.
+   * Marks generated files with `linguist-generated` and `-diff` to keep
+   * pull requests readable when committing generated clients.
+   *
+   * @default true
+   */
+  gitAttributes?: boolean;
+  /**
    * Text to include at the top of every generated file.
    */
   header?: OutputHeader;
@@ -240,6 +248,8 @@ export interface BaseOutput<TModuleExtension extends string = string> {
      */
     suffix: string | null;
   };
+  /** Whether to generate a `.gitattributes` file in the output folder. */
+  gitAttributes: boolean;
   /** Text to include at the top of every generated file. */
   header: OutputHeader;
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,11 @@ export { getInput } from './config/input/input';
 export { compileInputPath, logInputPaths } from './config/input/path';
 export type { Input, UserInput, UserWatch, Watch } from './config/input/types';
 export { getLogs } from './config/logs';
+export type {
+  GitAttributesOptions,
+  WriteOutputGitAttributesOptions,
+} from './config/output/gitAttributes';
+export { renderGitAttributes, writeOutputGitAttributes } from './config/output/gitAttributes';
 export type { PostProcessor, UserPostProcessor } from './config/output/postprocess';
 export { postprocessOutput } from './config/output/postprocess';
 export { sourceConfig } from './config/output/source/config';

--- a/web/src/content/docs/docs/openapi/python/output.mdx
+++ b/web/src/content/docs/docs/openapi/python/output.mdx
@@ -146,4 +146,10 @@ export default {
   </TabItem>
 </Tabs>
 
+## Git Attributes
+
+When you commit generated clients, a `.gitattributes` file is written into your output folder by default.
+It marks generated files and package entry files so GitHub can treat them as generated code.
+See the [Output configuration](/docs/openapi/typescript/configuration/output#git-attributes) page for details.
+
 <Examples />

--- a/web/src/content/docs/docs/openapi/typescript/configuration/output.mdx
+++ b/web/src/content/docs/docs/openapi/typescript/configuration/output.mdx
@@ -428,4 +428,32 @@ export default {
 Setting `clean` to `false` may result in broken output. Ensure you typecheck your code.
 :::
 
+## Git Attributes
+
+When you commit generated clients to your repository, GitHub can treat those files as generated code so they stay out of language stats and pull request diffs.
+
+By default, we write a `.gitattributes` file into your output folder. It marks suffixed generated files and entry files with `linguist-generated` and `-diff`. When `source` is enabled, the copied spec file is included without `-diff`. If you store hand-written files in the output folder (`clean: false`), set `gitAttributes: false` or keep those files outside the generated tree.
+
+```js {4} title="openapi-ts.config.ts"
+export default {
+  input: 'hey-api/backend', // sign up at app.heyapi.dev
+  output: {
+    gitAttributes: true,
+    path: 'src/client',
+  },
+};
+```
+
+Set `gitAttributes` to `false` to skip writing this file.
+
+```js {4} title="openapi-ts.config.ts"
+export default {
+  input: 'hey-api/backend', // sign up at app.heyapi.dev
+  output: {
+    gitAttributes: false,
+    path: 'src/client',
+  },
+};
+```
+
 <Examples />


### PR DESCRIPTION
<img width="1095" height="195" alt="image" src="https://github.com/user-attachments/assets/6b6750ae-3e32-41a1-bfc4-d71e871e0a97" />

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

## Summary

Generated output includes a `.gitattributes` file in the output folder.
Suffixed generated files and entry files are marked with `linguist-generated` and `-diff`.

When `output.source` is enabled, the copied spec file is included without `-diff`.

This helps teams that commit generated SDKs keep pull request diffs readable.
Disable with `output.gitAttributes: false` (default is `true`).

Docs note the `clean: false` escape hatch for mixed output folders.

## Linked issues

Closes: #4410

## Certification

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.