### PR TITLE
fix(shared): keep the array when 3.1 items carries a $ref beside a composition

### DIFF
--- a/.changeset/lucky-arrays-return.md
+++ b/.changeset/lucky-arrays-return.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/shared": patch
+---
+
+**fix**: keep the array when an OpenAPI 3.1 `items` carries a `$ref` beside a composition

--- a/packages/shared/src/openApi/3.1.x/parser/__tests__/index.test.ts
+++ b/packages/shared/src/openApi/3.1.x/parser/__tests__/index.test.ts
@@ -73,6 +73,45 @@ describe('parseV3_1_X', () => {
     });
   });
 
+  it('keeps the array when items carry a deep-path $ref beside a composition', () => {
+    const spec: OpenAPIV3_1.Document = {
+      components: {
+        schemas: {
+          Composite: { properties: { kind: { type: 'string' } }, type: 'object' },
+          Field: { properties: { op: { type: 'string' } }, type: 'object' },
+          Holder: {
+            properties: {
+              filters: {
+                items: {
+                  $ref: '#/components/schemas/Wrapper/properties/inner',
+                  oneOf: [
+                    { $ref: '#/components/schemas/Field' },
+                    { $ref: '#/components/schemas/Composite' },
+                  ],
+                },
+                type: 'array',
+              },
+            },
+            type: 'object',
+          },
+          Wrapper: {
+            properties: {
+              inner: { properties: { op: { type: 'string' } }, type: 'object' },
+            },
+            type: 'object',
+          },
+        },
+      },
+      info: { title: 'Test', version: '1' },
+      openapi: '3.1.0',
+    };
+    const context = createContext(spec);
+    parseV3_1_X(context);
+    const filters = context.ir.components?.schemas?.Holder?.properties?.filters;
+    expect(filters?.type).toBe('array');
+    expect(filters?.items).toHaveLength(1);
+  });
+
   it('encodes $ref for schema name containing /', () => {
     const spec: OpenAPIV3_1.Document = {
       components: {

--- a/packages/shared/src/openApi/3.1.x/parser/__tests__/index.test.ts
+++ b/packages/shared/src/openApi/3.1.x/parser/__tests__/index.test.ts
@@ -38,6 +38,41 @@ function createContext(spec: OpenAPIV3_1.Document) {
 }
 
 describe('parseV3_1_X', () => {
+  it('keeps the array when items carry a $ref beside a composition', () => {
+    const spec: OpenAPIV3_1.Document = {
+      components: {
+        schemas: {
+          Base: { properties: { op: { type: 'string' } }, type: 'object' },
+          Composite: { properties: { kind: { type: 'string' } }, type: 'object' },
+          Field: { properties: { op: { type: 'string' } }, type: 'object' },
+          Holder: {
+            properties: {
+              filters: {
+                items: {
+                  $ref: '#/components/schemas/Base',
+                  oneOf: [
+                    { $ref: '#/components/schemas/Field' },
+                    { $ref: '#/components/schemas/Composite' },
+                  ],
+                },
+                type: 'array',
+              },
+            },
+            type: 'object',
+          },
+        },
+      },
+      info: { title: 'Test', version: '1' },
+      openapi: '3.1.0',
+    };
+    const context = createContext(spec);
+    parseV3_1_X(context);
+    expect(context.ir.components?.schemas?.Holder?.properties?.filters).toEqual({
+      items: [{ $ref: '#/components/schemas/Base' }],
+      type: 'array',
+    });
+  });
+
   it('encodes $ref for schema name containing /', () => {
     const spec: OpenAPIV3_1.Document = {
       components: {

--- a/packages/shared/src/openApi/3.1.x/parser/schema.ts
+++ b/packages/shared/src/openApi/3.1.x/parser/schema.ts
@@ -319,7 +319,14 @@ function parseArray({
       schemaItems = Array(schema.maxItems).fill(irItemsSchema);
     } else {
       const ofArray = schema.items.allOf || schema.items.anyOf || schema.items.oneOf;
-      if (ofArray && ofArray.length > 1 && !getSchemaTypes(schema.items).includes('null')) {
+      if (
+        ofArray &&
+        ofArray.length > 1 &&
+        !getSchemaTypes(schema.items).includes('null') &&
+        // a `$ref` sibling of the composition parses to a reference, not to a
+        // composition; assigning it over `irSchema` would drop the array itself
+        !irItemsSchema.$ref
+      ) {
         // bring composition up to avoid incorrectly nested arrays
         Object.assign(irSchema, irItemsSchema);
       } else {

--- a/packages/shared/src/openApi/3.1.x/parser/schema.ts
+++ b/packages/shared/src/openApi/3.1.x/parser/schema.ts
@@ -317,16 +317,15 @@ function parseArray({
 
     if (!schemaItems.length && schema.maxItems && schema.maxItems === schema.minItems) {
       schemaItems = Array(schema.maxItems).fill(irItemsSchema);
+    } else if ('$ref' in schema.items) {
+      // 3.1 lets `$ref` carry siblings, so `items` may hold both a reference and a
+      // composition. The reference wins: lifting the parsed item schema would drop the
+      // array. Checked on the source schema because `parseRef` inlines a non-component
+      // ref and returns no `$ref` to test.
+      schemaItems.push(irItemsSchema);
     } else {
       const ofArray = schema.items.allOf || schema.items.anyOf || schema.items.oneOf;
-      if (
-        ofArray &&
-        ofArray.length > 1 &&
-        !getSchemaTypes(schema.items).includes('null') &&
-        // a `$ref` sibling of the composition parses to a reference, not to a
-        // composition; assigning it over `irSchema` would drop the array itself
-        !irItemsSchema.$ref
-      ) {
+      if (ofArray && ofArray.length > 1 && !getSchemaTypes(schema.items).includes('null')) {
         // bring composition up to avoid incorrectly nested arrays
         Object.assign(irSchema, irItemsSchema);
       } else {


### PR DESCRIPTION
Closes #4412

`parseArray` lifts a composition out of `items` into the array schema to avoid nested arrays. When
the composition sits next to a `$ref`, the parsed item schema is a reference, so that assignment
overwrites `type: 'array'` and the array disappears from the output.

This skips the lift when the parsed item schema is a reference. Deliberately narrow: it does not try
to apply `$ref` siblings conjunctively (the wider gap noted in the issue), it only stops the array
from being dropped — `Array<Base>` instead of `Base`.

Test added to `packages/shared/src/openApi/3.1.x/parser/__tests__/index.test.ts`; it fails on `main`
and passes with the fix. `@hey-api/shared` (527 tests) and `@hey-api/openapi-ts` (729 tests) suites
are green, no snapshot churn.

## Certification

<!-- Do not remove the line below. -->

- [x] <!-- hey-api:certification --> I have personally reviewed every line of this contribution and take responsibility for its correctness.
